### PR TITLE
feat(bots): require approval for sensitive actions

### DIFF
--- a/apps/server/src/provider/AkeruMastraHarness.test.ts
+++ b/apps/server/src/provider/AkeruMastraHarness.test.ts
@@ -6,7 +6,12 @@ import { LocalFilesystem, LocalSandbox, Workspace } from "@mastra/core/workspace
 import { assert, describe, it } from "vite-plus/test";
 
 import { AKERU_AGENT_INSTRUCTIONS } from "./AkeruAgentInstructions.ts";
-import { akeruToolCategory, criticalAkeruAction, resolveAkeruTools } from "./AkeruMastraHarness.ts";
+import {
+  akeruActionNeedsApproval,
+  akeruToolCategory,
+  criticalAkeruAction,
+  resolveAkeruTools,
+} from "./AkeruMastraHarness.ts";
 
 describe("AkeruMastraHarness", () => {
   it("configures Akeru as a general-purpose assistant with plugin awareness", () => {
@@ -35,6 +40,16 @@ describe("AkeruMastraHarness", () => {
       null,
     );
     assert.equal(criticalAkeruAction("api_request", { action: "delete" }), "delete");
+    assert.equal(criticalAkeruAction("api_request", { method: "DELETE" }), "delete");
+    assert.isTrue(akeruActionNeedsApproval("api_request", { verb: "dispatch" }));
+    assert.isTrue(akeruActionNeedsApproval("api_request", { operation: "synchronize" }));
+    assert.isFalse(akeruActionNeedsApproval("api_request", { method: "GET" }));
+    assert.isFalse(
+      akeruActionNeedsApproval("write_file", {
+        path: "notes.md",
+        content: "Call method dispatch after approval.",
+      }),
+    );
     assert.equal(akeruToolCategory("execute_command"), "execute");
     assert.equal(akeruToolCategory("gmail_send_message"), "other");
   });

--- a/apps/server/src/provider/AkeruMastraHarness.test.ts
+++ b/apps/server/src/provider/AkeruMastraHarness.test.ts
@@ -41,6 +41,11 @@ describe("AkeruMastraHarness", () => {
     );
     assert.equal(criticalAkeruAction("api_request", { action: "delete" }), "delete");
     assert.equal(criticalAkeruAction("api_request", { method: "DELETE" }), "delete");
+    assert.equal(criticalAkeruAction("api_request", { requestType: "delete" }), "delete");
+    assert.equal(
+      criticalAkeruAction("api_request", { options: { deliveryMode: "broadcast" } }),
+      "send",
+    );
     assert.isTrue(akeruActionNeedsApproval("api_request", { verb: "dispatch" }));
     assert.isTrue(akeruActionNeedsApproval("api_request", { operation: "synchronize" }));
     assert.isFalse(akeruActionNeedsApproval("api_request", { method: "GET" }));

--- a/apps/server/src/provider/AkeruMastraHarness.test.ts
+++ b/apps/server/src/provider/AkeruMastraHarness.test.ts
@@ -6,7 +6,7 @@ import { LocalFilesystem, LocalSandbox, Workspace } from "@mastra/core/workspace
 import { assert, describe, it } from "vite-plus/test";
 
 import { AKERU_AGENT_INSTRUCTIONS } from "./AkeruAgentInstructions.ts";
-import { resolveAkeruTools } from "./AkeruMastraHarness.ts";
+import { akeruToolCategory, criticalAkeruAction, resolveAkeruTools } from "./AkeruMastraHarness.ts";
 
 describe("AkeruMastraHarness", () => {
   it("configures Akeru as a general-purpose assistant with plugin awareness", () => {
@@ -14,6 +14,29 @@ describe("AkeruMastraHarness", () => {
     assert.include(AKERU_AGENT_INSTRUCTIONS, "enabled plugin tools");
     assert.include(AKERU_AGENT_INSTRUCTIONS, "Do not assume");
     assert.notInclude(AKERU_AGENT_INSTRUCTIONS, "coding agent");
+  });
+
+  it("classifies send, pay, delete, and production actions before tool execution", () => {
+    assert.equal(criticalAkeruAction("gmail_send_message"), "send");
+    assert.equal(criticalAkeruAction("gmail_send_read_receipt"), "send");
+    assert.equal(criticalAkeruAction("stripe_charge_customer"), "pay");
+    assert.equal(criticalAkeruAction("storage_delete_object"), "delete");
+    assert.equal(criticalAkeruAction("vercel_deploy"), "prod");
+    assert.equal(
+      criticalAkeruAction("execute_command", { command: "bun run release --prod" }),
+      "prod",
+    );
+    assert.equal(criticalAkeruAction("execute_command", { command: "bun test" }), null);
+    assert.equal(
+      criticalAkeruAction("write_file", {
+        path: "notes.md",
+        content: "Draft copy about send, pay, delete, and prod.",
+      }),
+      null,
+    );
+    assert.equal(criticalAkeruAction("api_request", { action: "delete" }), "delete");
+    assert.equal(akeruToolCategory("execute_command"), "execute");
+    assert.equal(akeruToolCategory("gmail_send_message"), "other");
   });
 
   it("builds workspace and selected MCP tools from the controller resource", async () => {

--- a/apps/server/src/provider/AkeruMastraHarness.ts
+++ b/apps/server/src/provider/AkeruMastraHarness.ts
@@ -76,7 +76,67 @@ export async function resolveAkeruTools(
   return { ...workspaceTools, ...options.getThreadTools(threadId) };
 }
 
-function toolCategory(toolName: string): "read" | "edit" | "execute" | "mcp" | "other" {
+export type AkeruToolCategory = "read" | "edit" | "execute" | "mcp" | "other";
+export type AkeruCriticalAction = "send" | "pay" | "delete" | "prod";
+
+const CRITICAL_ACTION_TOKENS: ReadonlyArray<readonly [AkeruCriticalAction, ReadonlySet<string>]> = [
+  ["send", new Set(["send", "post", "publish", "reply", "broadcast"])],
+  ["pay", new Set(["pay", "charge", "purchase", "checkout", "transfer"])],
+  ["delete", new Set(["delete", "remove", "destroy", "erase", "purge"])],
+  ["prod", new Set(["deploy", "release", "promote", "prod", "production"])],
+];
+
+function criticalActionFromText(value: string): AkeruCriticalAction | null {
+  const tokens = new Set(
+    value
+      .replace(/([a-z0-9])([A-Z])/g, "$1 $2")
+      .toLowerCase()
+      .split(/[^a-z0-9]+/)
+      .filter(Boolean),
+  );
+  for (const [action, actionTokens] of CRITICAL_ACTION_TOKENS) {
+    if ([...actionTokens].some((token) => tokens.has(token))) return action;
+  }
+  return null;
+}
+
+const CRITICAL_ARGUMENT_KEYS = new Set([
+  "action",
+  "operation",
+  "command",
+  "cmd",
+  "environment",
+  "env",
+  "stage",
+  "target",
+]);
+
+export function criticalAkeruAction(toolName: string, args?: unknown): AkeruCriticalAction | null {
+  const namedAction = criticalActionFromText(toolName);
+  if (namedAction) return namedAction;
+
+  const pending: unknown[] = [args];
+  let inspected = 0;
+  while (pending.length > 0 && inspected < 100) {
+    const value = pending.pop();
+    inspected += 1;
+    if (Array.isArray(value)) {
+      pending.push(...value.filter((entry) => typeof entry === "object" && entry !== null));
+      continue;
+    }
+    if (typeof value !== "object" || value === null) continue;
+    for (const [key, entry] of Object.entries(value)) {
+      if (CRITICAL_ARGUMENT_KEYS.has(key.toLowerCase()) && typeof entry === "string") {
+        const action = criticalActionFromText(`${key} ${entry}`);
+        if (action) return action;
+      }
+      if (typeof entry === "object" && entry !== null) pending.push(entry);
+    }
+  }
+  return null;
+}
+
+export function akeruToolCategory(toolName: string): AkeruToolCategory {
   if (/read|view|grep|search|find|list|stat/i.test(toolName)) return "read";
   if (/edit|write|delete|mkdir|move|rename/i.test(toolName)) return "edit";
   if (/execute|command|shell|process|terminal/i.test(toolName)) return "execute";
@@ -120,7 +180,7 @@ export async function createAkeruMastraHarness(
       "task_check",
       "subagent",
     ],
-    toolCategoryResolver: toolCategory,
+    toolCategoryResolver: akeruToolCategory,
     intervalHandlers: [],
   });
 

--- a/apps/server/src/provider/AkeruMastraHarness.ts
+++ b/apps/server/src/provider/AkeruMastraHarness.ts
@@ -103,6 +103,8 @@ function criticalActionFromText(value: string): AkeruCriticalAction | null {
 const CRITICAL_ARGUMENT_KEYS = new Set([
   "action",
   "operation",
+  "method",
+  "verb",
   "command",
   "cmd",
   "environment",
@@ -110,13 +112,31 @@ const CRITICAL_ARGUMENT_KEYS = new Set([
   "stage",
   "target",
 ]);
+const MUTATING_INTENT_KEYS = new Set(["action", "operation", "method", "verb"]);
+const READ_ONLY_INTENT_TOKENS = new Set([
+  "get",
+  "read",
+  "view",
+  "list",
+  "search",
+  "find",
+  "inspect",
+  "status",
+  "stat",
+]);
 
-export function criticalAkeruAction(toolName: string, args?: unknown): AkeruCriticalAction | null {
+type AkeruActionInspection = {
+  readonly action: AkeruCriticalAction | null;
+  readonly hasUnclassifiedIntent: boolean;
+};
+
+function inspectAkeruAction(toolName: string, args?: unknown): AkeruActionInspection {
   const namedAction = criticalActionFromText(toolName);
-  if (namedAction) return namedAction;
+  if (namedAction) return { action: namedAction, hasUnclassifiedIntent: false };
 
   const pending: unknown[] = [args];
   let inspected = 0;
+  let hasUnclassifiedIntent = false;
   while (pending.length > 0 && inspected < 100) {
     const value = pending.pop();
     inspected += 1;
@@ -126,14 +146,33 @@ export function criticalAkeruAction(toolName: string, args?: unknown): AkeruCrit
     }
     if (typeof value !== "object" || value === null) continue;
     for (const [key, entry] of Object.entries(value)) {
-      if (CRITICAL_ARGUMENT_KEYS.has(key.toLowerCase()) && typeof entry === "string") {
+      const normalizedKey = key.toLowerCase();
+      if (CRITICAL_ARGUMENT_KEYS.has(normalizedKey) && typeof entry === "string") {
         const action = criticalActionFromText(`${key} ${entry}`);
-        if (action) return action;
+        if (action) return { action, hasUnclassifiedIntent: false };
+        if (MUTATING_INTENT_KEYS.has(normalizedKey)) {
+          const tokens = entry
+            .toLowerCase()
+            .split(/[^a-z0-9]+/)
+            .filter(Boolean);
+          if (!tokens.some((token) => READ_ONLY_INTENT_TOKENS.has(token))) {
+            hasUnclassifiedIntent = true;
+          }
+        }
       }
       if (typeof entry === "object" && entry !== null) pending.push(entry);
     }
   }
-  return null;
+  return { action: null, hasUnclassifiedIntent };
+}
+
+export function criticalAkeruAction(toolName: string, args?: unknown): AkeruCriticalAction | null {
+  return inspectAkeruAction(toolName, args).action;
+}
+
+export function akeruActionNeedsApproval(toolName: string, args?: unknown): boolean {
+  const inspection = inspectAkeruAction(toolName, args);
+  return inspection.action !== null || inspection.hasUnclassifiedIntent;
 }
 
 export function akeruToolCategory(toolName: string): AkeruToolCategory {

--- a/apps/server/src/provider/AkeruMastraHarness.ts
+++ b/apps/server/src/provider/AkeruMastraHarness.ts
@@ -100,18 +100,7 @@ function criticalActionFromText(value: string): AkeruCriticalAction | null {
   return null;
 }
 
-const CRITICAL_ARGUMENT_KEYS = new Set([
-  "action",
-  "operation",
-  "method",
-  "verb",
-  "command",
-  "cmd",
-  "environment",
-  "env",
-  "stage",
-  "target",
-]);
+const NON_ACTION_TEXT_KEYS = new Set(["content"]);
 const MUTATING_INTENT_KEYS = new Set(["action", "operation", "method", "verb"]);
 const READ_ONLY_INTENT_TOKENS = new Set([
   "get",
@@ -147,17 +136,17 @@ function inspectAkeruAction(toolName: string, args?: unknown): AkeruActionInspec
     if (typeof value !== "object" || value === null) continue;
     for (const [key, entry] of Object.entries(value)) {
       const normalizedKey = key.toLowerCase();
-      if (CRITICAL_ARGUMENT_KEYS.has(normalizedKey) && typeof entry === "string") {
-        const action = criticalActionFromText(`${key} ${entry}`);
+      if (!NON_ACTION_TEXT_KEYS.has(normalizedKey)) {
+        const action = criticalActionFromText(typeof entry === "string" ? `${key} ${entry}` : key);
         if (action) return { action, hasUnclassifiedIntent: false };
-        if (MUTATING_INTENT_KEYS.has(normalizedKey)) {
-          const tokens = entry
-            .toLowerCase()
-            .split(/[^a-z0-9]+/)
-            .filter(Boolean);
-          if (!tokens.some((token) => READ_ONLY_INTENT_TOKENS.has(token))) {
-            hasUnclassifiedIntent = true;
-          }
+      }
+      if (MUTATING_INTENT_KEYS.has(normalizedKey) && typeof entry === "string") {
+        const tokens = entry
+          .toLowerCase()
+          .split(/[^a-z0-9]+/)
+          .filter(Boolean);
+        if (!tokens.some((token) => READ_ONLY_INTENT_TOKENS.has(token))) {
+          hasUnclassifiedIntent = true;
         }
       }
       if (typeof entry === "object" && entry !== null) pending.push(entry);

--- a/apps/server/src/provider/Layers/AgentController.test.ts
+++ b/apps/server/src/provider/Layers/AgentController.test.ts
@@ -530,6 +530,8 @@ describe("AgentControllerLive", () => {
           ["pay-call", "stripe_charge_customer", { amount: 100 }],
           ["delete-call", "storage_delete_object", { key: "report" }],
           ["prod-call", "execute_command", { command: "bun run release --prod" }],
+          ["method-call", "api_request", { method: "synchronize" }],
+          ["verb-call", "api_request", { verb: "dispatch" }],
         ] as const;
         for (const [toolCallId, toolName, args] of criticalCalls) {
           mastra.emit({
@@ -546,7 +548,7 @@ describe("AgentControllerLive", () => {
           decision: "approve",
         });
         const requests = events.filter((event) => event.type === "request.opened");
-        assert.equal(requests.length, 4);
+        assert.equal(requests.length, 6);
         for (const request of requests) {
           assert.include(request.payload.detail ?? "", "It does not undo completed work.");
           assert.deepEqual(request.payload.options, [
@@ -572,7 +574,7 @@ describe("AgentControllerLive", () => {
           args: { to: "person@example.com" },
         } as AgentControllerEvent);
         yield* Effect.yieldNow;
-        assert.equal(events.filter((event) => event.type === "request.opened").length, 5);
+        assert.equal(events.filter((event) => event.type === "request.opened").length, 7);
         expect(mastra.session.abort).not.toHaveBeenCalled();
         yield* Fiber.interrupt(eventsFiber);
       }),

--- a/apps/server/src/provider/Layers/AgentController.test.ts
+++ b/apps/server/src/provider/Layers/AgentController.test.ts
@@ -532,6 +532,7 @@ describe("AgentControllerLive", () => {
           ["prod-call", "execute_command", { command: "bun run release --prod" }],
           ["method-call", "api_request", { method: "synchronize" }],
           ["verb-call", "api_request", { verb: "dispatch" }],
+          ["request-type-call", "api_request", { requestType: "delete" }],
         ] as const;
         for (const [toolCallId, toolName, args] of criticalCalls) {
           mastra.emit({
@@ -548,7 +549,7 @@ describe("AgentControllerLive", () => {
           decision: "approve",
         });
         const requests = events.filter((event) => event.type === "request.opened");
-        assert.equal(requests.length, 6);
+        assert.equal(requests.length, 7);
         for (const request of requests) {
           assert.include(request.payload.detail ?? "", "It does not undo completed work.");
           assert.deepEqual(request.payload.options, [
@@ -574,7 +575,7 @@ describe("AgentControllerLive", () => {
           args: { to: "person@example.com" },
         } as AgentControllerEvent);
         yield* Effect.yieldNow;
-        assert.equal(events.filter((event) => event.type === "request.opened").length, 7);
+        assert.equal(events.filter((event) => event.type === "request.opened").length, 8);
         expect(mastra.session.abort).not.toHaveBeenCalled();
         yield* Fiber.interrupt(eventsFiber);
       }),

--- a/apps/server/src/provider/Layers/AgentController.test.ts
+++ b/apps/server/src/provider/Layers/AgentController.test.ts
@@ -643,7 +643,10 @@ describe("AgentControllerLive", () => {
     const mcpManager = {
       init: vi.fn(async () => undefined),
       disconnect: vi.fn(async () => undefined),
-      getTools: vi.fn(() => ({ exa_search: {} })),
+      getTools: vi.fn(() => ({
+        exa_search: { mcp: { annotations: { readOnlyHint: true } } },
+        external_action: { mcp: { annotations: { readOnlyHint: false } } },
+      })),
     };
     const makeMcpManagerMock = vi.fn((_dataDir, _configDir, _servers) => mcpManager as never);
     const makeMcpManager: NonNullable<AgentControllerLiveOptions["makeMcpManager"]> =
@@ -679,8 +682,46 @@ describe("AgentControllerLive", () => {
         });
         expect(mcpManager.init).toHaveBeenCalledOnce();
 
+        const events: ProviderRuntimeEvent[] = [];
+        const eventsFiber = yield* controller.streamEvents.pipe(
+          Stream.runForEach((event) =>
+            Effect.sync(() => {
+              events.push(event);
+            }),
+          ),
+          Effect.forkChild({ startImmediately: true }),
+        );
+        yield* Effect.yieldNow;
+        yield* controller.sendTurn({ threadId: codexThreadId, input: "Use MCP tools." });
+        mastra.emit({
+          type: "tool_approval_required",
+          toolCallId: "read-only-mcp",
+          toolName: "exa_search",
+          args: { query: "approval cards" },
+        } as AgentControllerEvent);
+        mastra.emit({
+          type: "tool_approval_required",
+          toolCallId: "unknown-mcp-mutation",
+          toolName: "external_action",
+          args: { payload: "opaque" },
+        } as AgentControllerEvent);
+        yield* Effect.yieldNow;
+
+        expect(mastra.session.respondToToolApproval).toHaveBeenCalledWith({
+          toolCallId: "read-only-mcp",
+          decision: "approve",
+        });
+        const request = events.find((event) => event.type === "request.opened");
+        assert.isDefined(request);
+        assert.include(request.payload.detail ?? "", "It does not undo completed work.");
+        assert.deepEqual(request.payload.options, [
+          { decision: "decline", label: "Decline" },
+          { decision: "accept", label: "Approve" },
+        ]);
+
         yield* controller.stopSession({ threadId: codexThreadId });
         expect(mcpManager.disconnect).toHaveBeenCalledOnce();
+        yield* Fiber.interrupt(eventsFiber);
       }),
       bridge.service,
       mastra.factory,

--- a/apps/server/src/provider/Layers/AgentController.test.ts
+++ b/apps/server/src/provider/Layers/AgentController.test.ts
@@ -479,6 +479,108 @@ describe("AgentControllerLive", () => {
     );
   });
 
+  it.effect("keeps critical actions behind one-use approvals in full access", () => {
+    const bridge = makeBridge();
+    const mastra = makeMastraHarness();
+    return provideController(
+      Effect.gen(function* () {
+        const controller = yield* AgentController;
+        yield* resolveCodex(controller);
+        yield* controller.startSession(codexThreadId, {
+          threadId: codexThreadId,
+          provider: ProviderDriverKind.make("codex"),
+          providerInstanceId: codexInstanceId,
+          cwd: process.cwd(),
+          modelSelection: codexSelection,
+          runtimeMode: "full-access",
+        });
+
+        expect(mastra.session.state.set).toHaveBeenCalledWith({
+          projectPath: process.cwd(),
+          yolo: false,
+        });
+        expect(mastra.session.permissions.setForCategory).toHaveBeenCalledWith({
+          category: "read",
+          policy: "ask",
+        });
+        expect(mastra.session.permissions.setForCategory).toHaveBeenCalledWith({
+          category: "execute",
+          policy: "ask",
+        });
+        const events: ProviderRuntimeEvent[] = [];
+        const eventsFiber = yield* controller.streamEvents.pipe(
+          Stream.runForEach((event) =>
+            Effect.sync(() => {
+              events.push(event);
+            }),
+          ),
+          Effect.forkChild({ startImmediately: true }),
+        );
+        yield* Effect.yieldNow;
+        yield* controller.sendTurn({ threadId: codexThreadId, input: "Use tools." });
+
+        mastra.emit({
+          type: "tool_approval_required",
+          toolCallId: "safe-command",
+          toolName: "execute_command",
+          args: { command: "bun test" },
+        } as AgentControllerEvent);
+        const criticalCalls = [
+          ["send-call", "gmail_send_message", { to: "person@example.com" }],
+          ["pay-call", "stripe_charge_customer", { amount: 100 }],
+          ["delete-call", "storage_delete_object", { key: "report" }],
+          ["prod-call", "execute_command", { command: "bun run release --prod" }],
+        ] as const;
+        for (const [toolCallId, toolName, args] of criticalCalls) {
+          mastra.emit({
+            type: "tool_approval_required",
+            toolCallId,
+            toolName,
+            args,
+          } as AgentControllerEvent);
+        }
+        yield* Effect.yieldNow;
+
+        expect(mastra.session.respondToToolApproval).toHaveBeenCalledWith({
+          toolCallId: "safe-command",
+          decision: "approve",
+        });
+        const requests = events.filter((event) => event.type === "request.opened");
+        assert.equal(requests.length, 4);
+        for (const request of requests) {
+          assert.include(request.payload.detail ?? "", "It does not undo completed work.");
+          assert.deepEqual(request.payload.options, [
+            { decision: "decline", label: "Decline" },
+            { decision: "accept", label: "Approve" },
+          ]);
+        }
+
+        yield* controller.respondToRequest({
+          threadId: codexThreadId,
+          requestId: ApprovalRequestId.make("send-call"),
+          decision: "acceptForSession",
+        });
+        expect(mastra.session.permissions.setForTool).not.toHaveBeenCalled();
+        expect(mastra.session.respondToToolApproval).toHaveBeenCalledWith({
+          toolCallId: "send-call",
+          decision: "approve",
+        });
+        mastra.emit({
+          type: "tool_approval_required",
+          toolCallId: "send-call-again",
+          toolName: "gmail_send_message",
+          args: { to: "person@example.com" },
+        } as AgentControllerEvent);
+        yield* Effect.yieldNow;
+        assert.equal(events.filter((event) => event.type === "request.opened").length, 5);
+        expect(mastra.session.abort).not.toHaveBeenCalled();
+        yield* Fiber.interrupt(eventsFiber);
+      }),
+      bridge.service,
+      mastra.factory,
+    );
+  });
+
   it.effect("reads persisted image attachments for Mastra turns", () => {
     const bridge = makeBridge();
     const mastra = makeMastraHarness();
@@ -626,7 +728,9 @@ describe("AgentControllerLive", () => {
         threadId: String(codexThreadId),
         sandbox: "upstash",
       });
-      expect(mastra.createSession.mock.calls[0]?.[0]).toMatchObject({ workspace: remote });
+      expect(mastra.createSession).toHaveBeenCalledWith(
+        expect.objectContaining({ workspace: remote }),
+      );
       yield* controller.stopSession({ threadId: codexThreadId });
     }).pipe(Effect.provide(layer), Effect.orDie);
   });

--- a/apps/server/src/provider/Layers/AgentController.ts
+++ b/apps/server/src/provider/Layers/AgentController.ts
@@ -39,9 +39,9 @@ import * as Stream from "effect/Stream";
 import { resolveAttachmentPath } from "../../attachmentStore.ts";
 import { ServerConfig } from "../../config.ts";
 import {
+  akeruActionNeedsApproval,
   akeruToolCategory,
   createAkeruMastraHarness,
-  criticalAkeruAction,
   type AkeruMastraHarness,
   type AkeruMastraHarnessOptions,
   type AkeruMastraSession,
@@ -408,9 +408,8 @@ const make = (options?: AgentControllerLiveOptions) =>
         case "tool_approval_required": {
           if (!turn) return;
           active.toolNames.set(event.toolCallId, event.toolName);
-          const criticalAction = criticalAkeruAction(event.toolName, event.args);
           const oneUseApproval =
-            criticalAction !== null ||
+            akeruActionNeedsApproval(event.toolName, event.args) ||
             mcpToolNeedsApproval(mcpManagers.get(String(threadId)), event.toolName);
           if (
             !oneUseApproval &&

--- a/apps/server/src/provider/Layers/AgentController.ts
+++ b/apps/server/src/provider/Layers/AgentController.ts
@@ -39,10 +39,14 @@ import * as Stream from "effect/Stream";
 import { resolveAttachmentPath } from "../../attachmentStore.ts";
 import { ServerConfig } from "../../config.ts";
 import {
+  akeruToolCategory,
   createAkeruMastraHarness,
+  criticalAkeruAction,
+  type AkeruCriticalAction,
   type AkeruMastraHarness,
   type AkeruMastraHarnessOptions,
   type AkeruMastraSession,
+  type AkeruToolCategory,
 } from "../AkeruMastraHarness.ts";
 import { createBotWorkspace, type CreateRemoteBotWorkspaceInput } from "../botWorkspace.ts";
 import { AgentControllerRuntimeError, AgentControllerUnsupportedEngineError } from "../Errors.ts";
@@ -146,14 +150,17 @@ export function toMcpServerConfigs(servers: readonly McpServer[]): Record<string
   );
 }
 
-function permissionPolicy(
-  runtimeMode: RuntimeMode,
-  category: "read" | "edit" | "execute" | "mcp" | "other",
-): "allow" | "ask" {
+function permissionPolicy(runtimeMode: RuntimeMode, category: AkeruToolCategory): "allow" | "ask" {
   if (runtimeMode === "full-access" || runtimeMode === "auto") return "allow";
   if (category === "read") return "allow";
   if (runtimeMode === "auto-accept-edits" && category === "edit") return "allow";
   return "ask";
+}
+
+function approvalDetail(toolName: string, criticalAction: AkeruCriticalAction | null): string {
+  return criticalAction
+    ? `Allow ${toolName}? This approval applies only to the pending action. It does not undo completed work.`
+    : `Allow ${toolName}?`;
 }
 
 function usesMastraCode(provider: ProviderDriverKind): boolean {
@@ -390,9 +397,20 @@ const make = (options?: AgentControllerLiveOptions) =>
           });
           return;
         }
-        case "tool_approval_required":
+        case "tool_approval_required": {
           if (!turn) return;
           active.toolNames.set(event.toolCallId, event.toolName);
+          const criticalAction = criticalAkeruAction(event.toolName, event.args);
+          if (
+            !criticalAction &&
+            permissionPolicy(active.runtimeMode, akeruToolCategory(event.toolName)) === "allow"
+          ) {
+            active.session.respondToToolApproval({
+              toolCallId: event.toolCallId,
+              decision: "approve",
+            });
+            return;
+          }
           turn.waiting = true;
           publishSessionState(threadId, active, "waiting");
           publish({
@@ -401,16 +419,16 @@ const make = (options?: AgentControllerLiveOptions) =>
             type: "request.opened",
             payload: {
               requestType: "dynamic_tool_call",
-              detail: `Allow ${event.toolName}?`,
+              detail: approvalDetail(event.toolName, criticalAction),
               args: event.args,
               options: [
-                { decision: "accept", label: "Allow" },
-                { decision: "acceptForSession", label: "Allow for session" },
                 { decision: "decline", label: "Decline" },
+                { decision: "accept", label: criticalAction ? "Approve" : "Allow" },
               ],
             },
           });
           return;
+        }
         case "tool_suspended":
           if (!turn) return;
           active.toolNames.set(event.toolCallId, event.toolName);
@@ -566,8 +584,8 @@ const make = (options?: AgentControllerLiveOptions) =>
       const workspace = yield* runMastra("workspace.create", () =>
         createBotWorkspace({
           threadId: key,
-          cwd: input.cwd,
-          sandbox: input.botSandbox,
+          ...(input.cwd ? { cwd: input.cwd } : {}),
+          ...(input.botSandbox !== undefined ? { sandbox: input.botSandbox } : {}),
           ...(options?.makeRemoteWorkspace
             ? { makeRemoteWorkspace: options.makeRemoteWorkspace }
             : {}),
@@ -591,7 +609,9 @@ const make = (options?: AgentControllerLiveOptions) =>
       yield* runMastra("state.set", () =>
         session.state.set({
           ...(input.cwd ? { projectPath: input.cwd } : {}),
-          yolo: input.runtimeMode === "full-access" || input.runtimeMode === "auto",
+          // Keep Mastra approval callbacks enabled. The hub below applies the
+          // runtime mode and preserves full-access behavior for safe calls.
+          yolo: false,
         }),
       );
       yield* runMastra("model.switch", () =>
@@ -605,10 +625,7 @@ const make = (options?: AgentControllerLiveOptions) =>
         ["read", "edit", "execute", "mcp", "other"] as const,
         (category) =>
           runMastra("permissions.setForCategory", () =>
-            session.permissions.setForCategory({
-              category,
-              policy: permissionPolicy(input.runtimeMode, category),
-            }),
+            session.permissions.setForCategory({ category, policy: "ask" }),
           ),
         { discard: true },
       );
@@ -762,22 +779,22 @@ const make = (options?: AgentControllerLiveOptions) =>
         return yield* legacyProviderBridge.respondToRequest(input);
       }
       const toolCallId = String(input.requestId);
-      const toolName = active.toolNames.get(toolCallId);
-      if (input.decision === "acceptForSession" && toolName) {
-        yield* runMastra("permissions.setForTool", () =>
-          active.session.permissions.setForTool({ toolName, policy: "allow" }),
-        );
-      }
+      // Every Mastra tool call must return through this hub so a later call
+      // cannot hide critical arguments behind an earlier session approval.
+      const decision =
+        input.decision === "acceptForSession" || input.decision === "acceptAlways"
+          ? "accept"
+          : input.decision;
       if (active.activeTurn) active.activeTurn.waiting = false;
       active.session.respondToToolApproval({
         toolCallId,
-        decision: approvalDecision(input.decision),
+        decision: approvalDecision(decision),
       });
       publish({
         ...baseEvent(input.threadId, active, active.activeTurn?.turnId),
         requestId: RuntimeRequestId.make(toolCallId),
         type: "request.resolved",
-        payload: { requestType: "dynamic_tool_call" as const, decision: input.decision },
+        payload: { requestType: "dynamic_tool_call" as const, decision },
       });
       publishSessionState(input.threadId, active, "running");
     });

--- a/apps/server/src/provider/Layers/AgentController.ts
+++ b/apps/server/src/provider/Layers/AgentController.ts
@@ -42,7 +42,6 @@ import {
   akeruToolCategory,
   createAkeruMastraHarness,
   criticalAkeruAction,
-  type AkeruCriticalAction,
   type AkeruMastraHarness,
   type AkeruMastraHarnessOptions,
   type AkeruMastraSession,
@@ -157,10 +156,19 @@ function permissionPolicy(runtimeMode: RuntimeMode, category: AkeruToolCategory)
   return "ask";
 }
 
-function approvalDetail(toolName: string, criticalAction: AkeruCriticalAction | null): string {
-  return criticalAction
+function approvalDetail(toolName: string, oneUseApproval: boolean): string {
+  return oneUseApproval
     ? `Allow ${toolName}? This approval applies only to the pending action. It does not undo completed work.`
     : `Allow ${toolName}?`;
+}
+
+function mcpToolNeedsApproval(manager: McpManager | undefined, toolName: string): boolean {
+  const tools = manager?.getTools();
+  if (!tools || !Object.hasOwn(tools, toolName)) return false;
+  const tool = tools[toolName] as {
+    readonly mcp?: { readonly annotations?: { readonly readOnlyHint?: boolean } };
+  };
+  return tool?.mcp?.annotations?.readOnlyHint !== true;
 }
 
 function usesMastraCode(provider: ProviderDriverKind): boolean {
@@ -401,8 +409,11 @@ const make = (options?: AgentControllerLiveOptions) =>
           if (!turn) return;
           active.toolNames.set(event.toolCallId, event.toolName);
           const criticalAction = criticalAkeruAction(event.toolName, event.args);
+          const oneUseApproval =
+            criticalAction !== null ||
+            mcpToolNeedsApproval(mcpManagers.get(String(threadId)), event.toolName);
           if (
-            !criticalAction &&
+            !oneUseApproval &&
             permissionPolicy(active.runtimeMode, akeruToolCategory(event.toolName)) === "allow"
           ) {
             active.session.respondToToolApproval({
@@ -419,11 +430,11 @@ const make = (options?: AgentControllerLiveOptions) =>
             type: "request.opened",
             payload: {
               requestType: "dynamic_tool_call",
-              detail: approvalDetail(event.toolName, criticalAction),
+              detail: approvalDetail(event.toolName, oneUseApproval),
               args: event.args,
               options: [
                 { decision: "decline", label: "Decline" },
-                { decision: "accept", label: criticalAction ? "Approve" : "Allow" },
+                { decision: "accept", label: oneUseApproval ? "Approve" : "Allow" },
               ],
             },
           });

--- a/apps/web/src/components/roster/BotApprovalPrompt.test.tsx
+++ b/apps/web/src/components/roster/BotApprovalPrompt.test.tsx
@@ -1,0 +1,37 @@
+import { ApprovalRequestId } from "@t3tools/contracts";
+import { renderToStaticMarkup } from "react-dom/server";
+import { describe, expect, it, vi } from "vite-plus/test";
+
+import { BotApprovalPrompt } from "./BotApprovalPrompt";
+
+const detail =
+  "Allow gmail_send_message? This approval applies only to the pending action. It does not undo completed work.";
+
+describe("BotApprovalPrompt", () => {
+  it("renders the one-use warning and only the hub-provided decisions", () => {
+    const markup = renderToStaticMarkup(
+      <BotApprovalPrompt
+        approval={{
+          requestId: ApprovalRequestId.make("send-call"),
+          requestKind: "command",
+          createdAt: "2026-08-27T00:00:00.000Z",
+          detail,
+          options: [
+            { decision: "decline", label: "Decline" },
+            { decision: "accept", label: "Approve" },
+          ],
+        }}
+        pendingCount={1}
+        responding={false}
+        error={null}
+        onRespond={vi.fn()}
+      />,
+    );
+
+    expect(markup).toContain('data-testid="bot-approval-prompt"');
+    expect(markup).toContain(detail);
+    expect(markup).toContain(">Decline<");
+    expect(markup).toContain(">Approve<");
+    expect(markup).not.toContain("Always allow");
+  });
+});

--- a/apps/web/src/components/roster/BotApprovalPrompt.tsx
+++ b/apps/web/src/components/roster/BotApprovalPrompt.tsx
@@ -1,0 +1,47 @@
+import type { ProviderApprovalDecision } from "@t3tools/contracts";
+
+import type { PendingApproval } from "../../session-logic";
+import { ComposerPendingApprovalActions } from "../chat/ComposerPendingApprovalActions";
+import { ComposerPendingApprovalPanel } from "../chat/ComposerPendingApprovalPanel";
+
+export function BotApprovalPrompt({
+  approval,
+  pendingCount,
+  responding,
+  error,
+  onRespond,
+}: {
+  readonly approval: PendingApproval;
+  readonly pendingCount: number;
+  readonly responding: boolean;
+  readonly error: string | null;
+  readonly onRespond: (decision: ProviderApprovalDecision) => Promise<unknown>;
+}) {
+  return (
+    <section
+      aria-label="Approval required"
+      className="w-full max-w-2xl rounded-2xl border border-border bg-foreground/5 p-3"
+      data-testid="bot-approval-prompt"
+    >
+      <p className="text-sm font-medium">Approval required</p>
+      <ComposerPendingApprovalPanel
+        approval={approval}
+        pendingCount={pendingCount}
+        className="mt-2"
+      />
+      <div className="mt-3 flex justify-end gap-1">
+        <ComposerPendingApprovalActions
+          requestId={approval.requestId}
+          isResponding={responding}
+          options={approval.options}
+          onRespondToApproval={(_requestId, decision) => onRespond(decision)}
+        />
+      </div>
+      {error ? (
+        <p role="alert" className="mt-2 text-xs text-destructive">
+          {error}
+        </p>
+      ) : null}
+    </section>
+  );
+}

--- a/apps/web/src/components/roster/BotThreadLanding.markdown.test.ts
+++ b/apps/web/src/components/roster/BotThreadLanding.markdown.test.ts
@@ -13,6 +13,22 @@ describe("BotThreadLanding message formatting", () => {
     expect(source).toContain("threadRef={runtime.linkedThreadRef ?? undefined}");
   });
 
+  it("renders the shared approval card in individual and group bot chats", () => {
+    const botSource = NodeFS.readFileSync(
+      new URL("./BotThreadLanding.tsx", import.meta.url),
+      "utf8",
+    );
+    const groupSource = NodeFS.readFileSync(
+      new URL("./GroupThreadLanding.tsx", import.meta.url),
+      "utf8",
+    );
+
+    expect(botSource).toContain("<BotApprovalPrompt");
+    expect(groupSource).toContain("<BotApprovalPrompt");
+    expect(botSource).not.toContain("function BotChoicePrompt");
+    expect(groupSource).not.toContain("function BotChoicePrompt");
+  });
+
   it("uses the free-scrolling conversation area instead of end-justified overflow", () => {
     const botSource = NodeFS.readFileSync(
       new URL("./BotThreadLanding.tsx", import.meta.url),

--- a/apps/web/src/components/roster/BotThreadLanding.tsx
+++ b/apps/web/src/components/roster/BotThreadLanding.tsx
@@ -22,6 +22,7 @@ import { toastManager } from "../ui/toast";
 import ChatMarkdown from "../ChatMarkdown";
 import { WorkspacePageHeader } from "../WorkspacePageHeader";
 import { BotActivityStatus } from "./BotActivityStatus";
+import { BotApprovalPrompt } from "./BotApprovalPrompt";
 import { BotAvatarView } from "./BotAvatarView";
 import { BotConversationScrollArea } from "./BotConversationScrollArea";
 import { visibleBotChatMessages } from "./botConversationPresentation";
@@ -30,6 +31,7 @@ import { BotPromptComposer } from "./BotPromptComposer";
 import { useBotPresence } from "./botPresence";
 import { useRosterStore } from "./rosterStore";
 import { useBotThreadRuntime } from "./useBotThreadRuntime";
+import { useRosterPendingApproval } from "./useRosterPendingApproval";
 
 export function BotThreadLanding({ botId }: { readonly botId: string }) {
   const navigate = useNavigate();
@@ -74,6 +76,7 @@ export function BotThreadLanding({ botId }: { readonly botId: string }) {
   );
   const effectiveModelSelection = stickyEngine;
   const runtime = useBotThreadRuntime(botId, effectiveModelSelection);
+  const approvalState = useRosterPendingApproval(runtime.linkedThreadRef);
   const presence = useBotPresence(botId);
 
   useEffect(() => {
@@ -97,6 +100,7 @@ export function BotThreadLanding({ botId }: { readonly botId: string }) {
   if (!bot || bot.archivedAt !== null) return null;
   const working = runtime.sending || presence === "working";
   const messages = visibleBotChatMessages(runtime.messages, working);
+  const pendingApproval = approvalState.pendingApproval;
 
   return (
     <SidebarInset
@@ -162,6 +166,15 @@ export function BotThreadLanding({ botId }: { readonly botId: string }) {
                 ),
               )
             )}
+            {pendingApproval ? (
+              <BotApprovalPrompt
+                approval={pendingApproval}
+                pendingCount={approvalState.pendingCount}
+                responding={approvalState.responding}
+                error={approvalState.responseError}
+                onRespond={(decision) => approvalState.respond(pendingApproval.requestId, decision)}
+              />
+            ) : null}
             {working ? <BotActivityStatus avatar={bot.avatar} name={bot.name} /> : null}
             {runtime.error ? (
               <div
@@ -178,6 +191,7 @@ export function BotThreadLanding({ botId }: { readonly botId: string }) {
             draftKey={bot.id}
             disabled={
               runtime.sending ||
+              pendingApproval !== null ||
               modelUpdatePending ||
               effectiveModelSelection === null ||
               !runtime.botReady ||

--- a/apps/web/src/components/roster/GroupThreadLanding.tsx
+++ b/apps/web/src/components/roster/GroupThreadLanding.tsx
@@ -4,6 +4,7 @@ import { useEffect } from "react";
 import { SidebarInset } from "../ui/sidebar";
 import { WorkspacePageHeader } from "../WorkspacePageHeader";
 import { BotActivityStatus } from "./BotActivityStatus";
+import { BotApprovalPrompt } from "./BotApprovalPrompt";
 import { BotAvatarView } from "./BotAvatarView";
 import { BotConversationScrollArea } from "./BotConversationScrollArea";
 import { visibleBotChatMessages } from "./botConversationPresentation";
@@ -11,6 +12,7 @@ import { BotPromptComposer } from "./BotPromptComposer";
 import { useGroupPresence } from "./botPresence";
 import { useRosterStore } from "./rosterStore";
 import { useGroupThreadRuntime } from "./useGroupThreadRuntime";
+import { useRosterPendingApproval } from "./useRosterPendingApproval";
 
 export function GroupThreadLanding({ groupId }: { readonly groupId: string }) {
   const navigate = useNavigate();
@@ -19,6 +21,7 @@ export function GroupThreadLanding({ groupId }: { readonly groupId: string }) {
   );
   const bots = useRosterStore((state) => state.bots);
   const runtime = useGroupThreadRuntime(groupId);
+  const approvalState = useRosterPendingApproval(runtime.linkedThreadRef);
   const presence = useGroupPresence(groupId);
 
   useEffect(() => {
@@ -32,6 +35,7 @@ export function GroupThreadLanding({ groupId }: { readonly groupId: string }) {
   const working = runtime.sending || presence === "working";
   const messages = visibleBotChatMessages(runtime.messages, working);
   const activeBot = members.find((bot) => bot.id === runtime.respondingBotId) ?? boss;
+  const pendingApproval = approvalState.pendingApproval;
 
   return (
     <SidebarInset
@@ -104,6 +108,15 @@ export function GroupThreadLanding({ groupId }: { readonly groupId: string }) {
               );
             })
           )}
+          {pendingApproval ? (
+            <BotApprovalPrompt
+              approval={pendingApproval}
+              pendingCount={approvalState.pendingCount}
+              responding={approvalState.responding}
+              error={approvalState.responseError}
+              onRespond={(decision) => approvalState.respond(pendingApproval.requestId, decision)}
+            />
+          ) : null}
           {working ? <BotActivityStatus avatar={activeBot.avatar} name={activeBot.name} /> : null}
           {runtime.error ? (
             <div
@@ -119,6 +132,7 @@ export function GroupThreadLanding({ groupId }: { readonly groupId: string }) {
           draftKey={`group:${group.id}`}
           disabled={
             runtime.sending ||
+            pendingApproval !== null ||
             !runtime.groupReady ||
             !runtime.bootstrapped ||
             runtime.defaultProject === null

--- a/apps/web/src/components/roster/useRosterPendingApproval.ts
+++ b/apps/web/src/components/roster/useRosterPendingApproval.ts
@@ -1,0 +1,56 @@
+import { squashAtomCommandFailure } from "@t3tools/client-runtime/state/runtime";
+import type {
+  ApprovalRequestId,
+  ProviderApprovalDecision,
+  ScopedThreadRef,
+} from "@t3tools/contracts";
+import { useCallback, useMemo, useRef, useState } from "react";
+
+import { derivePendingApprovals } from "../../session-logic";
+import { useThreadActivities } from "../../state/entities";
+import { threadEnvironment } from "../../state/threads";
+import { useAtomCommand } from "../../state/use-atom-command";
+
+export function useRosterPendingApproval(threadRef: ScopedThreadRef | null) {
+  const activities = useThreadActivities(threadRef);
+  const pendingApprovals = useMemo(() => derivePendingApprovals(activities), [activities]);
+  const respondToApproval = useAtomCommand(threadEnvironment.respondToApproval, {
+    reportFailure: false,
+  });
+  const respondingRef = useRef(false);
+  const [responding, setResponding] = useState(false);
+  const [responseError, setResponseError] = useState<string | null>(null);
+
+  const respond = useCallback(
+    async (requestId: ApprovalRequestId, decision: ProviderApprovalDecision): Promise<boolean> => {
+      if (!threadRef || respondingRef.current) return false;
+      respondingRef.current = true;
+      setResponding(true);
+      setResponseError(null);
+      try {
+        const result = await respondToApproval({
+          environmentId: threadRef.environmentId,
+          input: { threadId: threadRef.threadId, requestId, decision },
+        });
+        if (result._tag === "Failure") {
+          const cause = squashAtomCommandFailure(result);
+          setResponseError(cause instanceof Error ? cause.message : "Could not answer approval.");
+          return false;
+        }
+        return true;
+      } finally {
+        respondingRef.current = false;
+        setResponding(false);
+      }
+    },
+    [respondToApproval, threadRef],
+  );
+
+  return {
+    pendingApproval: pendingApprovals[0] ?? null,
+    pendingCount: pendingApprovals.length,
+    respond,
+    responding,
+    responseError,
+  };
+}

--- a/docs/internals/providers.md
+++ b/docs/internals/providers.md
@@ -44,6 +44,10 @@ resolves the selected Codex model through an explicit subscription `AuthStorage`
 maps Mastra message, tool, approval, usage, completion, and error events to
 `ProviderRuntimeEvent`.
 
+The controller routes every Mastra tool through its server-side approval policy. It auto-approves
+ordinary calls when the thread mode allows them, but send, pay, delete, and production actions always
+wait for a one-use approval. A session or permanent approval cannot bypass that check.
+
 Claude, Cursor, Grok, and OpenCode keep their existing adapters. [`LegacyProviderBridge`][bridge]
 routes those providers through `ProviderService` and forwards their canonical runtime events. Claude
 receives the same general-purpose Akeru instructions and enabled MCP servers. A provider change stops

--- a/docs/internals/providers.md
+++ b/docs/internals/providers.md
@@ -46,7 +46,9 @@ maps Mastra message, tool, approval, usage, completion, and error events to
 
 The controller routes every Mastra tool through its server-side approval policy. It auto-approves
 ordinary calls when the thread mode allows them, but send, pay, delete, and production actions always
-wait for a one-use approval. A session or permanent approval cannot bypass that check.
+wait for a one-use approval. MCP tools without a `readOnlyHint: true` annotation also wait because
+the hub cannot prove that an opaque external action is safe. A session or permanent approval cannot
+bypass that check.
 
 Claude, Cursor, Grok, and OpenCode keep their existing adapters. [`LegacyProviderBridge`][bridge]
 routes those providers through `ProviderService` and forwards their canonical runtime events. Claude

--- a/docs/user/bots.md
+++ b/docs/user/bots.md
@@ -14,3 +14,9 @@ Akeru Bot stores the profile in the connected environment. Other clients connect
 Use the panel button to collapse or reopen the editor. The default shortcut is **Mod+Alt+B**, and you can change `Right Panel: Toggle` in the keybinding settings. On a narrow screen, the same button opens a sheet.
 
 Bot replies support headings, links, tables, task lists, code blocks, math, and Mermaid diagrams.
+
+## Approve sensitive actions
+
+A bot waits for approval before it sends, pays, deletes, or changes production. This applies even when the bot has full access. Approve or decline the pending action from its conversation.
+
+The decision applies only to the pending action. It does not undo work that the bot completed earlier.

--- a/docs/user/bots.md
+++ b/docs/user/bots.md
@@ -17,6 +17,6 @@ Bot replies support headings, links, tables, task lists, code blocks, math, and 
 
 ## Approve sensitive actions
 
-A bot waits for approval before it sends, pays, deletes, or changes production. This applies even when the bot has full access. Approve or decline the pending action from its conversation.
+A bot waits for approval before it sends, pays, deletes, or changes production. This applies even when the bot has full access. Tools that do not identify themselves as read-only also wait. Approve or decline the pending action from its conversation.
 
 The decision applies only to the pending action. It does not undo work that the bot completed earlier.


### PR DESCRIPTION
Bot tools could execute sends, payments, deletions, and production changes without a one-use confirmation when the thread used a permissive runtime mode.

This change routes Mastra tool approval callbacks through the server approval hub. The hub keeps ordinary runtime-mode behavior, but it requires one-use approval for sensitive actions and MCP tools that do not identify themselves as read-only. Bot and group conversations now render the existing approval panel and actions. The card states that approval does not undo completed work.

Tests:
- `vp test run apps/server/src/provider/AkeruMastraHarness.test.ts apps/server/src/provider/Layers/AgentController.test.ts apps/web/src/components/roster/BotApprovalPrompt.test.tsx apps/web/src/components/roster/BotThreadLanding.markdown.test.ts`
- `vp run --filter t3 typecheck`
- `vp run --filter @t3tools/web typecheck`
- targeted `vp lint`
- `git diff --check`

Model: GPT-5.6 Sol
Harness: Pi
