### PR TITLE
feat(bots): reply before tools with status beats

### DIFF
--- a/apps/server/package.json
+++ b/apps/server/package.json
@@ -31,7 +31,7 @@
     "@mastra/code-sdk": "1.5.1",
     "@mastra/core": "1.63.0",
     "@opencode-ai/sdk": "^1.3.15",
-    "@opencoredev/sandbox-sdk": "file:../../../sandbox-sdk/packages/sdk",
+    "@opencoredev/sandbox-sdk": "0.2.0",
     "@pierre/diffs": "catalog:",
     "@upstash/box": "0.5.3",
     "@vercel/sandbox": "^2.5.0",

--- a/apps/server/src/orchestration/Layers/ProviderCommandReactor.test.ts
+++ b/apps/server/src/orchestration/Layers/ProviderCommandReactor.test.ts
@@ -623,6 +623,7 @@ describe("ProviderCommandReactor", () => {
         model: "gpt-5-codex",
       },
       mode: "default",
+      botConversation: false,
     });
     expect(harness.startSession.mock.calls[0]?.[0]).toEqual(ThreadId.make("thread-1"));
     expect(harness.startSession.mock.calls[0]?.[1]).toMatchObject({
@@ -633,6 +634,7 @@ describe("ProviderCommandReactor", () => {
       },
       mcpServers: [],
       botSandbox: null,
+      botConversation: false,
       runtimeMode: "approval-required",
     });
 
@@ -675,6 +677,7 @@ describe("ProviderCommandReactor", () => {
         model: "claude-fable-5",
       },
       mode: "default",
+      botConversation: true,
     });
     expect(harness.startSession.mock.calls[0]?.[1]).toMatchObject({
       provider: ProviderDriverKind.make("claudeAgent"),
@@ -684,6 +687,7 @@ describe("ProviderCommandReactor", () => {
         model: "claude-fable-5",
       },
       botSandbox: "local",
+      botConversation: true,
     });
   });
 

--- a/apps/server/src/orchestration/Layers/ProviderCommandReactor.test.ts
+++ b/apps/server/src/orchestration/Layers/ProviderCommandReactor.test.ts
@@ -3231,7 +3231,7 @@ describe("ProviderCommandReactor", () => {
       ),
     );
 
-    await Effect.runPromise(
+    await harness.runEffect(
       harness.engine.dispatch({
         type: "thread.session.set",
         commandId: CommandId.make("cmd-session-set-for-user-input-error"),
@@ -3249,7 +3249,7 @@ describe("ProviderCommandReactor", () => {
       }),
     );
 
-    await Effect.runPromise(
+    await harness.runEffect(
       harness.engine.dispatch({
         type: "thread.activity.append",
         commandId: CommandId.make("cmd-user-input-requested"),
@@ -3282,7 +3282,7 @@ describe("ProviderCommandReactor", () => {
       }),
     );
 
-    await Effect.runPromise(
+    await harness.runEffect(
       harness.engine.dispatch({
         type: "thread.user-input.respond",
         commandId: CommandId.make("cmd-user-input-respond-stale"),

--- a/apps/server/src/orchestration/Layers/ProviderCommandReactor.ts
+++ b/apps/server/src/orchestration/Layers/ProviderCommandReactor.ts
@@ -521,6 +521,7 @@ const make = Effect.gen(function* () {
       engine,
       fallback,
       mode: thread.interactionMode,
+      botConversation: thread.botId != null || thread.groupId != null,
     });
     return { ...selection, configured: engine !== null };
   });
@@ -697,6 +698,7 @@ const make = Effect.gen(function* () {
         modelSelection: desiredModelSelection,
         mcpServers,
         botSandbox: respondingBot?.sandbox ?? null,
+        botConversation: thread.botId != null || thread.groupId != null,
         ...(input?.resumeCursor !== undefined ? { resumeCursor: input.resumeCursor } : {}),
         runtimeMode: desiredRuntimeMode,
       });

--- a/apps/server/src/orchestration/Layers/ProviderRuntimeIngestion.test.ts
+++ b/apps/server/src/orchestration/Layers/ProviderRuntimeIngestion.test.ts
@@ -1018,6 +1018,61 @@ describe("ProviderRuntimeIngestion", () => {
     expect(message?.streaming).toBe(false);
   });
 
+  it("persists separate assistant notes while one turn remains active", async () => {
+    const harness = await createHarness();
+    const now = "2026-01-01T00:00:00.000Z";
+    const threadId = asThreadId("thread-1");
+    const turnId = asTurnId("turn-status-beats");
+
+    harness.emit({
+      type: "turn.started",
+      eventId: asEventId("evt-status-turn-started"),
+      provider: ProviderDriverKind.make("codex"),
+      createdAt: now,
+      threadId,
+      turnId,
+    });
+    for (const [itemId, text] of [
+      ["reply-before-tools", "I'll check that now."],
+      ["status-after-tool", "I found the relevant setting."],
+    ] as const) {
+      harness.emit({
+        type: "content.delta",
+        eventId: asEventId(`evt-${itemId}-delta`),
+        provider: ProviderDriverKind.make("codex"),
+        createdAt: now,
+        threadId,
+        turnId,
+        itemId: asItemId(itemId),
+        payload: { streamKind: "assistant_text", delta: text },
+      });
+      harness.emit({
+        type: "item.completed",
+        eventId: asEventId(`evt-${itemId}-completed`),
+        provider: ProviderDriverKind.make("codex"),
+        createdAt: now,
+        threadId,
+        turnId,
+        itemId: asItemId(itemId),
+        payload: { itemType: "assistant_message", status: "completed" },
+      });
+    }
+
+    const thread = await waitForThread(harness.readModel, (entry) =>
+      ["assistant:reply-before-tools", "assistant:status-after-tool"].every((id) =>
+        entry.messages.some(
+          (message: ProviderRuntimeTestMessage) => message.id === id && !message.streaming,
+        ),
+      ),
+    );
+    expect(
+      thread.messages
+        .filter((message: ProviderRuntimeTestMessage) => message.turnId === turnId)
+        .map((message: ProviderRuntimeTestMessage) => message.text),
+    ).toEqual(["I'll check that now.", "I found the relevant setting."]);
+    expect(thread.session?.activeTurnId).toBe(turnId);
+  });
+
   it("uses assistant item completion detail when no assistant deltas were streamed", async () => {
     const harness = await createHarness();
     const now = "2026-01-01T00:00:00.000Z";

--- a/apps/server/src/provider/AkeruAgentInstructions.ts
+++ b/apps/server/src/provider/AkeruAgentInstructions.ts
@@ -8,3 +8,13 @@ export const AKERU_AGENT_INSTRUCTIONS = [
   "When asked about available tools, describe only tools present in the current turn.",
   "Do not claim that a tool ran unless its result is present in this turn.",
 ].join("\n");
+
+export const AKERU_BOT_TURN_INSTRUCTIONS = [
+  "Before you use a tool for a visible user request, first answer with one short plain-language sentence that acknowledges the request and says what you will do next.",
+  "During longer tool work, add one short plain-language status note after meaningful progress or a change in direction and before the next tool call. Do not narrate every tool call.",
+  "Treat a hidden system reminder or automatic continuation as ongoing work, not a new user request. Skip the opening reply and continue with only useful status notes.",
+].join("\n");
+
+export const AKERU_BOT_INSTRUCTIONS = [AKERU_AGENT_INSTRUCTIONS, AKERU_BOT_TURN_INSTRUCTIONS].join(
+  "\n",
+);

--- a/apps/server/src/provider/AkeruMastraHarness.test.ts
+++ b/apps/server/src/provider/AkeruMastraHarness.test.ts
@@ -5,15 +5,30 @@ import { RequestContext } from "@mastra/core/request-context";
 import { LocalFilesystem, LocalSandbox, Workspace } from "@mastra/core/workspace";
 import { assert, describe, it } from "vite-plus/test";
 
-import { AKERU_AGENT_INSTRUCTIONS } from "./AkeruAgentInstructions.ts";
-import { resolveAkeruTools } from "./AkeruMastraHarness.ts";
+import { AKERU_AGENT_INSTRUCTIONS, AKERU_BOT_INSTRUCTIONS } from "./AkeruAgentInstructions.ts";
+import { resolveAkeruInstructions, resolveAkeruTools } from "./AkeruMastraHarness.ts";
 
 describe("AkeruMastraHarness", () => {
   it("configures Akeru as a general-purpose assistant with plugin awareness", () => {
     assert.include(AKERU_AGENT_INSTRUCTIONS, "general-purpose assistant");
     assert.include(AKERU_AGENT_INSTRUCTIONS, "enabled plugin tools");
     assert.include(AKERU_AGENT_INSTRUCTIONS, "Do not assume");
-    assert.notInclude(AKERU_AGENT_INSTRUCTIONS, "coding agent");
+    assert.notInclude(AKERU_AGENT_INSTRUCTIONS, "Before you use a tool");
+    assert.include(AKERU_BOT_INSTRUCTIONS, "first answer with one short plain-language sentence");
+    assert.include(AKERU_BOT_INSTRUCTIONS, "add one short plain-language status note");
+    assert.include(AKERU_BOT_INSTRUCTIONS, "hidden system reminder or automatic continuation");
+    assert.include(AKERU_BOT_INSTRUCTIONS, "Skip the opening reply");
+    assert.notInclude(AKERU_BOT_INSTRUCTIONS, "coding agent");
+  });
+
+  it("adds turn rules only for bot conversations", () => {
+    const regularContext = new RequestContext();
+    regularContext.setRaw("controller", { state: { botConversation: false } });
+    const botContext = new RequestContext();
+    botContext.setRaw("controller", { state: { botConversation: true } });
+
+    assert.notInclude(resolveAkeruInstructions(regularContext), "Before you use a tool");
+    assert.include(resolveAkeruInstructions(botContext), "Before you use a tool");
   });
 
   it("builds workspace and selected MCP tools from the controller resource", async () => {

--- a/apps/server/src/provider/AkeruMastraHarness.ts
+++ b/apps/server/src/provider/AkeruMastraHarness.ts
@@ -9,13 +9,14 @@ import { createCodingAgent } from "@mastra/core/coding-agent";
 import type { RequestContext } from "@mastra/core/request-context";
 import { createWorkspaceTools, type Workspace } from "@mastra/core/workspace";
 
-import { AKERU_AGENT_INSTRUCTIONS } from "./AkeruAgentInstructions.ts";
+import { AKERU_AGENT_INSTRUCTIONS, AKERU_BOT_INSTRUCTIONS } from "./AkeruAgentInstructions.ts";
 
 const DEFAULT_MODEL_ID = "openai/gpt-5.6-sol";
 
 export interface AkeruMastraState {
   readonly projectPath?: string;
   readonly yolo?: boolean;
+  readonly botConversation?: boolean;
 }
 
 export type AkeruMastraSession = Session<AkeruMastraState>;
@@ -56,6 +57,16 @@ function controllerResourceId(requestContext: RequestContext): string | undefine
   return typeof value === "string" ? value : undefined;
 }
 
+export function resolveAkeruInstructions(requestContext: RequestContext): string {
+  const state = controllerContext(requestContext)?.state;
+  return typeof state === "object" &&
+    state !== null &&
+    "botConversation" in state &&
+    state.botConversation === true
+    ? AKERU_BOT_INSTRUCTIONS
+    : AKERU_AGENT_INSTRUCTIONS;
+}
+
 function codexModelName(modelId: string): string {
   return modelId.startsWith("openai/") ? modelId.slice("openai/".length) : modelId;
 }
@@ -90,7 +101,7 @@ export async function createAkeruMastraHarness(
   const agent = createCodingAgent({
     id: "akeru-agent",
     name: "Akeru",
-    instructions: AKERU_AGENT_INSTRUCTIONS,
+    instructions: ({ requestContext }) => resolveAkeruInstructions(requestContext),
     model: ({ requestContext }) =>
       openaiCodexProvider(codexModelName(controllerModelId(requestContext)), {
         authStorage: options.authStorage,

--- a/apps/server/src/provider/Layers/AgentController.test.ts
+++ b/apps/server/src/provider/Layers/AgentController.test.ts
@@ -11,6 +11,7 @@ import {
   McpServerId,
   ProviderDriverKind,
   ProviderInstanceId,
+  RuntimeItemId,
   ThreadId,
   TurnId,
   type ProviderRuntimeEvent,
@@ -36,6 +37,8 @@ import {
 
 const codexThreadId = ThreadId.make("thread-mastra-codex");
 const claudeThreadId = ThreadId.make("thread-legacy-claude");
+const botGrokThreadId = ThreadId.make("thread-bot-grok");
+const regularGrokThreadId = ThreadId.make("thread-regular-grok");
 const codexInstanceId = ProviderInstanceId.make("codex");
 const claudeInstanceId = ProviderInstanceId.make("claudeAgent");
 
@@ -185,9 +188,9 @@ function makeMastraHarness() {
   };
 }
 
-function assistantMessage(text: string): MastraDBMessage {
+function assistantMessage(text: string, id = "assistant-message"): MastraDBMessage {
   return {
-    id: "assistant-message",
+    id,
     role: "assistant",
     createdAt: new Date("2026-01-01T00:00:00.000Z"),
     content: {
@@ -197,6 +200,15 @@ function assistantMessage(text: string): MastraDBMessage {
     threadId: String(codexThreadId),
     resourceId: String(codexThreadId),
   } as MastraDBMessage;
+}
+
+function requireEventIndex(
+  events: ReadonlyArray<ProviderRuntimeEvent>,
+  predicate: (event: ProviderRuntimeEvent) => boolean,
+): number {
+  const index = events.findIndex(predicate);
+  assert.isAtLeast(index, 0);
+  return index;
 }
 
 function makeLayer(
@@ -240,6 +252,7 @@ function resolveCodex(controller: AgentController["Service"]) {
     engine: { provider: "codex", model: "gpt-5.6-sol" },
     fallback: codexSelection,
     mode: "default",
+    botConversation: true,
   });
 }
 
@@ -430,6 +443,295 @@ describe("AgentControllerLive", () => {
     );
   });
 
+  it.effect("keeps pre-tool replies and later status beats as separate messages", () => {
+    const bridge = makeBridge();
+    const mastra = makeMastraHarness();
+    return provideController(
+      Effect.gen(function* () {
+        const controller = yield* AgentController;
+        yield* resolveCodex(controller);
+        yield* controller.startSession(codexThreadId, {
+          threadId: codexThreadId,
+          provider: ProviderDriverKind.make("codex"),
+          providerInstanceId: codexInstanceId,
+          cwd: process.cwd(),
+          modelSelection: codexSelection,
+          runtimeMode: "full-access",
+        });
+
+        const events: ProviderRuntimeEvent[] = [];
+        const eventsFiber = yield* controller.streamEvents.pipe(
+          Stream.runForEach((event) =>
+            Effect.sync(() => {
+              events.push(event);
+            }),
+          ),
+          Effect.forkChild({ startImmediately: true }),
+        );
+        yield* Effect.yieldNow;
+        yield* controller.sendTurn({ threadId: codexThreadId, input: "Check the project." });
+        mastra.emit({
+          type: "message_update",
+          message: assistantMessage("I'll check the project first.", "reply-before-tools"),
+        } as AgentControllerEvent);
+        mastra.emit({
+          type: "tool_start",
+          toolCallId: "view-1",
+          toolName: "view",
+          args: { path: "package.json" },
+        } as AgentControllerEvent);
+        mastra.emit({
+          type: "tool_end",
+          toolCallId: "view-1",
+          result: "{}",
+          isError: false,
+        } as AgentControllerEvent);
+        mastra.emit({
+          type: "message_update",
+          message: assistantMessage(
+            "I'll check the project first. This delayed update must stay hidden.",
+            "reply-before-tools",
+          ),
+        } as AgentControllerEvent);
+        mastra.emit({
+          type: "message_end",
+          message: assistantMessage("I'll check the project first.", "reply-before-tools"),
+        } as AgentControllerEvent);
+        mastra.emit({
+          type: "message_update",
+          message: assistantMessage("I found the relevant configuration.", "status-after-tool"),
+        } as AgentControllerEvent);
+        mastra.emit({ type: "agent_end", reason: "complete" } as AgentControllerEvent);
+        mastra.finishSend();
+        yield* Effect.yieldNow;
+        yield* Effect.yieldNow;
+        yield* Fiber.interrupt(eventsFiber);
+
+        const assistantStarts = events.filter(
+          (event) =>
+            event.type === "item.started" && event.payload.itemType === "assistant_message",
+        );
+        assert.deepEqual(
+          assistantStarts.map((event) => event.itemId),
+          [
+            RuntimeItemId.make("mastra-answer-reply-before-tools"),
+            RuntimeItemId.make("mastra-answer-status-after-tool"),
+          ],
+        );
+        assert.deepEqual(
+          events
+            .filter((event) => event.type === "content.delta")
+            .map((event) => event.payload.delta),
+          ["I'll check the project first.", "I found the relevant configuration."],
+        );
+        assert.isBelow(
+          requireEventIndex(
+            events,
+            (event) =>
+              event.type === "item.completed" &&
+              event.itemId === "mastra-answer-reply-before-tools",
+          ),
+          requireEventIndex(
+            events,
+            (event) => event.type === "item.started" && event.itemId === "view-1",
+          ),
+        );
+      }),
+      bridge.service,
+      mastra.factory,
+    );
+  });
+
+  it.effect("does not turn hidden signals into replies and allows text after a tool", () => {
+    const bridge = makeBridge();
+    const mastra = makeMastraHarness();
+    return provideController(
+      Effect.gen(function* () {
+        const controller = yield* AgentController;
+        yield* resolveCodex(controller);
+        yield* controller.startSession(codexThreadId, {
+          threadId: codexThreadId,
+          provider: ProviderDriverKind.make("codex"),
+          providerInstanceId: codexInstanceId,
+          cwd: process.cwd(),
+          modelSelection: codexSelection,
+          runtimeMode: "full-access",
+        });
+
+        const events: ProviderRuntimeEvent[] = [];
+        const eventsFiber = yield* controller.streamEvents.pipe(
+          Stream.runForEach((event) =>
+            Effect.sync(() => {
+              events.push(event);
+            }),
+          ),
+          Effect.forkChild({ startImmediately: true }),
+        );
+        yield* Effect.yieldNow;
+        yield* controller.sendTurn({ threadId: codexThreadId, input: "Continue the work." });
+        mastra.emit({
+          type: "message_end",
+          message: {
+            ...assistantMessage("hidden continuation", "hidden-signal"),
+            role: "signal",
+          },
+        } as AgentControllerEvent);
+        mastra.emit({
+          type: "tool_start",
+          toolCallId: "view-first",
+          toolName: "view",
+          args: { path: "package.json" },
+        } as AgentControllerEvent);
+        mastra.emit({
+          type: "tool_end",
+          toolCallId: "view-first",
+          result: "{}",
+          isError: false,
+        } as AgentControllerEvent);
+        mastra.emit({
+          type: "message_end",
+          message: assistantMessage("The check is complete.", "answer-after-tool"),
+        } as AgentControllerEvent);
+        mastra.emit({ type: "agent_end", reason: "complete" } as AgentControllerEvent);
+        mastra.finishSend();
+        yield* Effect.yieldNow;
+        yield* Effect.yieldNow;
+        yield* Fiber.interrupt(eventsFiber);
+
+        expect(
+          events.some(
+            (event) => "itemId" in event && event.itemId === "mastra-answer-hidden-signal",
+          ),
+        ).toBe(false);
+        assert.isBelow(
+          requireEventIndex(
+            events,
+            (event) => event.type === "item.completed" && event.itemId === "view-first",
+          ),
+          requireEventIndex(
+            events,
+            (event) =>
+              event.type === "item.started" && event.itemId === "mastra-answer-answer-after-tool",
+          ),
+        );
+      }),
+      bridge.service,
+      mastra.factory,
+    );
+  });
+
+  it.effect("completes a streaming reply when the turn is interrupted", () => {
+    const bridge = makeBridge();
+    const mastra = makeMastraHarness();
+    return provideController(
+      Effect.gen(function* () {
+        const controller = yield* AgentController;
+        yield* resolveCodex(controller);
+        yield* controller.startSession(codexThreadId, {
+          threadId: codexThreadId,
+          provider: ProviderDriverKind.make("codex"),
+          providerInstanceId: codexInstanceId,
+          cwd: process.cwd(),
+          modelSelection: codexSelection,
+          runtimeMode: "full-access",
+        });
+
+        const events: ProviderRuntimeEvent[] = [];
+        const eventsFiber = yield* controller.streamEvents.pipe(
+          Stream.runForEach((event) =>
+            Effect.sync(() => {
+              events.push(event);
+            }),
+          ),
+          Effect.forkChild({ startImmediately: true }),
+        );
+        yield* Effect.yieldNow;
+        const { turnId } = yield* controller.sendTurn({
+          threadId: codexThreadId,
+          input: "Start the work.",
+        });
+        mastra.emit({
+          type: "message_update",
+          message: assistantMessage("I started the check.", "reply-to-interrupt"),
+        } as AgentControllerEvent);
+        yield* controller.interruptTurn({ threadId: codexThreadId, turnId });
+        yield* Effect.yieldNow;
+        yield* Fiber.interrupt(eventsFiber);
+
+        assert.deepInclude(
+          events.find(
+            (event) =>
+              event.type === "item.completed" &&
+              event.itemId === "mastra-answer-reply-to-interrupt",
+          ),
+          { payload: { itemType: "assistant_message", status: "completed" } },
+        );
+        assert.deepInclude(
+          events.find((event) => event.type === "turn.completed"),
+          { payload: { state: "interrupted" } },
+        );
+        expect(mastra.session.abort).toHaveBeenCalledOnce();
+      }),
+      bridge.service,
+      mastra.factory,
+    );
+  });
+
+  it.effect("completes a reply before opening tool approval", () => {
+    const bridge = makeBridge();
+    const mastra = makeMastraHarness();
+    return provideController(
+      Effect.gen(function* () {
+        const controller = yield* AgentController;
+        yield* resolveCodex(controller);
+        yield* controller.startSession(codexThreadId, {
+          threadId: codexThreadId,
+          provider: ProviderDriverKind.make("codex"),
+          providerInstanceId: codexInstanceId,
+          cwd: process.cwd(),
+          modelSelection: codexSelection,
+          runtimeMode: "approval-required",
+        });
+
+        const events: ProviderRuntimeEvent[] = [];
+        const eventsFiber = yield* controller.streamEvents.pipe(
+          Stream.runForEach((event) =>
+            Effect.sync(() => {
+              events.push(event);
+            }),
+          ),
+          Effect.forkChild({ startImmediately: true }),
+        );
+        yield* Effect.yieldNow;
+        yield* controller.sendTurn({ threadId: codexThreadId, input: "Change the file." });
+        mastra.emit({
+          type: "message_update",
+          message: assistantMessage("I'll update the file.", "reply-before-approval"),
+        } as AgentControllerEvent);
+        mastra.emit({
+          type: "tool_approval_required",
+          toolCallId: "write-approval",
+          toolName: "write_file",
+          args: { path: "notes.md" },
+        } as AgentControllerEvent);
+        yield* Effect.yieldNow;
+        yield* Fiber.interrupt(eventsFiber);
+
+        assert.isBelow(
+          requireEventIndex(
+            events,
+            (event) =>
+              event.type === "item.completed" &&
+              event.itemId === "mastra-answer-reply-before-approval",
+          ),
+          requireEventIndex(events, (event) => event.type === "request.opened"),
+        );
+      }),
+      bridge.service,
+      mastra.factory,
+    );
+  });
+
   it.effect("keeps a suspended Mastra turn active until tool input resumes", () => {
     const bridge = makeBridge();
     const mastra = makeMastraHarness();
@@ -445,7 +747,21 @@ describe("AgentControllerLive", () => {
           modelSelection: codexSelection,
           runtimeMode: "approval-required",
         });
+        const events: ProviderRuntimeEvent[] = [];
+        const eventsFiber = yield* controller.streamEvents.pipe(
+          Stream.runForEach((event) =>
+            Effect.sync(() => {
+              events.push(event);
+            }),
+          ),
+          Effect.forkChild({ startImmediately: true }),
+        );
+        yield* Effect.yieldNow;
         yield* controller.sendTurn({ threadId: codexThreadId, input: "Ask for input." });
+        mastra.emit({
+          type: "message_update",
+          message: assistantMessage("I need one detail.", "reply-before-input"),
+        } as AgentControllerEvent);
         mastra.emit({
           type: "tool_suspended",
           toolCallId: "tool-input-1",
@@ -459,6 +775,15 @@ describe("AgentControllerLive", () => {
 
         const [waiting] = yield* controller.listSessions();
         assert.isDefined(waiting?.activeTurnId);
+        assert.isBelow(
+          requireEventIndex(
+            events,
+            (event) =>
+              event.type === "item.completed" &&
+              event.itemId === "mastra-answer-reply-before-input",
+          ),
+          requireEventIndex(events, (event) => event.type === "user-input.requested"),
+        );
 
         yield* controller.respondToUserInput({
           threadId: codexThreadId,
@@ -469,6 +794,7 @@ describe("AgentControllerLive", () => {
 
         const [completed] = yield* controller.listSessions();
         assert.isUndefined(completed?.activeTurnId);
+        yield* Fiber.interrupt(eventsFiber);
         expect(mastra.session.respondToToolSuspension).toHaveBeenCalledWith({
           toolCallId: "tool-input-1",
           resumeData: { answer: "Continue" },
@@ -626,7 +952,9 @@ describe("AgentControllerLive", () => {
         threadId: String(codexThreadId),
         sandbox: "upstash",
       });
-      expect(mastra.createSession.mock.calls[0]?.[0]).toMatchObject({ workspace: remote });
+      expect(mastra.createSession).toHaveBeenCalledWith(
+        expect.objectContaining({ workspace: remote }),
+      );
       yield* controller.stopSession({ threadId: codexThreadId });
     }).pipe(Effect.provide(layer), Effect.orDie);
   });
@@ -642,6 +970,7 @@ describe("AgentControllerLive", () => {
           engine: { provider: "claudeAgent", model: "claude-fable-5" },
           fallback: codexSelection,
           mode: "plan",
+          botConversation: true,
         });
         yield* controller.startSession(claudeThreadId, {
           threadId: claudeThreadId,
@@ -649,6 +978,7 @@ describe("AgentControllerLive", () => {
           providerInstanceId: claudeInstanceId,
           cwd: process.cwd(),
           runtimeMode: "approval-required",
+          botConversation: true,
         });
         const result = yield* controller.sendTurn({
           threadId: claudeThreadId,
@@ -656,10 +986,50 @@ describe("AgentControllerLive", () => {
         });
 
         assert.equal(result.turnId, TurnId.make("legacy-turn"));
-        expect(bridge.startSession).toHaveBeenCalledOnce();
-        expect(bridge.sendTurn).toHaveBeenCalledOnce();
+        expect(bridge.startSession).toHaveBeenCalledWith(
+          claudeThreadId,
+          expect.objectContaining({ botConversation: true }),
+        );
+        expect(bridge.sendTurn).toHaveBeenCalledWith({
+          threadId: claudeThreadId,
+          input: "Use Claude.",
+        });
         expect(mastra.createSession).not.toHaveBeenCalled();
         expect(mastra.sendMessage).not.toHaveBeenCalled();
+      }),
+      bridge.service,
+      mastra.factory,
+    );
+  });
+
+  it.effect("adds turn rules only to non-Claude bot provider payloads", () => {
+    const bridge = makeBridge();
+    const mastra = makeMastraHarness();
+    return provideController(
+      Effect.gen(function* () {
+        const controller = yield* AgentController;
+        for (const [threadId, botConversation] of [
+          [botGrokThreadId, true],
+          [regularGrokThreadId, false],
+        ] as const) {
+          yield* controller.resolveEngine({
+            threadId,
+            engine: { provider: "grok", model: "grok-code-fast-1" },
+            fallback: codexSelection,
+            mode: "default",
+            botConversation,
+          });
+          yield* controller.sendTurn({ threadId, input: "Check the project." });
+        }
+
+        expect(bridge.sendTurn.mock.calls[0]?.[0].input).toContain(
+          "Before you use a tool for a visible user request",
+        );
+        expect(bridge.sendTurn.mock.calls[0]?.[0].input).toMatch(/Check the project\.$/);
+        expect(bridge.sendTurn.mock.calls[1]?.[0]).toEqual({
+          threadId: regularGrokThreadId,
+          input: "Check the project.",
+        });
       }),
       bridge.service,
       mastra.factory,
@@ -683,12 +1053,14 @@ describe("AgentControllerLive", () => {
           engine: { provider: "claudeAgent", model: "claude-fable-5" },
           fallback: codexSelection,
           mode: "default",
+          botConversation: false,
         });
         yield* controller.resolveEngine({
           threadId: codexThreadId,
           engine: { provider: "codex", model: "gpt-5.6-sol" },
           fallback: codexSelection,
           mode: "default",
+          botConversation: false,
         });
         yield* controller.stopSession({ threadId: codexThreadId });
 

--- a/apps/server/src/provider/Layers/AgentController.ts
+++ b/apps/server/src/provider/Layers/AgentController.ts
@@ -26,6 +26,7 @@ import {
   type ModelSelection,
   type ProviderApprovalDecision,
   type ProviderRuntimeEvent,
+  type ProviderSendTurnInput,
   type ProviderSession,
   type RuntimeMode,
   type ThreadId,
@@ -44,6 +45,7 @@ import {
   type AkeruMastraHarnessOptions,
   type AkeruMastraSession,
 } from "../AkeruMastraHarness.ts";
+import { AKERU_BOT_TURN_INSTRUCTIONS } from "../AkeruAgentInstructions.ts";
 import { createBotWorkspace, type CreateRemoteBotWorkspaceInput } from "../botWorkspace.ts";
 import { AgentControllerRuntimeError, AgentControllerUnsupportedEngineError } from "../Errors.ts";
 import { AgentController, type AgentControllerShape } from "../Services/AgentController.ts";
@@ -59,14 +61,19 @@ interface ResolvedEngine {
   readonly providerInstanceId: ProviderInstanceId;
   readonly mastraModelId: string;
   readonly mode: "default" | "plan";
+  readonly botConversation: boolean;
+}
+
+interface ActiveAssistantMessage {
+  readonly itemId: RuntimeItemId;
+  length: number;
+  started: boolean;
+  completed: boolean;
 }
 
 interface ActiveTurn {
   readonly turnId: TurnId;
-  readonly assistantItemId: RuntimeItemId;
-  assistantLength: number;
-  assistantStarted: boolean;
-  assistantCompleted: boolean;
+  readonly assistantMessages: Map<string, ActiveAssistantMessage>;
   waiting: boolean;
   finished: boolean;
 }
@@ -158,6 +165,15 @@ function permissionPolicy(
 
 function usesMastraCode(provider: ProviderDriverKind): boolean {
   return String(provider) === "codex";
+}
+
+function withBotTurnInstructions(input: ProviderSendTurnInput): ProviderSendTurnInput {
+  return {
+    ...input,
+    input: [AKERU_BOT_TURN_INSTRUCTIONS, input.input]
+      .filter((part): part is string => typeof part === "string" && part.length > 0)
+      .join("\n\n"),
+  };
 }
 
 function itemType(
@@ -262,6 +278,23 @@ const make = (options?: AgentControllerLiveOptions) =>
       });
     };
 
+    const completeAssistantMessages = (
+      threadId: ThreadId,
+      active: ActiveSession,
+      turn: ActiveTurn,
+    ) => {
+      for (const message of turn.assistantMessages.values()) {
+        if (!message.started || message.completed) continue;
+        message.completed = true;
+        publish({
+          ...baseEvent(threadId, active, turn.turnId),
+          itemId: message.itemId,
+          type: "item.completed",
+          payload: { itemType: "assistant_message", status: "completed" },
+        });
+      }
+    };
+
     const finishTurn = (
       threadId: ThreadId,
       active: ActiveSession,
@@ -271,15 +304,7 @@ const make = (options?: AgentControllerLiveOptions) =>
       const turn = active.activeTurn;
       if (!turn || turn.finished) return;
       turn.finished = true;
-      if (turn.assistantStarted && !turn.assistantCompleted) {
-        turn.assistantCompleted = true;
-        publish({
-          ...baseEvent(threadId, active, turn.turnId),
-          itemId: turn.assistantItemId,
-          type: "item.completed",
-          payload: { itemType: "assistant_message", status: "completed" },
-        });
-      }
+      completeAssistantMessages(threadId, active, turn);
       publish({
         ...baseEvent(threadId, active, turn.turnId),
         type: "turn.completed",
@@ -302,30 +327,42 @@ const make = (options?: AgentControllerLiveOptions) =>
       const turn = active.activeTurn;
       if (!turn) return;
       const text = messageText(message);
-      if (!turn.assistantStarted && text.length > 0) {
-        turn.assistantStarted = true;
+      const messageKey = String(message.id);
+      let activeMessage = turn.assistantMessages.get(messageKey);
+      if (!activeMessage) {
+        activeMessage = {
+          itemId: RuntimeItemId.make(`mastra-answer-${messageKey}`),
+          length: 0,
+          started: false,
+          completed: false,
+        };
+        turn.assistantMessages.set(messageKey, activeMessage);
+      }
+      if (activeMessage.completed) return;
+      if (!activeMessage.started && text.length > 0) {
+        activeMessage.started = true;
         publish({
           ...baseEvent(threadId, active, turn.turnId),
-          itemId: turn.assistantItemId,
+          itemId: activeMessage.itemId,
           type: "item.started",
           payload: { itemType: "assistant_message", status: "inProgress" },
         });
       }
-      if (text.length > turn.assistantLength) {
-        const delta = text.slice(turn.assistantLength);
-        turn.assistantLength = text.length;
+      if (text.length > activeMessage.length) {
+        const delta = text.slice(activeMessage.length);
+        activeMessage.length = text.length;
         publish({
           ...baseEvent(threadId, active, turn.turnId),
-          itemId: turn.assistantItemId,
+          itemId: activeMessage.itemId,
           type: "content.delta",
           payload: { streamKind: "assistant_text", delta },
         });
       }
-      if (complete && turn.assistantStarted && !turn.assistantCompleted) {
-        turn.assistantCompleted = true;
+      if (complete && activeMessage.started && !activeMessage.completed) {
+        activeMessage.completed = true;
         publish({
           ...baseEvent(threadId, active, turn.turnId),
-          itemId: turn.assistantItemId,
+          itemId: activeMessage.itemId,
           type: "item.completed",
           payload: { itemType: "assistant_message", status: "completed" },
         });
@@ -347,6 +384,7 @@ const make = (options?: AgentControllerLiveOptions) =>
           return;
         case "tool_start": {
           if (!turn) return;
+          completeAssistantMessages(threadId, active, turn);
           active.toolNames.set(event.toolCallId, event.toolName);
           publish({
             ...baseEvent(threadId, active, turn.turnId),
@@ -392,6 +430,7 @@ const make = (options?: AgentControllerLiveOptions) =>
         }
         case "tool_approval_required":
           if (!turn) return;
+          completeAssistantMessages(threadId, active, turn);
           active.toolNames.set(event.toolCallId, event.toolName);
           turn.waiting = true;
           publishSessionState(threadId, active, "waiting");
@@ -413,6 +452,7 @@ const make = (options?: AgentControllerLiveOptions) =>
           return;
         case "tool_suspended":
           if (!turn) return;
+          completeAssistantMessages(threadId, active, turn);
           active.toolNames.set(event.toolCallId, event.toolName);
           turn.waiting = true;
           publishSessionState(threadId, active, "waiting");
@@ -518,6 +558,7 @@ const make = (options?: AgentControllerLiveOptions) =>
             providerInstanceId: modelSelection.instanceId,
             mastraModelId: mastraModelId(inspected.routing.driverKind, modelSelection.model),
             mode: input.mode,
+            botConversation: input.botConversation,
           };
           resolvedByThread.set(String(input.threadId), resolved);
           const active = sessions.get(String(input.threadId));
@@ -563,16 +604,19 @@ const make = (options?: AgentControllerLiveOptions) =>
         yield* runMastra("mcp.init", () => manager.init());
         mcpManagers.set(key, manager);
       }
-      const workspace = yield* runMastra("workspace.create", () =>
-        createBotWorkspace({
-          threadId: key,
-          cwd: input.cwd,
-          sandbox: input.botSandbox,
-          ...(options?.makeRemoteWorkspace
-            ? { makeRemoteWorkspace: options.makeRemoteWorkspace }
-            : {}),
-        }),
-      );
+      const workspaceCwd = input.cwd;
+      const workspace = workspaceCwd
+        ? yield* runMastra("workspace.create", () =>
+            createBotWorkspace({
+              threadId: key,
+              cwd: workspaceCwd,
+              sandbox: input.botSandbox ?? null,
+              ...(options?.makeRemoteWorkspace
+                ? { makeRemoteWorkspace: options.makeRemoteWorkspace }
+                : {}),
+            }),
+          )
+        : undefined;
       if (workspace) workspaces.set(key, workspace);
       const session = yield* runMastra("createSession", () =>
         bundle.controller.createSession({
@@ -592,6 +636,7 @@ const make = (options?: AgentControllerLiveOptions) =>
         session.state.set({
           ...(input.cwd ? { projectPath: input.cwd } : {}),
           yolo: input.runtimeMode === "full-access" || input.runtimeMode === "auto",
+          botConversation: resolved.botConversation,
         }),
       );
       yield* runMastra("model.switch", () =>
@@ -652,7 +697,14 @@ const make = (options?: AgentControllerLiveOptions) =>
               detail: `Mastra session for thread '${input.threadId}' is not running.`,
             });
           }
-          return yield* legacyProviderBridge.sendTurn(input);
+          const resolved = resolvedByThread.get(key);
+          // ACP and OpenCode do not expose a per-session system prompt here.
+          // Prefix only visible bot turns. Mastra's hidden signal messages never use sendTurn.
+          return yield* legacyProviderBridge.sendTurn(
+            resolved?.botConversation === true && String(resolved.provider) !== "claudeAgent"
+              ? withBotTurnInstructions(input)
+              : input,
+          );
         }
         if (active.activeTurn) {
           return yield* new AgentControllerRuntimeError({
@@ -697,10 +749,7 @@ const make = (options?: AgentControllerLiveOptions) =>
         const turnId = TurnId.make(`mastra-turn-${NodeCrypto.randomUUID()}`);
         active.activeTurn = {
           turnId,
-          assistantItemId: RuntimeItemId.make(`mastra-answer-${turnId}`),
-          assistantLength: 0,
-          assistantStarted: false,
-          assistantCompleted: false,
+          assistantMessages: new Map(),
           waiting: false,
           finished: false,
         };

--- a/apps/server/src/provider/Layers/ClaudeAdapter.test.ts
+++ b/apps/server/src/provider/Layers/ClaudeAdapter.test.ts
@@ -413,19 +413,43 @@ describe("ClaudeAdapterLive", () => {
           type: "preset",
           preset: "claude_code",
         });
-        assert.include(
+        const appendedInstructions =
           typeof createInput?.options.systemPrompt === "object" &&
-            "append" in createInput.options.systemPrompt
+          "append" in createInput.options.systemPrompt
             ? (createInput.options.systemPrompt.append ?? "")
-            : "",
-          "general-purpose assistant",
-        );
+            : "";
+        assert.include(appendedInstructions, "general-purpose assistant");
+        assert.notInclude(appendedInstructions, "Before you use a tool");
       }).pipe(
         Effect.provideService(Random.Random, makeDeterministicRandomService()),
         Effect.provide(harness.layer),
       );
     },
   );
+
+  it.effect("adds reply-first instructions to bot Claude sessions", () => {
+    const harness = makeHarness();
+    return Effect.gen(function* () {
+      const adapter = yield* ClaudeAdapter;
+      yield* adapter.startSession({
+        threadId: THREAD_ID,
+        provider: ProviderDriverKind.make("claudeAgent"),
+        runtimeMode: "full-access",
+        botConversation: true,
+      });
+
+      const systemPrompt = harness.getLastCreateQueryInput()?.options.systemPrompt;
+      const appendedInstructions =
+        typeof systemPrompt === "object" && "append" in systemPrompt
+          ? (systemPrompt.append ?? "")
+          : "";
+      assert.include(appendedInstructions, "Before you use a tool");
+      assert.include(appendedInstructions, "automatic continuation");
+    }).pipe(
+      Effect.provideService(Random.Random, makeDeterministicRandomService()),
+      Effect.provide(harness.layer),
+    );
+  });
 
   it.effect("passes the configured auto-compaction window to Claude", () => {
     const harness = makeHarness({ claudeConfig: { autoCompactWindow: "300000" } });

--- a/apps/server/src/provider/Layers/ClaudeAdapter.ts
+++ b/apps/server/src/provider/Layers/ClaudeAdapter.ts
@@ -78,7 +78,7 @@ import * as Stream from "effect/Stream";
 
 import { resolveAttachmentPath } from "../../attachmentStore.ts";
 import { ServerConfig } from "../../config.ts";
-import { AKERU_AGENT_INSTRUCTIONS } from "../AkeruAgentInstructions.ts";
+import { AKERU_AGENT_INSTRUCTIONS, AKERU_BOT_INSTRUCTIONS } from "../AkeruAgentInstructions.ts";
 import * as McpProviderSession from "../../mcp/McpProviderSession.ts";
 import { toClaudeMcpServers } from "../McpServerConfig.ts";
 import { resolveClaudeSdkExecutablePath } from "../Drivers/ClaudeExecutable.ts";
@@ -4325,7 +4325,7 @@ export const makeClaudeAdapter = Effect.fn("makeClaudeAdapter")(function* (
         systemPrompt: {
           type: "preset",
           preset: "claude_code",
-          append: AKERU_AGENT_INSTRUCTIONS,
+          append: input.botConversation ? AKERU_BOT_INSTRUCTIONS : AKERU_AGENT_INSTRUCTIONS,
         },
         settingSources: [...CLAUDE_SETTING_SOURCES],
         // `ultracode` is a Claude Code setting, not an API effort level. It is

--- a/apps/server/src/provider/Services/AgentController.ts
+++ b/apps/server/src/provider/Services/AgentController.ts
@@ -40,6 +40,7 @@ export interface AgentControllerShape {
     readonly engine: BotEngine | null;
     readonly fallback: ModelSelection;
     readonly mode: ProviderInteractionMode;
+    readonly botConversation: boolean;
   }) => Effect.Effect<AgentControllerEngineSelection, AgentControllerError>;
 
   /** Read routing metadata without changing the thread's active runtime session. */

--- a/apps/web/src/components/roster/BotRosterSidebar.tsx
+++ b/apps/web/src/components/roster/BotRosterSidebar.tsx
@@ -185,7 +185,6 @@ const BotStripTile = memo(function BotStripTile({
 function useLatestBotMessage(
   botId: string,
   fallback: RosterLastMessage | null,
-  working: boolean,
 ): RosterLastMessage | null {
   const rememberedPath = useRosterStore((state) => state.chatPathByBotId[botId]);
   const environmentId = usePrimaryEnvironmentId();
@@ -200,10 +199,7 @@ function useLatestBotMessage(
       : null;
   }, [botId, environmentId, rememberedPath, threadShells]);
   const messages = useThreadMessages(threadRef);
-  const visibleMessages = useMemo(
-    () => visibleBotChatMessages(messages, working),
-    [messages, working],
-  );
+  const visibleMessages = useMemo(() => visibleBotChatMessages(messages), [messages]);
   return useMemo(
     () => resolveLatestRosterMessage(fallback, visibleMessages),
     [fallback, visibleMessages],
@@ -223,7 +219,7 @@ const BotRosterRow = memo(function BotRosterRow({
 }) {
   const timestampFormat = useClientSettings((s) => s.timestampFormat);
   const presence = useBotPresence(bot.id);
-  const latestMessage = useLatestBotMessage(bot.id, lastMessage, presence === "working");
+  const latestMessage = useLatestBotMessage(bot.id, lastMessage);
   const { listeners, setNodeRef, transform, transition, isDragging } = useSortable({ id: bot.id });
   return (
     <li

--- a/apps/web/src/components/roster/BotThreadLanding.tsx
+++ b/apps/web/src/components/roster/BotThreadLanding.tsx
@@ -96,7 +96,7 @@ export function BotThreadLanding({ botId }: { readonly botId: string }) {
 
   if (!bot || bot.archivedAt !== null) return null;
   const working = runtime.sending || presence === "working";
-  const messages = visibleBotChatMessages(runtime.messages, working);
+  const messages = visibleBotChatMessages(runtime.messages);
 
   return (
     <SidebarInset

--- a/apps/web/src/components/roster/GroupThreadLanding.tsx
+++ b/apps/web/src/components/roster/GroupThreadLanding.tsx
@@ -30,7 +30,7 @@ export function GroupThreadLanding({ groupId }: { readonly groupId: string }) {
   const boss = members.find((bot) => bot.id === group.bossBotId) ?? members[0];
   if (!boss) return null;
   const working = runtime.sending || presence === "working";
-  const messages = visibleBotChatMessages(runtime.messages, working);
+  const messages = visibleBotChatMessages(runtime.messages);
   const activeBot = members.find((bot) => bot.id === runtime.respondingBotId) ?? boss;
 
   return (

--- a/apps/web/src/components/roster/botConversationPresentation.test.ts
+++ b/apps/web/src/components/roster/botConversationPresentation.test.ts
@@ -31,17 +31,21 @@ describe("bot conversation presentation", () => {
     expect(visibleBotChatMessages(messages).map((entry) => entry.id)).toEqual(["user", "answer"]);
   });
 
-  it("shows only the last settled assistant record from one turn", () => {
+  it("shows each settled assistant note from one turn", () => {
     const messages = [
       message("user", "user", false),
       message("intermediate", "assistant", false, "turn-1"),
       message("final", "assistant", false, "turn-1"),
     ];
 
-    expect(visibleBotChatMessages(messages).map((entry) => entry.id)).toEqual(["user", "final"]);
+    expect(visibleBotChatMessages(messages).map((entry) => entry.id)).toEqual([
+      "user",
+      "intermediate",
+      "final",
+    ]);
   });
 
-  it("hides assistant records from the active turn behind the working status", () => {
+  it("shows completed status beats while the turn remains active", () => {
     const messages = [
       message("first-user", "user", false),
       message("first-answer", "assistant", false, "turn-1"),
@@ -49,10 +53,11 @@ describe("bot conversation presentation", () => {
       message("active-intermediate", "assistant", false, "turn-2"),
     ];
 
-    expect(visibleBotChatMessages(messages, true).map((entry) => entry.id)).toEqual([
+    expect(visibleBotChatMessages(messages).map((entry) => entry.id)).toEqual([
       "first-user",
       "first-answer",
       "active-user",
+      "active-intermediate",
     ]);
   });
 });

--- a/apps/web/src/components/roster/botConversationPresentation.ts
+++ b/apps/web/src/components/roster/botConversationPresentation.ts
@@ -1,36 +1,13 @@
 import type { OrchestrationMessage } from "@t3tools/contracts";
 
 /**
- * Bot chat shows each user message and one final assistant answer per turn.
- * Provider progress and intermediate assistant records stay behind the working
- * status so one provider turn cannot appear as several bot replies.
+ * Bot chat shows user messages and every completed assistant note. A turn can
+ * answer before tools, add status beats during work, and finish with a result.
  */
 export function visibleBotChatMessages(
   messages: ReadonlyArray<OrchestrationMessage>,
-  working = false,
 ): ReadonlyArray<OrchestrationMessage> {
-  const latestAssistantIndexByResponse = new Map<string, number>();
-  let precedingUserId = "before-first-user";
-  let lastUserIndex = -1;
-
-  messages.forEach((message, index) => {
-    if (message.role === "user") {
-      precedingUserId = message.id;
-      lastUserIndex = index;
-      return;
-    }
-    if (message.role !== "assistant" || message.streaming) return;
-    latestAssistantIndexByResponse.set(message.turnId ?? precedingUserId, index);
-  });
-
-  precedingUserId = "before-first-user";
-  return messages.filter((message, index) => {
-    if (message.role === "user") {
-      precedingUserId = message.id;
-      return true;
-    }
-    if (message.role !== "assistant" || message.streaming) return false;
-    if (working && index > lastUserIndex) return false;
-    return latestAssistantIndexByResponse.get(message.turnId ?? precedingUserId) === index;
-  });
+  return messages.filter(
+    (message) => message.role === "user" || (message.role === "assistant" && !message.streaming),
+  );
 }

--- a/apps/web/vite.config.ts
+++ b/apps/web/vite.config.ts
@@ -1,4 +1,4 @@
-import * as NodeUrl from "node:url";
+import * as NodeURL from "node:url";
 import * as NodeZlib from "node:zlib";
 
 import tailwindcss from "@tailwindcss/vite";
@@ -15,7 +15,7 @@ import { DEV_PROXIED_PATH_PREFIXES } from "@t3tools/shared/devProxy";
 
 import { loadRepoEnv } from "../../scripts/lib/public-config";
 
-const reactGrabEntry = NodeUrl.fileURLToPath(import.meta.resolve("react-grab"));
+const reactGrabEntry = NodeURL.fileURLToPath(import.meta.resolve("react-grab"));
 
 const repoEnv = loadRepoEnv();
 Object.assign(process.env, repoEnv);

--- a/docs/internals/voice.md
+++ b/docs/internals/voice.md
@@ -12,7 +12,8 @@ How an Akeru Bot talks in chat. These rules feed bot system prompts and review o
 
 ## Working
 
-- Say what you are about to do in one line before a long task, then go quiet until there is a result.
+- Say what you are about to do in one line before a long task.
+- During longer work, add one short update after meaningful progress or a change in direction. Do not narrate each tool.
 - Report a result with what changed and where it lives. A link or a path beats a paragraph.
 - Ask one question when blocked. Include your best-guess default so a "yes" unblocks you.
 

--- a/docs/user/bots.md
+++ b/docs/user/bots.md
@@ -13,4 +13,6 @@ Akeru Bot stores the profile in the connected environment. Other clients connect
 
 Use the panel button to collapse or reopen the editor. The default shortcut is **Mod+Alt+B**, and you can change `Right Panel: Toggle` in the keybinding settings. On a narrow screen, the same button opens a sheet.
 
+When a request needs tools, the bot first replies in plain language. During longer work, it adds short status notes after meaningful progress. When work resumes automatically, it continues without a repeated opening note.
+
 Bot replies support headings, links, tables, task lists, code blocks, math, and Mermaid diagrams.

--- a/packages/contracts/src/provider.test.ts
+++ b/packages/contracts/src/provider.test.ts
@@ -55,9 +55,11 @@ describe("ProviderSessionStartInput", () => {
       threadId: "thread-1",
       provider: "codex",
       botSandbox: "vercel",
+      botConversation: true,
       runtimeMode: "full-access",
     });
     expect(parsed.botSandbox).toBe("vercel");
+    expect(parsed.botConversation).toBe(true);
   });
 
   it("rejects payloads without runtime mode", () => {

--- a/packages/contracts/src/provider.ts
+++ b/packages/contracts/src/provider.ts
@@ -65,6 +65,7 @@ export const ProviderSessionStartInput = Schema.Struct({
   approvalPolicy: Schema.optional(ProviderApprovalPolicy),
   sandboxMode: Schema.optional(ProviderSandboxMode),
   botSandbox: Schema.optional(Schema.NullOr(BotSandbox)),
+  botConversation: Schema.optional(Schema.Boolean),
   mcpServers: Schema.optional(Schema.Array(McpServer)),
   runtimeMode: RuntimeMode,
 });

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -485,8 +485,8 @@ importers:
         specifier: ^1.3.15
         version: 1.15.13
       '@opencoredev/sandbox-sdk':
-        specifier: file:../../../sandbox-sdk/packages/sdk
-        version: file:../sandbox-sdk/packages/sdk(@mastra/core@1.63.0(@bufbuild/protobuf@2.14.0)(bufferutil@4.1.0)(express@5.2.1)(utf-8-validate@6.0.6)(zod@4.4.3))(@modelcontextprotocol/sdk@1.29.0(zod@4.4.3))(@upstash/box@0.5.3(zod@4.4.3))(@vercel/sandbox@2.9.2)(bufferutil@4.1.0)(e2b@2.46.0)(utf-8-validate@6.0.6)(ws@8.21.0(bufferutil@4.1.0)(utf-8-validate@6.0.6))
+        specifier: 0.2.0
+        version: 0.2.0(@mastra/core@1.63.0(@bufbuild/protobuf@2.14.0)(bufferutil@4.1.0)(express@5.2.1)(utf-8-validate@6.0.6)(zod@4.4.3))(@modelcontextprotocol/sdk@1.29.0(zod@4.4.3))(@upstash/box@0.5.3(zod@4.4.3))(@vercel/sandbox@2.9.2)(bufferutil@4.1.0)(e2b@2.46.0)(utf-8-validate@6.0.6)(ws@8.21.0(bufferutil@4.1.0)(utf-8-validate@6.0.6))
       '@pierre/diffs':
         specifier: 'catalog:'
         version: 1.3.0-beta.10(patch_hash=7ef7cb0cbabb17c15cdb137554068b36f15f6f5265e73fb51452aa3380db91aa)(@shikijs/themes@4.3.0)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
@@ -4209,10 +4209,9 @@ packages:
   '@opencode-ai/sdk@1.15.13':
     resolution: {integrity: sha512-4TwojIoQ8EG6/mVBuUVYZXiFcwNmiiytEnjnvyuvSJjGwFIlw2YIBFxtSVC3FbwwbwHT63teh1RHiQUUC4U5xw==}
 
-  '@opencoredev/sandbox-sdk@file:../sandbox-sdk/packages/sdk':
-    resolution: {directory: ../sandbox-sdk/packages/sdk, type: directory}
+  '@opencoredev/sandbox-sdk@0.2.0':
+    resolution: {integrity: sha512-VBOz1yE+HmZ2iw6WfE5+3aVN8eu490a5nXtE2ikqjHXDZ5OjoDG3T39fIogUXf4N4f7zo+WpNyMP9SIC6b6sBw==}
     engines: {node: '>=22 <26'}
-    hasBin: true
     peerDependencies:
       '@ai-sdk/harness': ^1.0.0
       '@asciidev/box-sdk': ^0.0.24
@@ -13892,7 +13891,7 @@ snapshots:
       '@aws-crypto/sha256-js': 5.2.0
       '@aws-crypto/supports-web-crypto': 5.2.0
       '@aws-crypto/util': 5.2.0
-      '@aws-sdk/types': 3.973.10
+      '@aws-sdk/types': 3.974.5
       '@aws-sdk/util-locate-window': 3.965.5
       '@smithy/util-utf8': 2.3.0
       tslib: 2.8.1
@@ -13900,7 +13899,7 @@ snapshots:
   '@aws-crypto/sha256-js@5.2.0':
     dependencies:
       '@aws-crypto/util': 5.2.0
-      '@aws-sdk/types': 3.973.10
+      '@aws-sdk/types': 3.974.5
       tslib: 2.8.1
 
   '@aws-crypto/supports-web-crypto@5.2.0':
@@ -14267,9 +14266,9 @@ snapshots:
 
   '@aws-sdk/signature-v4-multi-region@3.996.31':
     dependencies:
-      '@aws-sdk/types': 3.973.10
+      '@aws-sdk/types': 3.974.5
       '@smithy/signature-v4': 5.4.6
-      '@smithy/types': 4.14.3
+      '@smithy/types': 4.17.2
       tslib: 2.8.1
 
   '@aws-sdk/signature-v4-multi-region@3.996.46':
@@ -14281,11 +14280,11 @@ snapshots:
 
   '@aws-sdk/token-providers@3.1062.0':
     dependencies:
-      '@aws-sdk/core': 3.974.17
+      '@aws-sdk/core': 3.977.9
       '@aws-sdk/nested-clients': 3.997.16
-      '@aws-sdk/types': 3.973.10
-      '@smithy/core': 3.24.6
-      '@smithy/types': 4.14.3
+      '@aws-sdk/types': 3.974.5
+      '@smithy/core': 3.33.3
+      '@smithy/types': 4.17.2
       tslib: 2.8.1
 
   '@aws-sdk/token-providers@3.1116.0':
@@ -14322,7 +14321,7 @@ snapshots:
 
   '@aws-sdk/xml-builder@3.972.27':
     dependencies:
-      '@smithy/types': 4.14.3
+      '@smithy/types': 4.17.2
       fast-xml-parser: 5.7.3
       tslib: 2.8.1
 
@@ -16915,7 +16914,7 @@ snapshots:
       openai: 6.26.0(ws@8.21.0(bufferutil@4.1.0)(utf-8-validate@6.0.6))(zod@4.4.3)
       partial-json: 0.1.7
       proxy-agent: 6.5.0
-      undici: 7.27.1
+      undici: 7.29.0
       zod-to-json-schema: 3.25.2(zod@4.4.3)
     transitivePeerDependencies:
       - '@modelcontextprotocol/sdk'
@@ -16944,7 +16943,7 @@ snapshots:
       minimatch: 10.2.5
       proper-lockfile: 4.1.2
       strip-ansi: 7.2.0
-      undici: 7.27.1
+      undici: 7.29.0
       yaml: 2.9.0
     optionalDependencies:
       '@mariozechner/clipboard': 0.3.9
@@ -17433,7 +17432,7 @@ snapshots:
     dependencies:
       cross-spawn: 7.0.6
 
-  '@opencoredev/sandbox-sdk@file:../sandbox-sdk/packages/sdk(@mastra/core@1.63.0(@bufbuild/protobuf@2.14.0)(bufferutil@4.1.0)(express@5.2.1)(utf-8-validate@6.0.6)(zod@4.4.3))(@modelcontextprotocol/sdk@1.29.0(zod@4.4.3))(@upstash/box@0.5.3(zod@4.4.3))(@vercel/sandbox@2.9.2)(bufferutil@4.1.0)(e2b@2.46.0)(utf-8-validate@6.0.6)(ws@8.21.0(bufferutil@4.1.0)(utf-8-validate@6.0.6))':
+  '@opencoredev/sandbox-sdk@0.2.0(@mastra/core@1.63.0(@bufbuild/protobuf@2.14.0)(bufferutil@4.1.0)(express@5.2.1)(utf-8-validate@6.0.6)(zod@4.4.3))(@modelcontextprotocol/sdk@1.29.0(zod@4.4.3))(@upstash/box@0.5.3(zod@4.4.3))(@vercel/sandbox@2.9.2)(bufferutil@4.1.0)(e2b@2.46.0)(utf-8-validate@6.0.6)(ws@8.21.0(bufferutil@4.1.0)(utf-8-validate@6.0.6))':
     dependencies:
       '@rivet-dev/agentos-core': 0.2.15(@modelcontextprotocol/sdk@1.29.0(zod@4.4.3))(bufferutil@4.1.0)(utf-8-validate@6.0.6)(ws@8.21.0(bufferutil@4.1.0)(utf-8-validate@6.0.6))
     optionalDependencies:
@@ -18781,8 +18780,8 @@ snapshots:
 
   '@smithy/fetch-http-handler@5.4.6':
     dependencies:
-      '@smithy/core': 3.24.6
-      '@smithy/types': 4.14.3
+      '@smithy/core': 3.33.3
+      '@smithy/types': 4.17.2
       tslib: 2.8.1
 
   '@smithy/fetch-http-handler@5.7.2':
@@ -18808,8 +18807,8 @@ snapshots:
 
   '@smithy/node-http-handler@4.7.7':
     dependencies:
-      '@smithy/core': 3.24.6
-      '@smithy/types': 4.14.3
+      '@smithy/core': 3.33.3
+      '@smithy/types': 4.17.2
       tslib: 2.8.1
 
   '@smithy/shared-ini-file-loader@4.5.6':
@@ -18819,8 +18818,8 @@ snapshots:
 
   '@smithy/signature-v4@5.4.6':
     dependencies:
-      '@smithy/core': 3.24.6
-      '@smithy/types': 4.14.3
+      '@smithy/core': 3.33.3
+      '@smithy/types': 4.17.2
       tslib: 2.8.1
 
   '@smithy/signature-v4@5.7.3':

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -11,6 +11,7 @@ packages:
 allowBuilds:
   "@google/genai": false
   agent-browser: false
+  better-sqlite3: false
   browser-tabs-lock: false
   bufferutil: false
   core-js: false
@@ -19,6 +20,8 @@ allowBuilds:
   electron-winstaller: false
   esbuild: true
   geckodriver: false
+  isolated-vm: false
+  koffi: false
   msgpackr-extract: true
   msw: false
   node-pty: true


### PR DESCRIPTION
## What Changed

- Scope reply-first and status-beat instructions to bot and group threads across Codex, Claude, Cursor, Grok, and OpenCode.
- Persist separate assistant notes before and between tool steps, approvals, and user-input requests.
- Show completed opening replies and status notes while bot work remains active.
- Keep hidden self-wake signals from producing a second opening reply.
- Document the bot voice and progress-note behavior.
- Use the published sandbox SDK so clean CI checkouts can install dependencies.

## Why

Bots buffered pre-tool text and the bot conversation UI hid assistant messages until the turn ended. Long runs could therefore appear silent even when the provider produced an opening reply or progress note.

[LEO-281](https://linear.app/opencoredev/issue/LEO-281/reply-first-then-work-with-status-beats)

## UI Changes

Bot and group conversations now show opening replies and completed status notes during active turns. No screenshot or video is included because this changes message sequencing and visibility without changing visual styling or motion, and no live desktop was used.

## Testing

- `vp install --frozen-lockfile`
- `node scripts/release-smoke.ts`
- `vp test run packages/contracts/src/provider.test.ts apps/server/src/provider/AkeruMastraHarness.test.ts apps/server/src/provider/Layers/AgentController.test.ts apps/server/src/provider/Layers/ClaudeAdapter.test.ts apps/server/src/orchestration/Layers/ProviderCommandReactor.test.ts apps/server/src/orchestration/Layers/ProviderRuntimeIngestion.test.ts apps/web/src/components/roster/botConversationPresentation.test.ts` — 221 tests passed.
- `vp run --filter @t3tools/contracts --filter t3 --filter @t3tools/web typecheck`
- Targeted `vp fmt --check`
- `git diff --check`

## Checklist

- [x] This PR is small and focused
- [x] I explained what changed and why
- [ ] I included before/after screenshots for any UI changes — not included; no visual styling changed and no live desktop was used
- [ ] I included a video for animation/interaction changes — not applicable; no motion changed

Created with OpenAI GPT-5.6 Sol in T3 Code.
