### PR TITLE
feat(settings): let bots share or isolate sandbox resources

### DIFF
--- a/apps/server/package.json
+++ b/apps/server/package.json
@@ -31,7 +31,7 @@
     "@mastra/code-sdk": "1.5.1",
     "@mastra/core": "1.63.0",
     "@opencode-ai/sdk": "^1.3.15",
-    "@opencoredev/sandbox-sdk": "file:../../../sandbox-sdk/packages/sdk",
+    "@opencoredev/sandbox-sdk": "0.2.0",
     "@pierre/diffs": "catalog:",
     "@upstash/box": "0.5.3",
     "@vercel/sandbox": "^2.5.0",

--- a/apps/server/src/orchestration/Layers/ProviderCommandReactor.test.ts
+++ b/apps/server/src/orchestration/Layers/ProviderCommandReactor.test.ts
@@ -176,6 +176,9 @@ describe("ProviderCommandReactor", () => {
     readonly unavailableEngine?: boolean;
   }) {
     const now = "2026-01-01T00:00:00.000Z";
+    const serverSettings = await Effect.runPromise(
+      Effect.service(ServerSettingsService).pipe(Effect.provide(ServerSettingsService.layerTest())),
+    );
     const baseDir =
       input?.baseDir ?? NodeFS.mkdtempSync(NodePath.join(NodeOS.tmpdir(), "t3code-reactor-"));
     createdBaseDirs.add(baseDir);
@@ -470,7 +473,7 @@ describe("ProviderCommandReactor", () => {
           generateThreadTitle,
         }),
       ),
-      Layer.provideMerge(ServerSettingsService.layerTest()),
+      Layer.provideMerge(Layer.succeed(ServerSettingsService, serverSettings)),
       Layer.provideMerge(ServerConfig.layerTest(process.cwd(), baseDir)),
       Layer.provideMerge(NodeServices.layer),
     );
@@ -583,6 +586,7 @@ describe("ProviderCommandReactor", () => {
       generateBranchName,
       generateThreadTitle,
       runtimeSessions,
+      serverSettings,
       stateDir,
       drain,
       runEffect,
@@ -633,6 +637,7 @@ describe("ProviderCommandReactor", () => {
       },
       mcpServers: [],
       botSandbox: null,
+      botSandboxBrowserSharing: "shared",
       runtimeMode: "approval-required",
     });
 
@@ -641,6 +646,58 @@ describe("ProviderCommandReactor", () => {
     expect(thread?.session?.threadId).toBe("thread-1");
     expect(thread?.session?.status).toBe("starting");
     expect(thread?.session?.runtimeMode).toBe("approval-required");
+  });
+
+  it("restarts an active provider session when sandbox and browser sharing changes", async () => {
+    const harness = await createHarness();
+    const now = "2026-01-01T00:00:00.000Z";
+
+    await Effect.runPromise(
+      harness.engine.dispatch({
+        type: "thread.turn.start",
+        commandId: CommandId.make("cmd-turn-start-sharing-1"),
+        threadId: ThreadId.make("thread-1"),
+        message: {
+          messageId: asMessageId("user-message-sharing-1"),
+          role: "user",
+          text: "first",
+          attachments: [],
+        },
+        interactionMode: DEFAULT_PROVIDER_INTERACTION_MODE,
+        runtimeMode: "approval-required",
+        createdAt: now,
+      }),
+    );
+    await waitFor(() => harness.startSession.mock.calls.length === 1);
+    await waitFor(() => harness.sendTurn.mock.calls.length === 1);
+
+    await Effect.runPromise(
+      harness.serverSettings.updateSettings({ botSandboxBrowserSharing: "separate" }),
+    );
+    await Effect.runPromise(
+      harness.engine.dispatch({
+        type: "thread.turn.start",
+        commandId: CommandId.make("cmd-turn-start-sharing-2"),
+        threadId: ThreadId.make("thread-1"),
+        message: {
+          messageId: asMessageId("user-message-sharing-2"),
+          role: "user",
+          text: "second",
+          attachments: [],
+        },
+        interactionMode: DEFAULT_PROVIDER_INTERACTION_MODE,
+        runtimeMode: "approval-required",
+        createdAt: now,
+      }),
+    );
+
+    await waitFor(() => harness.startSession.mock.calls.length === 2);
+    await waitFor(() => harness.sendTurn.mock.calls.length === 2);
+    expect(harness.stopSession).toHaveBeenCalledOnce();
+    expect(harness.startSession.mock.calls[1]?.[1]).toMatchObject({
+      botSandboxBrowserSharing: "separate",
+    });
+    expect(harness.startSession.mock.calls[1]?.[1]).not.toHaveProperty("resumeCursor");
   });
 
   it("uses the configured bot engine instead of the thread default", async () => {
@@ -683,7 +740,9 @@ describe("ProviderCommandReactor", () => {
         instanceId: ProviderInstanceId.make("claudeAgent"),
         model: "claude-fable-5",
       },
+      botId: BotId.make("bot-1"),
       botSandbox: "local",
+      botSandboxBrowserSharing: "shared",
     });
   });
 

--- a/apps/server/src/orchestration/Layers/ProviderCommandReactor.ts
+++ b/apps/server/src/orchestration/Layers/ProviderCommandReactor.ts
@@ -37,6 +37,10 @@ import {
 import type { AgentControllerError } from "../../provider/Errors.ts";
 import { TextGeneration } from "../../textGeneration/TextGeneration.ts";
 import { AgentController } from "../../provider/Services/AgentController.ts";
+import {
+  botRuntimeResourceScope,
+  botWorkspaceResourceKey,
+} from "../../provider/botWorkspacePool.ts";
 import { ProviderRegistry } from "../../provider/Services/ProviderRegistry.ts";
 import { ProjectionBotRepository } from "../../persistence/Services/ProjectionBots.ts";
 import { ProjectionMcpServerRepository } from "../../persistence/Services/ProjectionMcpServers.ts";
@@ -343,6 +347,7 @@ const make = Effect.gen(function* () {
     );
 
   const threadModelSelections = new Map<string, ModelSelection>();
+  const threadBotWorkspaceKeys = new Map<string, string>();
 
   const appendProviderFailureActivity = (input: {
     readonly threadId: ThreadId;
@@ -672,6 +677,8 @@ const make = Effect.gen(function* () {
     const providerChanged = currentInfo.driverKind !== desiredInfo.driverKind;
     const project = yield* resolveProject(thread.projectId);
     const mcpServers = yield* resolveControllerMcpServers(thread);
+    const botSandboxBrowserSharing = (yield* serverSettingsService.getSettings)
+      .botSandboxBrowserSharing;
     const respondingBotId = resolveControllerBotId(thread);
     const respondingBot =
       respondingBotId === null
@@ -682,6 +689,14 @@ const make = Effect.gen(function* () {
     const effectiveCwd = resolveThreadWorkspaceCwd({
       thread,
       projects: project ? [project] : [],
+    });
+    const botWorkspaceKey = botWorkspaceResourceKey({
+      resourceScope: botRuntimeResourceScope({
+        sharing: botSandboxBrowserSharing,
+        ...(respondingBotId ? { botId: respondingBotId } : {}),
+        threadId,
+      }),
+      sandbox: respondingBot?.sandbox ?? null,
     });
 
     const startProviderSession = (input?: {
@@ -696,7 +711,9 @@ const make = Effect.gen(function* () {
         ...(thread.title ? { title: thread.title } : {}),
         modelSelection: desiredModelSelection,
         mcpServers,
+        ...(respondingBotId ? { botId: respondingBotId } : {}),
         botSandbox: respondingBot?.sandbox ?? null,
+        botSandboxBrowserSharing,
         ...(input?.resumeCursor !== undefined ? { resumeCursor: input.resumeCursor } : {}),
         runtimeMode: desiredRuntimeMode,
       });
@@ -752,6 +769,9 @@ const make = Effect.gen(function* () {
         activeSession?.mcpServerIds ?? [],
         mcpServers.map((server) => server.id),
       );
+      const previousBotWorkspaceKey = threadBotWorkspaceKeys.get(threadId);
+      const botWorkspaceChanged =
+        previousBotWorkspaceKey !== undefined && previousBotWorkspaceKey !== botWorkspaceKey;
 
       if (
         !runtimeModeChanged &&
@@ -759,13 +779,15 @@ const make = Effect.gen(function* () {
         !instanceChanged &&
         !shouldRestartForModelChange &&
         !shouldRestartForModelSelectionChange &&
-        !mcpServersChanged
+        !mcpServersChanged &&
+        !botWorkspaceChanged
       ) {
+        threadBotWorkspaceKeys.set(threadId, botWorkspaceKey);
         return { threadId: existingSessionThreadId, engine: desiredEngine };
       }
 
       const resumeCursor =
-        shouldRestartForModelChange || providerChanged
+        shouldRestartForModelChange || providerChanged || botWorkspaceChanged
           ? undefined
           : (activeSession?.resumeCursor ?? undefined);
       yield* Effect.logInfo("provider command reactor restarting provider session", {
@@ -787,9 +809,10 @@ const make = Effect.gen(function* () {
         shouldRestartForModelChange,
         shouldRestartForModelSelectionChange,
         mcpServersChanged,
+        botWorkspaceChanged,
         hasResumeCursor: resumeCursor !== undefined,
       });
-      if (mcpServersChanged || providerChanged) {
+      if (mcpServersChanged || providerChanged || botWorkspaceChanged) {
         yield* agentController.stopSession({ threadId });
       }
       const restartedSession = yield* startProviderSession(
@@ -804,11 +827,13 @@ const make = Effect.gen(function* () {
         cwd: restartedSession.cwd,
       });
       yield* bindSessionToThread(restartedSession);
+      threadBotWorkspaceKeys.set(threadId, botWorkspaceKey);
       return { threadId: restartedSession.threadId, engine: desiredEngine };
     }
 
     const startedSession = yield* startProviderSession(undefined);
     yield* bindSessionToThread(startedSession);
+    threadBotWorkspaceKeys.set(threadId, botWorkspaceKey);
     return { threadId: startedSession.threadId, engine: desiredEngine };
   });
 

--- a/apps/server/src/provider/Layers/AgentController.test.ts
+++ b/apps/server/src/provider/Layers/AgentController.test.ts
@@ -8,6 +8,7 @@ import type { AgentControllerEvent, MastraDBMessage, Session } from "@mastra/cor
 import { LocalFilesystem, LocalSandbox, Workspace } from "@mastra/core/workspace";
 import {
   ApprovalRequestId,
+  BotId,
   McpServerId,
   ProviderDriverKind,
   ProviderInstanceId,
@@ -155,7 +156,7 @@ function makeMastraHarness() {
     respondToToolApproval: vi.fn(),
     respondToToolSuspension: vi.fn(async () => undefined),
   } as unknown as Session<Record<string, unknown>>;
-  const createSession = vi.fn(async () => session as never);
+  const createSession = vi.fn(async (_input: unknown) => session as never);
   const deleteSession = vi.fn(async () => true);
   const destroy = vi.fn(async () => undefined);
   const factory: NonNullable<AgentControllerLiveOptions["makeMastraHarness"]> = async (options) => {
@@ -618,16 +619,201 @@ describe("AgentControllerLive", () => {
         cwd: process.cwd(),
         modelSelection: codexSelection,
         runtimeMode: "full-access",
+        botId: BotId.make("bot-upstash"),
         botSandbox: "upstash",
+        botSandboxBrowserSharing: "separate",
       });
 
       expect(makeRemoteWorkspace).toHaveBeenCalledOnce();
       expect(makeRemoteWorkspace).toHaveBeenCalledWith({
-        threadId: String(codexThreadId),
+        threadId: "bot-bot-upstash",
         sandbox: "upstash",
       });
       expect(mastra.createSession.mock.calls[0]?.[0]).toMatchObject({ workspace: remote });
       yield* controller.stopSession({ threadId: codexThreadId });
+    }).pipe(Effect.provide(layer), Effect.orDie);
+  });
+
+  it.effect("keeps one remote workspace for shared bot sessions", () => {
+    const bridge = makeBridge();
+    const mastra = makeMastraHarness();
+    const remote = new Workspace({
+      filesystem: new LocalFilesystem({ basePath: process.cwd() }),
+      sandbox: new LocalSandbox({ workingDirectory: process.cwd() }),
+    });
+    const destroy = vi.spyOn(remote, "destroy");
+    const makeRemoteWorkspace = vi.fn(async () => remote);
+    const layer = makeAgentControllerLive({
+      makeMastraHarness: mastra.factory,
+      makeRemoteWorkspace,
+    }).pipe(
+      Layer.provide(
+        Layer.merge(
+          Layer.succeed(LegacyProviderBridge, bridge.service),
+          ServerConfig.layerTest(process.cwd(), {
+            prefix: "akeru-mastra-shared-sandbox-test-",
+          }).pipe(Layer.provide(NodeServices.layer)),
+        ),
+      ),
+    );
+    const firstThreadId = ThreadId.make("thread-shared-first");
+    const secondThreadId = ThreadId.make("thread-shared-second");
+
+    return Effect.gen(function* () {
+      const controller = yield* AgentController;
+      for (const threadId of [firstThreadId, secondThreadId]) {
+        yield* controller.resolveEngine({
+          threadId,
+          engine: { provider: "codex", model: "gpt-5.6-sol" },
+          fallback: codexSelection,
+          mode: "default",
+        });
+      }
+      yield* controller.startSession(firstThreadId, {
+        threadId: firstThreadId,
+        provider: ProviderDriverKind.make("codex"),
+        providerInstanceId: codexInstanceId,
+        modelSelection: codexSelection,
+        runtimeMode: "full-access",
+        botId: BotId.make("bot-first"),
+        botSandbox: "vercel",
+        botSandboxBrowserSharing: "shared",
+      });
+      yield* controller.startSession(secondThreadId, {
+        threadId: secondThreadId,
+        provider: ProviderDriverKind.make("codex"),
+        providerInstanceId: codexInstanceId,
+        modelSelection: codexSelection,
+        runtimeMode: "full-access",
+        botId: BotId.make("bot-second"),
+        botSandbox: "vercel",
+        botSandboxBrowserSharing: "shared",
+      });
+
+      expect(makeRemoteWorkspace).toHaveBeenCalledOnce();
+      expect(mastra.createSession.mock.calls[0]?.[0]).toMatchObject({ workspace: remote });
+      expect(mastra.createSession.mock.calls[1]?.[0]).toMatchObject({ workspace: remote });
+
+      yield* controller.stopSession({ threadId: firstThreadId });
+      expect(destroy).not.toHaveBeenCalled();
+      yield* controller.stopSession({ threadId: secondThreadId });
+      expect(destroy).toHaveBeenCalledOnce();
+    }).pipe(Effect.provide(layer), Effect.orDie);
+  });
+
+  it.effect("shares one local workspace for bots in the same working directory", () => {
+    const bridge = makeBridge();
+    const mastra = makeMastraHarness();
+    const firstThreadId = ThreadId.make("thread-local-shared-first");
+    const secondThreadId = ThreadId.make("thread-local-shared-second");
+
+    return provideController(
+      Effect.gen(function* () {
+        const controller = yield* AgentController;
+        for (const threadId of [firstThreadId, secondThreadId]) {
+          yield* controller.resolveEngine({
+            threadId,
+            engine: { provider: "codex", model: "gpt-5.6-sol" },
+            fallback: codexSelection,
+            mode: "default",
+          });
+          yield* controller.startSession(threadId, {
+            threadId,
+            provider: ProviderDriverKind.make("codex"),
+            providerInstanceId: codexInstanceId,
+            cwd: process.cwd(),
+            modelSelection: codexSelection,
+            runtimeMode: "full-access",
+            botId: BotId.make(`bot-${threadId}`),
+            botSandbox: "local",
+            botSandboxBrowserSharing: "shared",
+          });
+        }
+
+        const harness = mastra.harnessOptions[0];
+        assert.isDefined(harness);
+        expect(harness.getThreadWorkspace(String(firstThreadId))).toBe(
+          harness.getThreadWorkspace(String(secondThreadId)),
+        );
+
+        yield* controller.stopSession({ threadId: firstThreadId });
+        yield* controller.stopSession({ threadId: secondThreadId });
+      }),
+      bridge.service,
+      mastra.factory,
+    );
+  });
+
+  it.effect("creates one remote workspace for each bot in separate mode", () => {
+    const bridge = makeBridge();
+    const mastra = makeMastraHarness();
+    const remoteWorkspaces: Workspace[] = [];
+    const makeRemoteWorkspace = vi.fn(async () => {
+      const workspace = new Workspace({
+        filesystem: new LocalFilesystem({ basePath: process.cwd() }),
+        sandbox: new LocalSandbox({ workingDirectory: process.cwd() }),
+      });
+      remoteWorkspaces.push(workspace);
+      return workspace;
+    });
+    const layer = makeAgentControllerLive({
+      makeMastraHarness: mastra.factory,
+      makeRemoteWorkspace,
+    }).pipe(
+      Layer.provide(
+        Layer.merge(
+          Layer.succeed(LegacyProviderBridge, bridge.service),
+          ServerConfig.layerTest(process.cwd(), {
+            prefix: "akeru-mastra-separate-sandbox-test-",
+          }).pipe(Layer.provide(NodeServices.layer)),
+        ),
+      ),
+    );
+    const firstThreadId = ThreadId.make("thread-separate-first");
+    const secondThreadId = ThreadId.make("thread-separate-second");
+
+    return Effect.gen(function* () {
+      const controller = yield* AgentController;
+      for (const threadId of [firstThreadId, secondThreadId]) {
+        yield* controller.resolveEngine({
+          threadId,
+          engine: { provider: "codex", model: "gpt-5.6-sol" },
+          fallback: codexSelection,
+          mode: "default",
+        });
+      }
+      yield* controller.startSession(firstThreadId, {
+        threadId: firstThreadId,
+        provider: ProviderDriverKind.make("codex"),
+        providerInstanceId: codexInstanceId,
+        modelSelection: codexSelection,
+        runtimeMode: "full-access",
+        botId: BotId.make("bot-first"),
+        botSandbox: "vercel",
+        botSandboxBrowserSharing: "separate",
+      });
+      yield* controller.startSession(secondThreadId, {
+        threadId: secondThreadId,
+        provider: ProviderDriverKind.make("codex"),
+        providerInstanceId: codexInstanceId,
+        modelSelection: codexSelection,
+        runtimeMode: "full-access",
+        botId: BotId.make("bot-second"),
+        botSandbox: "vercel",
+        botSandboxBrowserSharing: "separate",
+      });
+
+      expect(makeRemoteWorkspace).toHaveBeenCalledTimes(2);
+      expect(remoteWorkspaces[0]).not.toBe(remoteWorkspaces[1]);
+      expect(mastra.createSession.mock.calls[0]?.[0]).toMatchObject({
+        workspace: remoteWorkspaces[0],
+      });
+      expect(mastra.createSession.mock.calls[1]?.[0]).toMatchObject({
+        workspace: remoteWorkspaces[1],
+      });
+
+      yield* controller.stopSession({ threadId: firstThreadId });
+      yield* controller.stopSession({ threadId: secondThreadId });
     }).pipe(Effect.provide(layer), Effect.orDie);
   });
 

--- a/apps/server/src/provider/Layers/AgentController.test.ts
+++ b/apps/server/src/provider/Layers/AgentController.test.ts
@@ -129,8 +129,9 @@ function makeMastraHarness() {
         resolveSend = resolve;
       }),
   );
+  const stateSet = vi.fn(async () => undefined);
   const session = {
-    state: { set: vi.fn(async () => undefined) },
+    state: { set: stateSet },
     mode: {
       get: () => modeId,
       switch: vi.fn(async ({ modeId: next }: { readonly modeId: string }) => {
@@ -178,6 +179,7 @@ function makeMastraHarness() {
     factory,
     harnessOptions,
     session,
+    stateSet,
     createSession,
     deleteSession,
     sendMessage,
@@ -631,6 +633,64 @@ describe("AgentControllerLive", () => {
       });
       expect(mastra.createSession.mock.calls[0]?.[0]).toMatchObject({ workspace: remote });
       yield* controller.stopSession({ threadId: codexThreadId });
+    }).pipe(Effect.provide(layer), Effect.orDie);
+  });
+
+  it.effect("releases a remote workspace when session initialization fails", () => {
+    const bridge = makeBridge();
+    const mastra = makeMastraHarness();
+    const firstRemote = new Workspace({
+      filesystem: new LocalFilesystem({ basePath: process.cwd() }),
+      sandbox: new LocalSandbox({ workingDirectory: process.cwd() }),
+    });
+    const secondRemote = new Workspace({
+      filesystem: new LocalFilesystem({ basePath: process.cwd() }),
+      sandbox: new LocalSandbox({ workingDirectory: process.cwd() }),
+    });
+    const firstDestroy = vi.spyOn(firstRemote, "destroy");
+    const secondDestroy = vi.spyOn(secondRemote, "destroy");
+    const makeRemoteWorkspace = vi
+      .fn()
+      .mockResolvedValueOnce(firstRemote)
+      .mockResolvedValueOnce(secondRemote);
+    const layer = makeAgentControllerLive({
+      makeMastraHarness: mastra.factory,
+      makeRemoteWorkspace,
+    }).pipe(
+      Layer.provide(
+        Layer.merge(
+          Layer.succeed(LegacyProviderBridge, bridge.service),
+          ServerConfig.layerTest(process.cwd(), {
+            prefix: "akeru-mastra-failed-session-test-",
+          }).pipe(Layer.provide(NodeServices.layer)),
+        ),
+      ),
+    );
+
+    return Effect.gen(function* () {
+      const controller = yield* AgentController;
+      yield* resolveCodex(controller);
+      mastra.stateSet.mockRejectedValueOnce(new Error("state unavailable"));
+      const input = {
+        threadId: codexThreadId,
+        provider: ProviderDriverKind.make("codex"),
+        providerInstanceId: codexInstanceId,
+        modelSelection: codexSelection,
+        runtimeMode: "full-access" as const,
+        botId: BotId.make("bot-retry"),
+        botSandbox: "vercel" as const,
+        botSandboxBrowserSharing: "separate" as const,
+      };
+
+      yield* controller.startSession(codexThreadId, input).pipe(Effect.flip);
+      expect(firstDestroy).toHaveBeenCalledOnce();
+
+      yield* controller.startSession(codexThreadId, input);
+      expect(makeRemoteWorkspace).toHaveBeenCalledTimes(2);
+      expect(secondDestroy).not.toHaveBeenCalled();
+
+      yield* controller.stopSession({ threadId: codexThreadId });
+      expect(secondDestroy).toHaveBeenCalledOnce();
     }).pipe(Effect.provide(layer), Effect.orDie);
   });
 

--- a/apps/server/src/provider/Layers/AgentController.ts
+++ b/apps/server/src/provider/Layers/AgentController.ts
@@ -16,6 +16,7 @@ import type {
 } from "@mastra/core/agent-controller";
 import { Workspace } from "@mastra/core/workspace";
 import {
+  DEFAULT_BOT_SANDBOX_BROWSER_SHARING,
   EventId,
   ProviderDriverKind,
   ProviderInstanceId,
@@ -44,7 +45,17 @@ import {
   type AkeruMastraHarnessOptions,
   type AkeruMastraSession,
 } from "../AkeruMastraHarness.ts";
-import { createBotWorkspace, type CreateRemoteBotWorkspaceInput } from "../botWorkspace.ts";
+import {
+  createBotWorkspace,
+  isRemoteBotSandbox,
+  type CreateRemoteBotWorkspaceInput,
+} from "../botWorkspace.ts";
+import {
+  botRuntimeResourceScope,
+  BotWorkspacePool,
+  botWorkspaceResourceKey,
+  type BotWorkspaceLease,
+} from "../botWorkspacePool.ts";
 import { AgentControllerRuntimeError, AgentControllerUnsupportedEngineError } from "../Errors.ts";
 import { AgentController, type AgentControllerShape } from "../Services/AgentController.ts";
 import { LegacyProviderBridge } from "../Services/LegacyProviderBridge.ts";
@@ -83,6 +94,7 @@ interface ActiveSession {
   status: ProviderSession["status"];
   activeTurn: ActiveTurn | null;
   readonly toolNames: Map<string, string>;
+  readonly workspaceResourceKey: string;
   readonly unsubscribe: () => void;
 }
 
@@ -196,6 +208,8 @@ const make = (options?: AgentControllerLiveOptions) =>
     const authStorage = createAkeruMastraAuthStorage(config.secretsDir);
     const mcpManagers = new Map<string, McpManager>();
     const workspaces = new Map<string, Workspace>();
+    const workspaceLeases = new Map<string, BotWorkspaceLease>();
+    const workspacePool = new BotWorkspacePool();
     const makeMastraHarness = options?.makeMastraHarness ?? createAkeruMastraHarness;
     const bundle = yield* runMastra("construct", () =>
       makeMastraHarness({
@@ -216,12 +230,11 @@ const make = (options?: AgentControllerLiveOptions) =>
     };
 
     const disconnectWorkspace = (key: string) => {
-      const workspace = workspaces.get(key);
-      if (!workspace) return Effect.void;
+      const lease = workspaceLeases.get(key);
+      if (!lease) return Effect.void;
       workspaces.delete(key);
-      return runMastra("workspace.destroy", () => workspace.destroy()).pipe(
-        Effect.ignoreCause({ log: true }),
-      );
+      workspaceLeases.delete(key);
+      return runMastra("workspace.release", lease.release).pipe(Effect.ignoreCause({ log: true }));
     };
 
     const publish = (event: ProviderRuntimeEvent) => {
@@ -541,8 +554,21 @@ const make = (options?: AgentControllerLiveOptions) =>
       "AgentController.startSession",
     )(function* (threadId, input) {
       const key = String(threadId);
+      const resourceScope = botRuntimeResourceScope({
+        sharing: input.botSandboxBrowserSharing ?? DEFAULT_BOT_SANDBOX_BROWSER_SHARING,
+        ...(input.botId ? { botId: input.botId } : {}),
+        threadId: key,
+      });
+      const workspaceResourceKey = botWorkspaceResourceKey({
+        resourceScope,
+        ...(input.cwd ? { cwd: input.cwd } : {}),
+        ...(input.botSandbox !== undefined ? { sandbox: input.botSandbox } : {}),
+      });
       const existing = sessions.get(key);
-      if (existing) return toProviderSession(threadId, existing);
+      if (existing?.workspaceResourceKey === workspaceResourceKey) {
+        return toProviderSession(threadId, existing);
+      }
+      if (existing) yield* stopSession({ threadId });
       const resolved = resolvedByThread.get(key);
       if (!resolved) {
         return yield* new AgentControllerRuntimeError({
@@ -563,17 +589,30 @@ const make = (options?: AgentControllerLiveOptions) =>
         yield* runMastra("mcp.init", () => manager.init());
         mcpManagers.set(key, manager);
       }
-      const workspace = yield* runMastra("workspace.create", () =>
-        createBotWorkspace({
-          threadId: key,
-          cwd: input.cwd,
-          sandbox: input.botSandbox,
-          ...(options?.makeRemoteWorkspace
-            ? { makeRemoteWorkspace: options.makeRemoteWorkspace }
-            : {}),
-        }),
-      );
-      if (workspace) workspaces.set(key, workspace);
+      const workspaceLease = yield* runMastra("workspace.acquire", async () => {
+        const create = async () => {
+          const workspace = await createBotWorkspace({
+            threadId: resourceScope,
+            ...(input.cwd ? { cwd: input.cwd } : {}),
+            ...(input.botSandbox !== undefined ? { sandbox: input.botSandbox } : {}),
+            ...(options?.makeRemoteWorkspace
+              ? { makeRemoteWorkspace: options.makeRemoteWorkspace }
+              : {}),
+          });
+          if (!workspace) throw new Error(`Workspace is unavailable for thread '${key}'.`);
+          return workspace;
+        };
+
+        if (isRemoteBotSandbox(input.botSandbox) || input.cwd) {
+          return workspacePool.acquire(workspaceResourceKey, create);
+        }
+        return undefined;
+      });
+      const workspace = workspaceLease?.workspace;
+      if (workspaceLease) {
+        workspaces.set(key, workspaceLease.workspace);
+        workspaceLeases.set(key, workspaceLease);
+      }
       const session = yield* runMastra("createSession", () =>
         bundle.controller.createSession({
           id: key,
@@ -625,6 +664,7 @@ const make = (options?: AgentControllerLiveOptions) =>
         status: "ready" as const,
         activeTurn: null,
         toolNames: new Map<string, string>(),
+        workspaceResourceKey,
       };
       const unsubscribe = session.subscribe((event) => {
         const active = sessions.get(key);
@@ -863,6 +903,9 @@ const make = (options?: AgentControllerLiveOptions) =>
           yield* disconnectWorkspace(threadId);
         }
         sessions.clear();
+        yield* runMastra("workspace-pool.destroy", () => workspacePool.destroyAll()).pipe(
+          Effect.ignoreCause({ log: true }),
+        );
         bundle.destroy();
         yield* runMastra("destroy", () => bundle.controller.destroy()).pipe(
           Effect.ignoreCause({ log: true }),

--- a/apps/server/src/provider/Layers/AgentController.ts
+++ b/apps/server/src/provider/Layers/AgentController.ts
@@ -589,67 +589,70 @@ const make = (options?: AgentControllerLiveOptions) =>
         yield* runMastra("mcp.init", () => manager.init());
         mcpManagers.set(key, manager);
       }
-      const workspaceLease = yield* runMastra("workspace.acquire", async () => {
-        const create = async () => {
-          const workspace = await createBotWorkspace({
-            threadId: resourceScope,
-            ...(input.cwd ? { cwd: input.cwd } : {}),
-            ...(input.botSandbox !== undefined ? { sandbox: input.botSandbox } : {}),
-            ...(options?.makeRemoteWorkspace
-              ? { makeRemoteWorkspace: options.makeRemoteWorkspace }
-              : {}),
-          });
-          if (!workspace) throw new Error(`Workspace is unavailable for thread '${key}'.`);
-          return workspace;
-        };
+      const session = yield* Effect.gen(function* () {
+        const workspaceLease = yield* runMastra("workspace.acquire", async () => {
+          const create = async () => {
+            const workspace = await createBotWorkspace({
+              threadId: resourceScope,
+              ...(input.cwd ? { cwd: input.cwd } : {}),
+              ...(input.botSandbox !== undefined ? { sandbox: input.botSandbox } : {}),
+              ...(options?.makeRemoteWorkspace
+                ? { makeRemoteWorkspace: options.makeRemoteWorkspace }
+                : {}),
+            });
+            if (!workspace) throw new Error(`Workspace is unavailable for thread '${key}'.`);
+            return workspace;
+          };
 
-        if (isRemoteBotSandbox(input.botSandbox) || input.cwd) {
-          return workspacePool.acquire(workspaceResourceKey, create);
+          if (isRemoteBotSandbox(input.botSandbox) || input.cwd) {
+            return workspacePool.acquire(workspaceResourceKey, create);
+          }
+          return undefined;
+        });
+        const workspace = workspaceLease?.workspace;
+        if (workspaceLease) {
+          workspaces.set(key, workspaceLease.workspace);
+          workspaceLeases.set(key, workspaceLease);
         }
-        return undefined;
-      });
-      const workspace = workspaceLease?.workspace;
-      if (workspaceLease) {
-        workspaces.set(key, workspaceLease.workspace);
-        workspaceLeases.set(key, workspaceLease);
-      }
-      const session = yield* runMastra("createSession", () =>
-        bundle.controller.createSession({
-          id: key,
-          ownerId: "akeru-desktop",
-          resourceId: key,
-          threadId: key,
-          ...(input.cwd ? { tags: { projectPath: input.cwd } } : {}),
-          ...(workspace ? { workspace } : {}),
-        }),
-      ).pipe(
+        const session = yield* runMastra("createSession", () =>
+          bundle.controller.createSession({
+            id: key,
+            ownerId: "akeru-desktop",
+            resourceId: key,
+            threadId: key,
+            ...(input.cwd ? { tags: { projectPath: input.cwd } } : {}),
+            ...(workspace ? { workspace } : {}),
+          }),
+        );
+        yield* runMastra("state.set", () =>
+          session.state.set({
+            ...(input.cwd ? { projectPath: input.cwd } : {}),
+            yolo: input.runtimeMode === "full-access" || input.runtimeMode === "auto",
+          }),
+        );
+        yield* runMastra("model.switch", () =>
+          session.model.switch({ modelId: resolved.mastraModelId }),
+        );
+        const modeId = mastraModeId(resolved.mode);
+        if (session.mode.get() !== modeId) {
+          yield* runMastra("mode.switch", () => session.mode.switch({ modeId }));
+        }
+        yield* Effect.forEach(
+          ["read", "edit", "execute", "mcp", "other"] as const,
+          (category) =>
+            runMastra("permissions.setForCategory", () =>
+              session.permissions.setForCategory({
+                category,
+                policy: permissionPolicy(input.runtimeMode, category),
+              }),
+            ),
+          { discard: true },
+        );
+        return session;
+      }).pipe(
         Effect.tapError(() =>
           Effect.all([disconnectMcpManager(key), disconnectWorkspace(key)], { discard: true }),
         ),
-      );
-      yield* runMastra("state.set", () =>
-        session.state.set({
-          ...(input.cwd ? { projectPath: input.cwd } : {}),
-          yolo: input.runtimeMode === "full-access" || input.runtimeMode === "auto",
-        }),
-      );
-      yield* runMastra("model.switch", () =>
-        session.model.switch({ modelId: resolved.mastraModelId }),
-      );
-      const modeId = mastraModeId(resolved.mode);
-      if (session.mode.get() !== modeId) {
-        yield* runMastra("mode.switch", () => session.mode.switch({ modeId }));
-      }
-      yield* Effect.forEach(
-        ["read", "edit", "execute", "mcp", "other"] as const,
-        (category) =>
-          runMastra("permissions.setForCategory", () =>
-            session.permissions.setForCategory({
-              category,
-              policy: permissionPolicy(input.runtimeMode, category),
-            }),
-          ),
-        { discard: true },
       );
       const createdAt = nowIso();
       const activeWithoutUnsubscribe = {

--- a/apps/server/src/provider/botWorkspacePool.test.ts
+++ b/apps/server/src/provider/botWorkspacePool.test.ts
@@ -1,0 +1,105 @@
+import { LocalFilesystem, LocalSandbox, Workspace } from "@mastra/core/workspace";
+import { BotId } from "@t3tools/contracts";
+import { describe, expect, it, vi } from "vite-plus/test";
+
+import {
+  botRuntimeResourceScope,
+  BotWorkspacePool,
+  botWorkspaceResourceKey,
+} from "./botWorkspacePool.ts";
+
+function localWorkspace() {
+  return new Workspace({
+    filesystem: new LocalFilesystem({ basePath: process.cwd() }),
+    sandbox: new LocalSandbox({ workingDirectory: process.cwd() }),
+  });
+}
+
+describe("bot runtime resource scope", () => {
+  it("defaults every bot to one shared scope", () => {
+    expect(
+      botRuntimeResourceScope({
+        sharing: "shared",
+        botId: BotId.make("bot-one"),
+        threadId: "thread-one",
+      }),
+    ).toBe("shared");
+    expect(
+      botRuntimeResourceScope({
+        sharing: "shared",
+        botId: BotId.make("bot-two"),
+        threadId: "thread-two",
+      }),
+    ).toBe("shared");
+  });
+
+  it("uses one scope per bot in separate mode and falls back to the thread", () => {
+    expect(
+      botRuntimeResourceScope({
+        sharing: "separate",
+        botId: BotId.make("bot-one"),
+        threadId: "thread-one",
+      }),
+    ).toBe("bot-bot-one");
+    expect(botRuntimeResourceScope({ sharing: "separate", threadId: "thread-without-bot" })).toBe(
+      "thread-thread-without-bot",
+    );
+  });
+
+  it("isolates providers and local working directories", () => {
+    expect(botWorkspaceResourceKey({ resourceScope: "shared", sandbox: "vercel" })).not.toBe(
+      botWorkspaceResourceKey({ resourceScope: "shared", sandbox: "upstash" }),
+    );
+    expect(
+      botWorkspaceResourceKey({ resourceScope: "shared", sandbox: "local", cwd: "/first" }),
+    ).not.toBe(
+      botWorkspaceResourceKey({ resourceScope: "shared", sandbox: "local", cwd: "/second" }),
+    );
+  });
+});
+
+describe("BotWorkspacePool", () => {
+  it("reuses a resource until its final release", async () => {
+    const pool = new BotWorkspacePool();
+    const workspace = localWorkspace();
+    const destroy = vi.spyOn(workspace, "destroy");
+    const create = vi.fn(async () => workspace);
+
+    const first = await pool.acquire("vercel:shared", create);
+    const second = await pool.acquire("vercel:shared", create);
+
+    expect(first.workspace).toBe(second.workspace);
+    expect(create).toHaveBeenCalledOnce();
+    await first.release();
+    expect(destroy).not.toHaveBeenCalled();
+    await second.release();
+    expect(destroy).toHaveBeenCalledOnce();
+    await second.release();
+    expect(destroy).toHaveBeenCalledOnce();
+  });
+
+  it("keeps separate bot resources isolated", async () => {
+    const pool = new BotWorkspacePool();
+    const first = await pool.acquire("vercel:bot-one", async () => localWorkspace());
+    const second = await pool.acquire("vercel:bot-two", async () => localWorkspace());
+
+    expect(first.workspace).not.toBe(second.workspace);
+    await first.release();
+    await second.release();
+    await pool.destroyAll();
+  });
+
+  it("allows a failed resource creation to retry", async () => {
+    const pool = new BotWorkspacePool();
+    const create = vi
+      .fn<() => Promise<Workspace>>()
+      .mockRejectedValueOnce(new Error("sandbox unavailable"))
+      .mockResolvedValueOnce(localWorkspace());
+
+    await expect(pool.acquire("vercel:shared", create)).rejects.toThrow("sandbox unavailable");
+    const lease = await pool.acquire("vercel:shared", create);
+    expect(create).toHaveBeenCalledTimes(2);
+    await lease.release();
+    await pool.destroyAll();
+  });
+});

--- a/apps/server/src/provider/botWorkspacePool.ts
+++ b/apps/server/src/provider/botWorkspacePool.ts
@@ -1,0 +1,93 @@
+import type { Workspace } from "@mastra/core/workspace";
+import type { BotId, BotSandbox, BotSandboxBrowserSharing } from "@t3tools/contracts";
+
+export function botRuntimeResourceScope(input: {
+  readonly sharing: BotSandboxBrowserSharing;
+  readonly botId?: BotId;
+  readonly threadId: string;
+}): string {
+  if (input.sharing === "shared") return "shared";
+  return input.botId ? `bot-${input.botId}` : `thread-${input.threadId}`;
+}
+
+export function botWorkspaceResourceKey(input: {
+  readonly resourceScope: string;
+  readonly cwd?: string;
+  readonly sandbox?: BotSandbox | null;
+}): string {
+  const sandbox = input.sandbox ?? "local";
+  return sandbox === "local"
+    ? `${sandbox}:${input.cwd ?? "no-workspace"}:${input.resourceScope}`
+    : `${sandbox}:${input.resourceScope}`;
+}
+
+export interface BotWorkspaceLease {
+  readonly workspace: Workspace;
+  readonly release: () => Promise<void>;
+}
+
+interface BotWorkspacePoolEntry {
+  readonly workspace: Promise<Workspace>;
+  references: number;
+  closing?: Promise<void>;
+}
+
+/** Keeps one workspace alive while matching thread sessions use it. */
+export class BotWorkspacePool {
+  private readonly entries = new Map<string, BotWorkspacePoolEntry>();
+
+  async acquire(key: string, create: () => Promise<Workspace>): Promise<BotWorkspaceLease> {
+    const current = this.entries.get(key);
+    if (current?.closing) {
+      await current.closing;
+      return this.acquire(key, create);
+    }
+
+    const entry = current ?? { workspace: create(), references: 0 };
+    if (!current) this.entries.set(key, entry);
+    entry.references += 1;
+
+    let workspace: Workspace;
+    try {
+      workspace = await entry.workspace;
+    } catch (error) {
+      entry.references -= 1;
+      if (entry.references === 0 && this.entries.get(key) === entry) {
+        this.entries.delete(key);
+      }
+      throw error;
+    }
+
+    let released = false;
+    return {
+      workspace,
+      release: async () => {
+        if (released) return;
+        released = true;
+        entry.references -= 1;
+        if (entry.references > 0 || this.entries.get(key) !== entry) return;
+
+        entry.closing = workspace.destroy().finally(() => {
+          if (this.entries.get(key) === entry) this.entries.delete(key);
+        });
+        await entry.closing;
+      },
+    };
+  }
+
+  async destroyAll(): Promise<void> {
+    const entries = [...this.entries.entries()];
+    await Promise.all(
+      entries.map(async ([key, entry]) => {
+        if (!entry.closing) {
+          entry.closing = entry.workspace
+            .then((workspace) => workspace.destroy())
+            .finally(() => {
+              if (this.entries.get(key) === entry) this.entries.delete(key);
+            });
+        }
+        await entry.closing;
+      }),
+    );
+  }
+}

--- a/apps/server/src/serverSettings.test.ts
+++ b/apps/server/src/serverSettings.test.ts
@@ -923,6 +923,23 @@ it.layer(NodeServices.layer)("server settings", (it) => {
     }).pipe(Effect.provide(makeServerSettingsLayer())),
   );
 
+  it.effect("persists separate bot sandbox and browser sharing", () =>
+    Effect.gen(function* () {
+      const serverSettings = yield* ServerSettingsModule.ServerSettingsService;
+      const serverConfig = yield* ServerConfig.ServerConfig;
+      const fileSystem = yield* FileSystem.FileSystem;
+
+      const next = yield* serverSettings.updateSettings({
+        botSandboxBrowserSharing: "separate",
+      });
+
+      assert.equal(next.botSandboxBrowserSharing, "separate");
+      const raw = yield* fileSystem.readFileString(serverConfig.settingsPath);
+      // @effect-diagnostics-next-line preferSchemaOverJson:off
+      assert.equal(JSON.parse(raw).botSandboxBrowserSharing, "separate");
+    }).pipe(Effect.provide(makeServerSettingsLayer())),
+  );
+
   it.effect("writes non-default settings and explicit optional provider defaults to disk", () =>
     Effect.gen(function* () {
       const serverSettings = yield* ServerSettingsModule.ServerSettingsService;

--- a/apps/web/src/components/settings/SettingsPanels.tsx
+++ b/apps/web/src/components/settings/SettingsPanels.tsx
@@ -4,6 +4,7 @@ import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { useAtomValue } from "@effect/atom-react";
 import {
   type BackgroundActivityProfile,
+  type BotSandboxBrowserSharing,
   type DesktopUpdateChannel,
   ProviderDriverKind,
   type ScopedThreadRef,
@@ -158,6 +159,11 @@ const TIMESTAMP_FORMAT_LABELS = {
   "12-hour": "12-hour",
   "24-hour": "24-hour",
 } as const;
+
+const BOT_SANDBOX_BROWSER_SHARING_LABELS: Record<BotSandboxBrowserSharing, string> = {
+  shared: "Shared",
+  separate: "Separate",
+};
 
 const BACKGROUND_ACTIVITY_PROFILE_LABELS: Record<BackgroundActivityProfile, string> = {
   balanced: "Balanced",
@@ -521,6 +527,9 @@ export function useSettingsRestore(onRestored?: () => void) {
       DEFAULT_UNIFIED_SETTINGS.enableProviderUpdateChecks
         ? ["Provider update checks"]
         : []),
+      ...(settings.botSandboxBrowserSharing !== DEFAULT_UNIFIED_SETTINGS.botSandboxBrowserSharing
+        ? ["Sandbox and browser sharing"]
+        : []),
       ...(isBackgroundActivityDirty ? ["Background activity"] : []),
       ...(settings.defaultThreadEnvMode !== DEFAULT_UNIFIED_SETTINGS.defaultThreadEnvMode
         ? ["New thread mode"]
@@ -575,6 +584,7 @@ export function useSettingsRestore(onRestored?: () => void) {
       settings.glassOpacity,
       settings.enableLegacyTokenStreaming,
       settings.enableProviderUpdateChecks,
+      settings.botSandboxBrowserSharing,
       settings.sidebarAutoSettleAfterDays,
       settings.sidebarAutoSettleOnMerge,
       settings.sidebarProjectGroupingMode,
@@ -666,6 +676,7 @@ export function useSettingsRestore(onRestored?: () => void) {
       sidebarAutoSettleOnMerge: DEFAULT_UNIFIED_SETTINGS.sidebarAutoSettleOnMerge,
       enableLegacyTokenStreaming: DEFAULT_UNIFIED_SETTINGS.enableLegacyTokenStreaming,
       enableProviderUpdateChecks: DEFAULT_UNIFIED_SETTINGS.enableProviderUpdateChecks,
+      botSandboxBrowserSharing: DEFAULT_UNIFIED_SETTINGS.botSandboxBrowserSharing,
       backgroundActivity: DEFAULT_UNIFIED_SETTINGS.backgroundActivity,
       backgroundActivityProfile: DEFAULT_UNIFIED_SETTINGS.backgroundActivityProfile,
       automaticGitFetchInterval: DEFAULT_UNIFIED_SETTINGS.automaticGitFetchInterval,
@@ -1934,6 +1945,48 @@ export function GeneralSettingsPanel() {
               }}
               aria-label="Project grouping"
             />
+          }
+        />
+
+        <SettingsRow
+          {...searchableSetting("sandbox-browser-sharing")}
+          description="Shared uses one sandbox and browser for every bot. Separate gives each bot its own sandbox and browser profile."
+          resetAction={
+            settings.botSandboxBrowserSharing !==
+            DEFAULT_UNIFIED_SETTINGS.botSandboxBrowserSharing ? (
+              <SettingResetButton
+                label="sandbox and browser sharing"
+                onClick={() =>
+                  updateSettings({
+                    botSandboxBrowserSharing: DEFAULT_UNIFIED_SETTINGS.botSandboxBrowserSharing,
+                  })
+                }
+              />
+            ) : null
+          }
+          control={
+            <Select
+              value={settings.botSandboxBrowserSharing}
+              onValueChange={(value) => {
+                if (value === "shared" || value === "separate") {
+                  updateSettings({ botSandboxBrowserSharing: value });
+                }
+              }}
+            >
+              <SelectTrigger className="w-full sm:w-40" aria-label="Sandbox and browser sharing">
+                <SelectValue>
+                  {BOT_SANDBOX_BROWSER_SHARING_LABELS[settings.botSandboxBrowserSharing]}
+                </SelectValue>
+              </SelectTrigger>
+              <SelectPopup align="end" alignItemWithTrigger={false}>
+                <SelectItem hideIndicator value="shared">
+                  Shared
+                </SelectItem>
+                <SelectItem hideIndicator value="separate">
+                  Separate
+                </SelectItem>
+              </SelectPopup>
+            </Select>
           }
         />
 

--- a/apps/web/src/components/settings/settingsSearch.test.ts
+++ b/apps/web/src/components/settings/settingsSearch.test.ts
@@ -75,6 +75,13 @@ describe("searchSettings", () => {
     expect(searchableSetting("archive")).toEqual({ id: "archive", title: "Archived threads" });
   });
 
+  it("routes sandbox and browser sharing to General settings", () => {
+    expect(searchSettings("sandbox and browser sharing")[0]).toMatchObject({
+      id: "sandbox-browser-sharing",
+      to: "/settings/general",
+    });
+  });
+
   it("routes appearance settings to their current section", () => {
     expect(searchSettings("theme")[0]).toMatchObject({
       id: "theme",

--- a/apps/web/src/components/settings/settingsSearch.ts
+++ b/apps/web/src/components/settings/settingsSearch.ts
@@ -112,6 +112,11 @@ export const SETTINGS_SEARCH_ITEMS = [
     to: "/settings/general",
   },
   {
+    id: "sandbox-browser-sharing",
+    title: "Sandbox and browser sharing",
+    to: "/settings/general",
+  },
+  {
     id: "auto-settle-inactive-threads",
     title: "Auto-settle inactive threads",
     to: "/settings/general",

--- a/docs/user/bots.md
+++ b/docs/user/bots.md
@@ -11,6 +11,8 @@ Open a bot to edit its profile in the panel beside the conversation.
 
 Akeru Bot stores the profile in the connected environment. Other clients connected to the same environment see the same bot configuration. Workspace-disabled tools stay unavailable to all bots.
 
+Settings controls whether bots share their sandbox and browser. **Shared** is the default. **Separate** gives each bot its own Sandbox SDK session and browser profile.
+
 Use the panel button to collapse or reopen the editor. The default shortcut is **Mod+Alt+B**, and you can change `Right Panel: Toggle` in the keybinding settings. On a narrow screen, the same button opens a sheet.
 
 Bot replies support headings, links, tables, task lists, code blocks, math, and Mermaid diagrams.

--- a/packages/contracts/src/orchestration.ts
+++ b/packages/contracts/src/orchestration.ts
@@ -300,6 +300,10 @@ export type BotEngine = typeof BotEngine.Type;
 export const BotSandbox = Schema.Literals(["local", "vercel", "akeru-cloud", "upstash"]);
 export type BotSandbox = typeof BotSandbox.Type;
 
+export const BotSandboxBrowserSharing = Schema.Literals(["shared", "separate"]);
+export type BotSandboxBrowserSharing = typeof BotSandboxBrowserSharing.Type;
+export const DEFAULT_BOT_SANDBOX_BROWSER_SHARING: BotSandboxBrowserSharing = "shared";
+
 export const BotUsageCap = Schema.Struct({
   unit: Schema.Literal("tokens"),
   limit: Schema.Int.check(Schema.isGreaterThan(0)),

--- a/packages/contracts/src/provider.test.ts
+++ b/packages/contracts/src/provider.test.ts
@@ -60,6 +60,18 @@ describe("ProviderSessionStartInput", () => {
     expect(parsed.botSandbox).toBe("vercel");
   });
 
+  it("accepts bot-scoped sandbox and browser sharing", () => {
+    const parsed = decodeProviderSessionStartInput({
+      threadId: "thread-1",
+      provider: "codex",
+      botId: "bot-one",
+      botSandboxBrowserSharing: "separate",
+      runtimeMode: "full-access",
+    });
+    expect(parsed.botId).toBe("bot-one");
+    expect(parsed.botSandboxBrowserSharing).toBe("separate");
+  });
+
   it("rejects payloads without runtime mode", () => {
     expect(() =>
       decodeProviderSessionStartInput({

--- a/packages/contracts/src/provider.ts
+++ b/packages/contracts/src/provider.ts
@@ -3,6 +3,7 @@ import { TrimmedNonEmptyString } from "./baseSchemas.ts";
 import { McpServer, McpServerId } from "./mcpServer.ts";
 import {
   ApprovalRequestId,
+  BotId,
   EventId,
   IsoDateTime,
   ProviderItemId,
@@ -11,6 +12,7 @@ import {
 } from "./baseSchemas.ts";
 import {
   BotSandbox,
+  BotSandboxBrowserSharing,
   ChatAttachment,
   ModelSelection,
   PROVIDER_SEND_TURN_MAX_ATTACHMENTS,
@@ -64,7 +66,9 @@ export const ProviderSessionStartInput = Schema.Struct({
   resumeCursor: Schema.optional(Schema.Unknown),
   approvalPolicy: Schema.optional(ProviderApprovalPolicy),
   sandboxMode: Schema.optional(ProviderSandboxMode),
+  botId: Schema.optional(BotId),
   botSandbox: Schema.optional(Schema.NullOr(BotSandbox)),
+  botSandboxBrowserSharing: Schema.optional(BotSandboxBrowserSharing),
   mcpServers: Schema.optional(Schema.Array(McpServer)),
   runtimeMode: RuntimeMode,
 });

--- a/packages/contracts/src/settings.test.ts
+++ b/packages/contracts/src/settings.test.ts
@@ -162,6 +162,19 @@ describe("ClientSettings sidebar", () => {
   });
 });
 
+describe("ServerSettings bot sandbox and browser sharing", () => {
+  it("defaults to shared and accepts separate as an opt-in", () => {
+    expect(decodeServerSettings({}).botSandboxBrowserSharing).toBe("shared");
+    expect(
+      decodeServerSettingsPatch({ botSandboxBrowserSharing: "separate" }).botSandboxBrowserSharing,
+    ).toBe("separate");
+  });
+
+  it("rejects unsupported sharing modes", () => {
+    expect(() => decodeServerSettingsPatch({ botSandboxBrowserSharing: "per-thread" })).toThrow();
+  });
+});
+
 describe("ServerSettings.providerInstances (slice-2 invariant)", () => {
   it("defaults text generation to Luna at low reasoning effort", () => {
     expect(DEFAULT_SERVER_SETTINGS.textGenerationModelSelection).toEqual({

--- a/packages/contracts/src/settings.ts
+++ b/packages/contracts/src/settings.ts
@@ -9,7 +9,11 @@ import {
   DEFAULT_TEXT_GENERATION_REASONING_EFFORT,
   ProviderOptionSelections,
 } from "./model.ts";
-import { ModelSelection } from "./orchestration.ts";
+import {
+  BotSandboxBrowserSharing,
+  DEFAULT_BOT_SANDBOX_BROWSER_SHARING,
+  ModelSelection,
+} from "./orchestration.ts";
 import {
   DEFAULT_PREVIEW_APPEARANCE,
   DEFAULT_PREVIEW_ZOOM_FACTOR,
@@ -638,6 +642,9 @@ export const ServerSettings = Schema.Struct({
     Schema.withDecodingDefault(Effect.succeed(false)),
   ),
   enableProviderUpdateChecks: Schema.Boolean.pipe(Schema.withDecodingDefault(Effect.succeed(true))),
+  botSandboxBrowserSharing: BotSandboxBrowserSharing.pipe(
+    Schema.withDecodingDefault(Effect.succeed(DEFAULT_BOT_SANDBOX_BROWSER_SHARING)),
+  ),
   /**
    * Whether agents may drive the in-app preview browser. Turning this off
    * withholds the MCP credential, so the `t3-code` server (and with it every
@@ -863,6 +870,7 @@ export const ServerSettingsPatch = Schema.Struct({
   // Server settings
   enableLegacyTokenStreaming: Schema.optionalKey(Schema.Boolean),
   enableProviderUpdateChecks: Schema.optionalKey(Schema.Boolean),
+  botSandboxBrowserSharing: Schema.optionalKey(BotSandboxBrowserSharing),
   enableAgentBrowserAccess: Schema.optionalKey(Schema.Boolean),
   backgroundActivity: Schema.optionalKey(
     Schema.Struct({

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -485,8 +485,8 @@ importers:
         specifier: ^1.3.15
         version: 1.15.13
       '@opencoredev/sandbox-sdk':
-        specifier: file:../../../sandbox-sdk/packages/sdk
-        version: file:../sandbox-sdk/packages/sdk(@mastra/core@1.63.0(@bufbuild/protobuf@2.14.0)(bufferutil@4.1.0)(express@5.2.1)(utf-8-validate@6.0.6)(zod@4.4.3))(@modelcontextprotocol/sdk@1.29.0(zod@4.4.3))(@upstash/box@0.5.3(zod@4.4.3))(@vercel/sandbox@2.9.2)(bufferutil@4.1.0)(e2b@2.46.0)(utf-8-validate@6.0.6)(ws@8.21.0(bufferutil@4.1.0)(utf-8-validate@6.0.6))
+        specifier: 0.2.0
+        version: 0.2.0(@mastra/core@1.63.0(@bufbuild/protobuf@2.14.0)(bufferutil@4.1.0)(express@5.2.1)(utf-8-validate@6.0.6)(zod@4.4.3))(@modelcontextprotocol/sdk@1.29.0(zod@4.4.3))(@upstash/box@0.5.3(zod@4.4.3))(@vercel/sandbox@2.9.2)(bufferutil@4.1.0)(e2b@2.46.0)(utf-8-validate@6.0.6)(ws@8.21.0(bufferutil@4.1.0)(utf-8-validate@6.0.6))
       '@pierre/diffs':
         specifier: 'catalog:'
         version: 1.3.0-beta.10(patch_hash=7ef7cb0cbabb17c15cdb137554068b36f15f6f5265e73fb51452aa3380db91aa)(@shikijs/themes@4.3.0)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
@@ -4209,8 +4209,8 @@ packages:
   '@opencode-ai/sdk@1.15.13':
     resolution: {integrity: sha512-4TwojIoQ8EG6/mVBuUVYZXiFcwNmiiytEnjnvyuvSJjGwFIlw2YIBFxtSVC3FbwwbwHT63teh1RHiQUUC4U5xw==}
 
-  '@opencoredev/sandbox-sdk@file:../sandbox-sdk/packages/sdk':
-    resolution: {directory: ../sandbox-sdk/packages/sdk, type: directory}
+  '@opencoredev/sandbox-sdk@0.2.0':
+    resolution: {integrity: sha512-VBOz1yE+HmZ2iw6WfE5+3aVN8eu490a5nXtE2ikqjHXDZ5OjoDG3T39fIogUXf4N4f7zo+WpNyMP9SIC6b6sBw==}
     engines: {node: '>=22 <26'}
     hasBin: true
     peerDependencies:
@@ -17433,7 +17433,7 @@ snapshots:
     dependencies:
       cross-spawn: 7.0.6
 
-  '@opencoredev/sandbox-sdk@file:../sandbox-sdk/packages/sdk(@mastra/core@1.63.0(@bufbuild/protobuf@2.14.0)(bufferutil@4.1.0)(express@5.2.1)(utf-8-validate@6.0.6)(zod@4.4.3))(@modelcontextprotocol/sdk@1.29.0(zod@4.4.3))(@upstash/box@0.5.3(zod@4.4.3))(@vercel/sandbox@2.9.2)(bufferutil@4.1.0)(e2b@2.46.0)(utf-8-validate@6.0.6)(ws@8.21.0(bufferutil@4.1.0)(utf-8-validate@6.0.6))':
+  '@opencoredev/sandbox-sdk@0.2.0(@mastra/core@1.63.0(@bufbuild/protobuf@2.14.0)(bufferutil@4.1.0)(express@5.2.1)(utf-8-validate@6.0.6)(zod@4.4.3))(@modelcontextprotocol/sdk@1.29.0(zod@4.4.3))(@upstash/box@0.5.3(zod@4.4.3))(@vercel/sandbox@2.9.2)(bufferutil@4.1.0)(e2b@2.46.0)(utf-8-validate@6.0.6)(ws@8.21.0(bufferutil@4.1.0)(utf-8-validate@6.0.6))':
     dependencies:
       '@rivet-dev/agentos-core': 0.2.15(@modelcontextprotocol/sdk@1.29.0(zod@4.4.3))(bufferutil@4.1.0)(utf-8-validate@6.0.6)(ws@8.21.0(bufferutil@4.1.0)(utf-8-validate@6.0.6))
     optionalDependencies:


### PR DESCRIPTION
Bot sandbox and browser resources had one implicit ownership model, so users could not choose between reuse and isolation. This adds one server-backed Settings choice that defaults to shared resources and can switch to per-bot resource scopes. Active provider sessions restart when the scope changes, and pooled workspaces release after their final session or a failed startup.

Made with GPT-5.6 Sol in T3 Code.