### PR TITLE
feat(app): ask before local agent commands

### DIFF
--- a/apps/mobile/src/features/threads/new-task-flow-provider.tsx
+++ b/apps/mobile/src/features/threads/new-task-flow-provider.tsx
@@ -11,8 +11,8 @@ import type {
 } from "@t3tools/contracts";
 import {
   CommandId,
+  DEFAULT_LOCAL_EXECUTION_MODE,
   DEFAULT_PROVIDER_INTERACTION_MODE,
-  DEFAULT_RUNTIME_MODE,
   MessageId,
   T3_PROJECT_FILE_NAME,
   ThreadId,
@@ -400,7 +400,10 @@ export function NewTaskFlowProvider(props: React.PropsWithChildren) {
     draftStartFromOrigin ??
     selectedEnvironmentServerConfig?.settings.newWorktreesStartFromOrigin ??
     true;
-  const runtimeMode = selectedProjectDraft.runtimeMode ?? DEFAULT_RUNTIME_MODE;
+  const runtimeMode =
+    selectedProjectDraft.runtimeMode ??
+    selectedEnvironmentServerConfig?.settings.localExecutionMode ??
+    DEFAULT_LOCAL_EXECUTION_MODE;
   const interactionMode = planModeEnabled
     ? (selectedProjectDraft.interactionMode ?? DEFAULT_PROVIDER_INTERACTION_MODE)
     : DEFAULT_PROVIDER_INTERACTION_MODE;
@@ -865,7 +868,10 @@ export function NewTaskFlowProvider(props: React.PropsWithChildren) {
         text,
         attachments: draft.attachments,
         modelSelection: draftModelSelection,
-        runtimeMode: draft.runtimeMode ?? DEFAULT_RUNTIME_MODE,
+        runtimeMode:
+          draft.runtimeMode ??
+          selectedEnvironmentServerConfig?.settings.localExecutionMode ??
+          DEFAULT_LOCAL_EXECUTION_MODE,
         interactionMode: resolvePendingTaskInteractionMode({
           preferenceLoaded: planModePreferenceLoaded,
           planModeEnabled,

--- a/apps/mobile/src/state/use-thread-outbox-drain.ts
+++ b/apps/mobile/src/state/use-thread-outbox-drain.ts
@@ -6,8 +6,8 @@ import type {
 import type { AtomCommandResult } from "@t3tools/client-runtime/state/runtime";
 import {
   CommandId,
+  DEFAULT_LOCAL_EXECUTION_MODE,
   DEFAULT_PROVIDER_INTERACTION_MODE,
-  DEFAULT_RUNTIME_MODE,
   type MessageId,
 } from "@t3tools/contracts";
 import { buildTemporaryWorktreeBranchName } from "@t3tools/shared/git";
@@ -268,7 +268,7 @@ export function useThreadOutboxDrain(): void {
           text: queuedMessage.text.trim(),
           attachments: queuedMessage.attachments,
           modelSelection,
-          runtimeMode: queuedMessage.runtimeMode ?? DEFAULT_RUNTIME_MODE,
+          runtimeMode: queuedMessage.runtimeMode ?? DEFAULT_LOCAL_EXECUTION_MODE,
           interactionMode: queuedMessage.interactionMode ?? DEFAULT_PROVIDER_INTERACTION_MODE,
           workspaceMode: creation.workspaceMode,
           branch: creation.branch,

--- a/apps/server/package.json
+++ b/apps/server/package.json
@@ -31,7 +31,7 @@
     "@mastra/code-sdk": "1.5.1",
     "@mastra/core": "1.63.0",
     "@opencode-ai/sdk": "^1.3.15",
-    "@opencoredev/sandbox-sdk": "file:../../../sandbox-sdk/packages/sdk",
+    "@opencoredev/sandbox-sdk": "^0.2.0",
     "@pierre/diffs": "catalog:",
     "@upstash/box": "0.5.3",
     "@vercel/sandbox": "^2.5.0",

--- a/apps/web/src/components/roster/BotRosterSidebar.tsx
+++ b/apps/web/src/components/roster/BotRosterSidebar.tsx
@@ -42,6 +42,7 @@ import { visibleBotChatMessages } from "./botConversationPresentation";
 import { useBotPresence } from "./botPresence";
 import { findLatestBotThreadTarget } from "./botThreadRuntime.logic";
 import { NewBotDialog } from "./NewBotDialog";
+import { DEFAULT_BOT_RUNTIME_MODE } from "./botSandbox";
 import {
   buildGroupedRosterSections,
   buildRosterStrip,
@@ -455,7 +456,7 @@ export default function BotRosterSidebar() {
         avatar,
         engine: null,
         sandbox: null,
-        runtimeMode: "full-access",
+        runtimeMode: DEFAULT_BOT_RUNTIME_MODE,
         usageCap: null,
         groupId: null,
       },

--- a/apps/web/src/components/roster/botSandbox.test.ts
+++ b/apps/web/src/components/roster/botSandbox.test.ts
@@ -1,12 +1,30 @@
 import { describe, expect, it } from "vite-plus/test";
 
-import { BOT_SANDBOX_OPTIONS, botSandboxChoice, botSandboxLabel } from "./botSandbox";
+import {
+  BOT_SANDBOX_OPTIONS,
+  DEFAULT_BOT_RUNTIME_MODE,
+  botSandboxChoice,
+  botSandboxLabel,
+  resolveBotRuntimeMode,
+} from "./botSandbox";
 
 describe("botSandbox", () => {
   it("treats a missing bot sandbox as local", () => {
     expect(botSandboxChoice(null)).toBe("local");
     expect(botSandboxChoice("local")).toBe("local");
     expect(botSandboxChoice("vercel")).toBe("vercel");
+  });
+
+  it("asks before local tools unless full access is enabled", () => {
+    expect(DEFAULT_BOT_RUNTIME_MODE).toBe("approval-required");
+    expect(resolveBotRuntimeMode(null, "approval-required")).toBe("approval-required");
+    expect(resolveBotRuntimeMode("local", "full-access")).toBe("full-access");
+  });
+
+  it("runs cloud sandbox tools without a local approval prompt", () => {
+    for (const sandbox of ["vercel", "akeru-cloud", "upstash"] as const) {
+      expect(resolveBotRuntimeMode(sandbox, "approval-required")).toBe("full-access");
+    }
   });
 
   it("lists the first sandbox providers", () => {

--- a/apps/web/src/components/roster/botSandbox.ts
+++ b/apps/web/src/components/roster/botSandbox.ts
@@ -1,4 +1,12 @@
+import {
+  DEFAULT_LOCAL_EXECUTION_MODE,
+  type LocalExecutionMode,
+  type RuntimeMode,
+} from "@t3tools/contracts";
+
 import type { Bot } from "./types";
+
+export const DEFAULT_BOT_RUNTIME_MODE: RuntimeMode = DEFAULT_LOCAL_EXECUTION_MODE;
 
 export const BOT_SANDBOX_OPTIONS = [
   { value: "local", label: "Local" },
@@ -15,4 +23,11 @@ export function botSandboxChoice(sandbox: Bot["sandbox"]): BotSandboxChoice {
 
 export function botSandboxLabel(sandbox: BotSandboxChoice): string {
   return BOT_SANDBOX_OPTIONS.find((option) => option.value === sandbox)?.label ?? "Local";
+}
+
+export function resolveBotRuntimeMode(
+  sandbox: Bot["sandbox"],
+  localExecutionMode: LocalExecutionMode,
+): RuntimeMode {
+  return botSandboxChoice(sandbox) === "local" ? localExecutionMode : "full-access";
 }

--- a/apps/web/src/components/roster/useBotThreadRuntime.ts
+++ b/apps/web/src/components/roster/useBotThreadRuntime.ts
@@ -3,7 +3,6 @@ import { scopeThreadRef } from "@t3tools/client-runtime/environment";
 import { squashAtomCommandFailure } from "@t3tools/client-runtime/state/runtime";
 import {
   BotId,
-  DEFAULT_RUNTIME_MODE,
   EnvironmentId,
   ThreadId,
   type ModelSelection,
@@ -28,6 +27,7 @@ import { primaryServerProvidersAtom } from "../../state/server";
 import { threadEnvironment } from "../../state/threads";
 import { useAtomCommand } from "../../state/use-atom-command";
 import { sortScopedProjectsForSidebar } from "../Sidebar.logic";
+import { resolveBotRuntimeMode } from "./botSandbox";
 import { buildBotTurnStartInput, findLatestBotThreadTarget } from "./botThreadRuntime.logic";
 import { parseChatPath } from "./roster.logic";
 import { useRosterStore } from "./rosterStore";
@@ -130,6 +130,9 @@ export function useBotThreadRuntime(botId: string, effectiveModelSelection: Mode
     () => resolveAppModelSelectionState(settings, providers),
     [providers, settings],
   );
+  const setRuntimeMode = useAtomCommand(threadEnvironment.setRuntimeMode, {
+    reportFailure: false,
+  });
   const startTurn = useAtomCommand(threadEnvironment.startTurn, { reportFailure: false });
   const botReady = serverBots.some((candidate) => candidate.id === botId);
   const sendInFlightRef = useRef(false);
@@ -161,7 +164,7 @@ export function useBotThreadRuntime(botId: string, effectiveModelSelection: Mode
       const threadId = currentThreadRef?.threadId ?? newThreadId();
       const modelSelection: ModelSelection =
         effectiveModelSelection ?? activeProject.defaultModelSelection ?? appDefaultModelSelection;
-      const runtimeMode = bot?.runtimeMode ?? DEFAULT_RUNTIME_MODE;
+      const runtimeMode = resolveBotRuntimeMode(bot?.sandbox ?? null, settings.localExecutionMode);
       const title = threadTitle(prompt, files);
 
       try {
@@ -175,6 +178,16 @@ export function useBotThreadRuntime(botId: string, effectiveModelSelection: Mode
           })),
         );
         const environmentId = currentThreadRef?.environmentId ?? activeProject.environmentId;
+        if (currentThreadRef && rememberedThread?.runtimeMode !== runtimeMode) {
+          const modeResult = await setRuntimeMode({
+            environmentId,
+            input: { threadId, runtimeMode },
+          });
+          if (modeResult._tag === "Failure") {
+            setError(errorMessage(modeResult));
+            return false;
+          }
+        }
         const startResult = await startTurn({
           environmentId,
           input: buildBotTurnStartInput({
@@ -225,6 +238,9 @@ export function useBotThreadRuntime(botId: string, effectiveModelSelection: Mode
       botId,
       effectiveModelSelection,
       botReady,
+      rememberedThread?.runtimeMode,
+      settings.localExecutionMode,
+      setRuntimeMode,
       startTurn,
     ],
   );

--- a/apps/web/src/components/roster/useGroupThreadRuntime.ts
+++ b/apps/web/src/components/roster/useGroupThreadRuntime.ts
@@ -3,7 +3,6 @@ import { scopeThreadRef } from "@t3tools/client-runtime/environment";
 import { squashAtomCommandFailure } from "@t3tools/client-runtime/state/runtime";
 import {
   BotId,
-  DEFAULT_RUNTIME_MODE,
   EnvironmentId,
   GroupId,
   ProviderInstanceId,
@@ -30,6 +29,7 @@ import { threadEnvironment } from "../../state/threads";
 import { useAtomCommand } from "../../state/use-atom-command";
 import { DEFAULT_INTERACTION_MODE } from "../../types";
 import { sortScopedProjectsForSidebar } from "../Sidebar.logic";
+import { resolveBotRuntimeMode } from "./botSandbox";
 import { buildGroupTurnStartInput, findLatestGroupThreadTarget } from "./botThreadRuntime.logic";
 import { useRosterStore } from "./rosterStore";
 
@@ -129,6 +129,9 @@ export function useGroupThreadRuntime(groupId: string) {
     () => resolveAppModelSelectionState(settings, providers),
     [providers, settings],
   );
+  const setRuntimeMode = useAtomCommand(threadEnvironment.setRuntimeMode, {
+    reportFailure: false,
+  });
   const startTurn = useAtomCommand(threadEnvironment.startTurn, { reportFailure: false });
   const groupReady = serverGroups.some((candidate) => candidate.id === groupId);
   const sendInFlightRef = useRef(false);
@@ -173,6 +176,7 @@ export function useGroupThreadRuntime(groupId: string) {
       const createdAt = new Date().toISOString();
       const currentThreadRef = retainedThreadRef.current.threadRef;
       const threadId = currentThreadRef?.threadId ?? newThreadId();
+      const runtimeMode = resolveBotRuntimeMode(respondingBot.sandbox, settings.localExecutionMode);
 
       try {
         const attachments = await Promise.all(
@@ -185,6 +189,16 @@ export function useGroupThreadRuntime(groupId: string) {
           })),
         );
         const environmentId = currentThreadRef?.environmentId ?? activeProject.environmentId;
+        if (currentThreadRef && rememberedThread?.runtimeMode !== runtimeMode) {
+          const modeResult = await setRuntimeMode({
+            environmentId,
+            input: { threadId, runtimeMode },
+          });
+          if (modeResult._tag === "Failure") {
+            setError(errorMessage(modeResult));
+            return false;
+          }
+        }
         const result = await startTurn({
           environmentId,
           input: buildGroupTurnStartInput({
@@ -200,7 +214,7 @@ export function useGroupThreadRuntime(groupId: string) {
               attachments,
             },
             modelSelection,
-            runtimeMode: respondingBot.runtimeMode ?? DEFAULT_RUNTIME_MODE,
+            runtimeMode,
             interactionMode: DEFAULT_INTERACTION_MODE,
             createdAt,
             createThread: currentThreadRef === null,
@@ -220,7 +234,18 @@ export function useGroupThreadRuntime(groupId: string) {
         setSending(false);
       }
     },
-    [activeProject, appDefaultModelSelection, bots, group, groupId, groupReady, startTurn],
+    [
+      activeProject,
+      appDefaultModelSelection,
+      bots,
+      group,
+      groupId,
+      groupReady,
+      rememberedThread?.runtimeMode,
+      settings.localExecutionMode,
+      setRuntimeMode,
+      startTurn,
+    ],
   );
 
   return {

--- a/apps/web/src/components/roster/useServerRoster.ts
+++ b/apps/web/src/components/roster/useServerRoster.ts
@@ -10,6 +10,7 @@ import {
 } from "../../state/bots";
 import { usePrimaryEnvironmentId } from "../../state/environments";
 import { useAtomCommand } from "../../state/use-atom-command";
+import { DEFAULT_BOT_RUNTIME_MODE } from "./botSandbox";
 import { useRosterStore } from "./rosterStore";
 import type { BotAvatar } from "./types";
 
@@ -38,7 +39,7 @@ export function useServerRosterSync(): void {
           avatar: { kind: "blob", shape: "circle", color: "#5B7FD4" },
           engine: null,
           sandbox: null,
-          runtimeMode: "full-access",
+          runtimeMode: DEFAULT_BOT_RUNTIME_MODE,
           usageCap: null,
           groupId: null,
         },

--- a/apps/web/src/components/settings/SettingsPanels.tsx
+++ b/apps/web/src/components/settings/SettingsPanels.tsx
@@ -522,6 +522,9 @@ export function useSettingsRestore(onRestored?: () => void) {
         ? ["Provider update checks"]
         : []),
       ...(isBackgroundActivityDirty ? ["Background activity"] : []),
+      ...(settings.localExecutionMode !== DEFAULT_UNIFIED_SETTINGS.localExecutionMode
+        ? ["Local execution"]
+        : []),
       ...(settings.defaultThreadEnvMode !== DEFAULT_UNIFIED_SETTINGS.defaultThreadEnvMode
         ? ["New thread mode"]
         : []),
@@ -560,6 +563,7 @@ export function useSettingsRestore(onRestored?: () => void) {
       settings.confirmThreadArchive,
       settings.confirmThreadDelete,
       settings.addProjectBaseDirectory,
+      settings.localExecutionMode,
       settings.defaultThreadEnvMode,
       settings.newWorktreesStartFromOrigin,
       settings.diffIgnoreWhitespace,
@@ -670,6 +674,7 @@ export function useSettingsRestore(onRestored?: () => void) {
       backgroundActivityProfile: DEFAULT_UNIFIED_SETTINGS.backgroundActivityProfile,
       automaticGitFetchInterval: DEFAULT_UNIFIED_SETTINGS.automaticGitFetchInterval,
       providerHealthRefreshInterval: DEFAULT_UNIFIED_SETTINGS.providerHealthRefreshInterval,
+      localExecutionMode: DEFAULT_UNIFIED_SETTINGS.localExecutionMode,
       defaultThreadEnvMode: DEFAULT_UNIFIED_SETTINGS.defaultThreadEnvMode,
       newWorktreesStartFromOrigin: DEFAULT_UNIFIED_SETTINGS.newWorktreesStartFromOrigin,
       addProjectBaseDirectory: DEFAULT_UNIFIED_SETTINGS.addProjectBaseDirectory,
@@ -2251,6 +2256,47 @@ export function GeneralSettingsPanel() {
                 onOpenChange={setBackgroundActivityDialogOpen}
               />
             </>
+          }
+        />
+
+        <SettingsRow
+          {...searchableSetting("local-execution")}
+          description="Ask before local file changes and shell commands. Full access skips these prompts. Sensitive actions still ask."
+          resetAction={
+            settings.localExecutionMode !== DEFAULT_UNIFIED_SETTINGS.localExecutionMode ? (
+              <SettingResetButton
+                label="local execution"
+                onClick={() =>
+                  updateSettings({
+                    localExecutionMode: DEFAULT_UNIFIED_SETTINGS.localExecutionMode,
+                  })
+                }
+              />
+            ) : null
+          }
+          control={
+            <Select
+              value={settings.localExecutionMode}
+              onValueChange={(value) => {
+                if (value === "approval-required" || value === "full-access") {
+                  updateSettings({ localExecutionMode: value });
+                }
+              }}
+            >
+              <SelectTrigger className="w-full sm:w-40" aria-label="Local execution">
+                <SelectValue>
+                  {settings.localExecutionMode === "full-access" ? "Full access" : "Ask first"}
+                </SelectValue>
+              </SelectTrigger>
+              <SelectPopup align="end" alignItemWithTrigger={false}>
+                <SelectItem hideIndicator value="approval-required">
+                  Ask first
+                </SelectItem>
+                <SelectItem hideIndicator value="full-access">
+                  Full access
+                </SelectItem>
+              </SelectPopup>
+            </Select>
           }
         />
 

--- a/apps/web/src/components/settings/settingsSearch.test.ts
+++ b/apps/web/src/components/settings/settingsSearch.test.ts
@@ -46,6 +46,10 @@ describe("searchSettings", () => {
   it("matches normalized title substrings", () => {
     expect(searchSettings("  WORD   WRAP  ", ITEMS).map((item) => item.id)).toEqual(["word-wrap"]);
     expect(searchSettings("glass").map((item) => item.id)).toEqual(["setting-glass-opacity"]);
+    expect(searchSettings("local execution")[0]).toMatchObject({
+      id: "local-execution",
+      to: "/settings/general",
+    });
     expect(searchSettings("xyzzy")).toEqual([]);
   });
 

--- a/apps/web/src/components/settings/settingsSearch.ts
+++ b/apps/web/src/components/settings/settingsSearch.ts
@@ -147,6 +147,11 @@ export const SETTINGS_SEARCH_ITEMS = [
     to: "/settings/general",
   },
   {
+    id: "local-execution",
+    title: "Local execution",
+    to: "/settings/general",
+  },
+  {
     id: "new-threads",
     title: "New threads",
     to: "/settings/general",

--- a/apps/web/src/components/sidebar/SidebarChrome.test.ts
+++ b/apps/web/src/components/sidebar/SidebarChrome.test.ts
@@ -22,6 +22,58 @@ describe("sidebar footer", () => {
     expect(source).toContain("Sign in for remote access");
   });
 
+  it("creates manual and first-run bots with approval required", () => {
+    const rosterSource = NodeFS.readFileSync(
+      new URL("../roster/BotRosterSidebar.tsx", import.meta.url),
+      "utf8",
+    );
+    const syncSource = NodeFS.readFileSync(
+      new URL("../roster/useServerRoster.ts", import.meta.url),
+      "utf8",
+    );
+
+    expect(rosterSource).toContain("runtimeMode: DEFAULT_BOT_RUNTIME_MODE");
+    expect(syncSource).toContain("runtimeMode: DEFAULT_BOT_RUNTIME_MODE");
+    expect(rosterSource).not.toContain('runtimeMode: "full-access"');
+    expect(syncSource).not.toContain('runtimeMode: "full-access"');
+  });
+
+  it("updates existing bot and group threads before starting the next turn", () => {
+    const botSource = NodeFS.readFileSync(
+      new URL("../roster/useBotThreadRuntime.ts", import.meta.url),
+      "utf8",
+    );
+    const groupSource = NodeFS.readFileSync(
+      new URL("../roster/useGroupThreadRuntime.ts", import.meta.url),
+      "utf8",
+    );
+
+    for (const source of [botSource, groupSource]) {
+      const modeUpdate = source.indexOf("const modeResult = await setRuntimeMode");
+      expect(modeUpdate).toBeGreaterThan(-1);
+      expect(modeUpdate).toBeLessThan(source.indexOf("await startTurn", modeUpdate));
+    }
+  });
+
+  it("mints fresh web and mobile threads from the local execution setting", () => {
+    const webSource = NodeFS.readFileSync(
+      new URL("../../hooks/useHandleNewThread.ts", import.meta.url),
+      "utf8",
+    );
+    const mobileSource = NodeFS.readFileSync(
+      new URL(
+        "../../../../mobile/src/features/threads/new-task-flow-provider.tsx",
+        import.meta.url,
+      ),
+      "utf8",
+    );
+
+    expect(webSource).toContain(
+      "runtimeMode: carryRuntimeMode ?? primaryServerSettings.localExecutionMode",
+    );
+    expect(mobileSource).toContain("selectedEnvironmentServerConfig?.settings.localExecutionMode");
+  });
+
   it("keeps the roster scrollable from touch gestures that start on a bot row", () => {
     const source = NodeFS.readFileSync(
       new URL("../roster/BotRosterSidebar.tsx", import.meta.url),

--- a/apps/web/src/composerDraftStore.test.ts
+++ b/apps/web/src/composerDraftStore.test.ts
@@ -806,7 +806,7 @@ describe("composerDraftStore project draft thread mapping", () => {
       branch: "feature/test",
       worktreePath: "/tmp/worktree-test",
       envMode: "worktree",
-      runtimeMode: "full-access",
+      runtimeMode: "approval-required",
       interactionMode: "default",
       createdAt: "2026-01-01T00:00:00.000Z",
     });
@@ -817,7 +817,7 @@ describe("composerDraftStore project draft thread mapping", () => {
       branch: "feature/test",
       worktreePath: "/tmp/worktree-test",
       envMode: "worktree",
-      runtimeMode: "full-access",
+      runtimeMode: "approval-required",
       interactionMode: "default",
       createdAt: "2026-01-01T00:00:00.000Z",
     });

--- a/apps/web/src/composerDraftStore.ts
+++ b/apps/web/src/composerDraftStore.ts
@@ -1,4 +1,5 @@
 import {
+  DEFAULT_LOCAL_EXECUTION_MODE,
   DEFAULT_MODEL,
   DEFAULT_MODEL_BY_PROVIDER,
   defaultInstanceIdForDriver,
@@ -33,7 +34,7 @@ import { createModelSelection, normalizeModelSlug } from "@t3tools/shared/model"
 import { useMemo } from "react";
 import { getLocalStorageItem } from "./hooks/useLocalStorage";
 import { resolveAppModelSelection, resolveAppModelSelectionForInstance } from "./modelSelection";
-import { DEFAULT_INTERACTION_MODE, DEFAULT_RUNTIME_MODE, type ChatImageAttachment } from "./types";
+import { DEFAULT_INTERACTION_MODE, type ChatImageAttachment } from "./types";
 import {
   type TerminalContextDraft,
   ensureInlineTerminalContextPlaceholders,
@@ -1406,7 +1407,8 @@ function createDraftThreadState(
     projectId: projectRef.projectId,
     logicalProjectKey,
     createdAt: options?.createdAt ?? existingThread?.createdAt ?? new Date().toISOString(),
-    runtimeMode: options?.runtimeMode ?? existingThread?.runtimeMode ?? DEFAULT_RUNTIME_MODE,
+    runtimeMode:
+      options?.runtimeMode ?? existingThread?.runtimeMode ?? DEFAULT_LOCAL_EXECUTION_MODE,
     interactionMode:
       options?.interactionMode ?? existingThread?.interactionMode ?? DEFAULT_INTERACTION_MODE,
     branch: nextBranch,
@@ -1579,7 +1581,7 @@ function normalizePersistedDraftThreads(
             : new Date().toISOString(),
         runtimeMode: isRuntimeMode(candidateDraftThread.runtimeMode)
           ? candidateDraftThread.runtimeMode
-          : DEFAULT_RUNTIME_MODE,
+          : DEFAULT_LOCAL_EXECUTION_MODE,
         interactionMode:
           candidateDraftThread.interactionMode === "plan" ||
           candidateDraftThread.interactionMode === "default"
@@ -1629,7 +1631,7 @@ function normalizePersistedDraftThreads(
           projectId: projectRef.projectId,
           logicalProjectKey,
           createdAt: new Date().toISOString(),
-          runtimeMode: DEFAULT_RUNTIME_MODE,
+          runtimeMode: DEFAULT_LOCAL_EXECUTION_MODE,
           interactionMode: DEFAULT_INTERACTION_MODE,
           branch: null,
           worktreePath: null,

--- a/apps/web/src/hooks/useHandleNewThread.ts
+++ b/apps/web/src/hooks/useHandleNewThread.ts
@@ -4,12 +4,7 @@ import {
   scopeProjectRef,
   scopeThreadRef,
 } from "@t3tools/client-runtime/environment";
-import {
-  DEFAULT_RUNTIME_MODE,
-  type RuntimeMode,
-  type ScopedProjectRef,
-  type ThreadId,
-} from "@t3tools/contracts";
+import { type RuntimeMode, type ScopedProjectRef, type ThreadId } from "@t3tools/contracts";
 import { useParams, useRouter } from "@tanstack/react-router";
 import { useCallback, useMemo } from "react";
 import {
@@ -280,7 +275,7 @@ export function useNewThreadHandler() {
           if (workspaceContext) {
             setDraftThreadContext(emptyStoredDraftThread.draftId, {
               ...workspaceContext,
-              ...(carryRuntimeMode ? { runtimeMode: carryRuntimeMode } : {}),
+              runtimeMode: carryRuntimeMode ?? primaryServerSettings.localExecutionMode,
               ...(carryInteractionMode ? { interactionMode: carryInteractionMode } : {}),
             });
             if (carryModelSelection) {
@@ -303,7 +298,7 @@ export function useNewThreadHandler() {
             {
               threadId: emptyStoredDraftThread.threadId,
               ...workspaceContext,
-              ...(carryRuntimeMode ? { runtimeMode: carryRuntimeMode } : {}),
+              runtimeMode: carryRuntimeMode ?? primaryServerSettings.localExecutionMode,
               ...(carryInteractionMode ? { interactionMode: carryInteractionMode } : {}),
             },
           );
@@ -415,7 +410,7 @@ export function useNewThreadHandler() {
               envMode: initialEnvMode,
               newWorktreesStartFromOrigin: primaryServerSettings.newWorktreesStartFromOrigin,
             }),
-          runtimeMode: carryRuntimeMode ?? DEFAULT_RUNTIME_MODE,
+          runtimeMode: carryRuntimeMode ?? primaryServerSettings.localExecutionMode,
           ...(carryInteractionMode ? { interactionMode: carryInteractionMode } : {}),
         });
         applyStickyState(draftId);

--- a/apps/web/vite.config.ts
+++ b/apps/web/vite.config.ts
@@ -1,4 +1,4 @@
-import * as NodeUrl from "node:url";
+import * as NodeURL from "node:url";
 import * as NodeZlib from "node:zlib";
 
 import tailwindcss from "@tailwindcss/vite";
@@ -15,7 +15,7 @@ import { DEV_PROXIED_PATH_PREFIXES } from "@t3tools/shared/devProxy";
 
 import { loadRepoEnv } from "../../scripts/lib/public-config";
 
-const reactGrabEntry = NodeUrl.fileURLToPath(import.meta.resolve("react-grab"));
+const reactGrabEntry = NodeURL.fileURLToPath(import.meta.resolve("react-grab"));
 
 const repoEnv = loadRepoEnv();
 Object.assign(process.env, repoEnv);

--- a/docs/user/bots.md
+++ b/docs/user/bots.md
@@ -11,6 +11,8 @@ Open a bot to edit its profile in the panel beside the conversation.
 
 Akeru Bot stores the profile in the connected environment. Other clients connected to the same environment see the same bot configuration. Workspace-disabled tools stay unavailable to all bots.
 
+Local bots ask before file changes and shell commands by default. Select **Settings > General > Local execution > Full access** to skip those local prompts. Actions that send, pay, delete, change production, or use secrets still ask. Bots that run in a cloud sandbox do not show the local computer prompt.
+
 Use the panel button to collapse or reopen the editor. The default shortcut is **Mod+Alt+B**, and you can change `Right Panel: Toggle` in the keybinding settings. On a narrow screen, the same button opens a sheet.
 
 Bot replies support headings, links, tables, task lists, code blocks, math, and Mermaid diagrams.

--- a/docs/user/permission-modes.md
+++ b/docs/user/permission-modes.md
@@ -4,8 +4,8 @@ A permission mode controls how much the agent does on its own and when it stops 
 
 The mode is set per thread, from the mode control in the message composer. Changing it in one
 thread does not change any other thread. A thread created from inside another thread keeps that
-thread's mode; otherwise new threads start in **Full access** unless you pick something else
-before sending.
+thread's mode. Otherwise, new threads use **Settings > General > Local execution** and ask before
+local file changes and shell commands by default.
 
 ## The Modes
 
@@ -20,8 +20,9 @@ on the provider: Codex delegates routine approvals to an AI reviewer, Claude use
 permission mode, and providers without an equivalent (such as OpenCode) fall back to asking, like
 Supervised.
 
-**Full access**: allow commands and edits without prompts. The default. The agent runs
-unattended until it finishes or asks a question of its own.
+**Full access**: allow commands and edits without local prompts. The agent runs unattended until
+it finishes or asks a question of its own. Actions that send, pay, delete, change production, or
+use secrets still ask.
 
 Approvals appear inline in the conversation. Approve or reject one and the agent continues from
 there.

--- a/packages/contracts/src/orchestration.test.ts
+++ b/packages/contracts/src/orchestration.test.ts
@@ -4,6 +4,7 @@ import * as Schema from "effect/Schema";
 
 import {
   BotAvatar,
+  DEFAULT_LOCAL_EXECUTION_MODE,
   DEFAULT_PROVIDER_INTERACTION_MODE,
   DEFAULT_RUNTIME_MODE,
   ClientOrchestrationCommand,
@@ -261,8 +262,29 @@ it.effect("decodes thread.turn.start defaults for provider and runtime mode", ()
       createdAt: "2026-01-01T00:00:00.000Z",
     });
     assert.strictEqual(parsed.modelSelection, undefined);
-    assert.strictEqual(parsed.runtimeMode, DEFAULT_RUNTIME_MODE);
+    assert.strictEqual(parsed.runtimeMode, DEFAULT_LOCAL_EXECUTION_MODE);
     assert.strictEqual(parsed.interactionMode, DEFAULT_PROVIDER_INTERACTION_MODE);
+  }),
+);
+
+it.effect("decodes bot.create to approval required when an old client omits runtimeMode", () =>
+  Effect.gen(function* () {
+    const parsed = yield* decodeOrchestrationCommand({
+      type: "bot.create",
+      commandId: "cmd-bot-default-runtime",
+      botId: "bot-default-runtime",
+      name: "Akeru",
+      title: "Akeru",
+      avatar: { kind: "dither", seed: "akeru" },
+      engine: null,
+      sandbox: null,
+      usageCap: null,
+      groupId: null,
+      createdAt: "2026-01-01T00:00:00.000Z",
+    });
+
+    if (parsed.type !== "bot.create") assert.fail(`Expected bot.create, received ${parsed.type}.`);
+    assert.strictEqual(parsed.runtimeMode, DEFAULT_LOCAL_EXECUTION_MODE);
   }),
 );
 

--- a/packages/contracts/src/orchestration.ts
+++ b/packages/contracts/src/orchestration.ts
@@ -127,7 +127,11 @@ export const RuntimeMode = Schema.Literals([
   "full-access",
 ]);
 export type RuntimeMode = typeof RuntimeMode.Type;
+// Event decoders keep the historical full-access fallback for old persisted data.
 export const DEFAULT_RUNTIME_MODE: RuntimeMode = "full-access";
+export const LocalExecutionMode = Schema.Literals(["approval-required", "full-access"]);
+export type LocalExecutionMode = typeof LocalExecutionMode.Type;
+export const DEFAULT_LOCAL_EXECUTION_MODE: LocalExecutionMode = "approval-required";
 export const ProviderInteractionMode = Schema.Literals(["default", "plan"]);
 export type ProviderInteractionMode = typeof ProviderInteractionMode.Type;
 export const DEFAULT_PROVIDER_INTERACTION_MODE: ProviderInteractionMode = "default";
@@ -834,7 +838,9 @@ const BotCreateCommand = Schema.Struct({
   avatar: BotAvatar,
   engine: Schema.NullOr(BotEngine),
   sandbox: Schema.NullOr(BotSandbox),
-  runtimeMode: RuntimeMode.pipe(Schema.withDecodingDefault(Effect.succeed(DEFAULT_RUNTIME_MODE))),
+  runtimeMode: RuntimeMode.pipe(
+    Schema.withDecodingDefault(Effect.succeed(DEFAULT_LOCAL_EXECUTION_MODE)),
+  ),
   usageCap: Schema.NullOr(BotUsageCap).pipe(Schema.withDecodingDefault(Effect.succeed(null))),
   groupId: Schema.NullOr(GroupId),
   createdAt: IsoDateTime,
@@ -1164,7 +1170,9 @@ export const ThreadTurnStartCommand = Schema.Struct({
   }),
   modelSelection: Schema.optional(ModelSelection),
   titleSeed: Schema.optional(TrimmedNonEmptyString),
-  runtimeMode: RuntimeMode.pipe(Schema.withDecodingDefault(Effect.succeed(DEFAULT_RUNTIME_MODE))),
+  runtimeMode: RuntimeMode.pipe(
+    Schema.withDecodingDefault(Effect.succeed(DEFAULT_LOCAL_EXECUTION_MODE)),
+  ),
   interactionMode: ProviderInteractionMode.pipe(
     Schema.withDecodingDefault(Effect.succeed(DEFAULT_PROVIDER_INTERACTION_MODE)),
   ),

--- a/packages/contracts/src/settings.test.ts
+++ b/packages/contracts/src/settings.test.ts
@@ -49,6 +49,20 @@ describe("ClaudeSettings auto-compaction", () => {
   });
 });
 
+describe("ServerSettings local execution", () => {
+  it("asks before local execution by default and accepts an explicit full-access opt-in", () => {
+    expect(decodeServerSettings({}).localExecutionMode).toBe("approval-required");
+    expect(
+      decodeServerSettingsPatch({ localExecutionMode: "full-access" }).localExecutionMode,
+    ).toBe("full-access");
+  });
+
+  it("rejects other runtime modes", () => {
+    expect(() => decodeServerSettingsPatch({ localExecutionMode: "auto" })).toThrow();
+    expect(() => decodeServerSettingsPatch({ localExecutionMode: "auto-accept-edits" })).toThrow();
+  });
+});
+
 describe("ClientSettings word wrap", () => {
   it("defaults word wrap on", () => {
     expect(decodeClientSettings({}).wordWrap).toBe(true);

--- a/packages/contracts/src/settings.ts
+++ b/packages/contracts/src/settings.ts
@@ -9,7 +9,11 @@ import {
   DEFAULT_TEXT_GENERATION_REASONING_EFFORT,
   ProviderOptionSelections,
 } from "./model.ts";
-import { ModelSelection } from "./orchestration.ts";
+import {
+  DEFAULT_LOCAL_EXECUTION_MODE,
+  LocalExecutionMode,
+  ModelSelection,
+} from "./orchestration.ts";
 import {
   DEFAULT_PREVIEW_APPEARANCE,
   DEFAULT_PREVIEW_ZOOM_FACTOR,
@@ -650,6 +654,9 @@ export const ServerSettings = Schema.Struct({
    * between a desktop window and a phone attached to the same server.
    */
   enableAgentBrowserAccess: Schema.Boolean.pipe(Schema.withDecodingDefault(Effect.succeed(true))),
+  localExecutionMode: LocalExecutionMode.pipe(
+    Schema.withDecodingDefault(Effect.succeed(DEFAULT_LOCAL_EXECUTION_MODE)),
+  ),
   backgroundActivity: BackgroundActivitySettings,
   // Legacy flat fields retained for old settings files and old clients. New
   // consumers should resolve `backgroundActivity` instead.
@@ -864,6 +871,7 @@ export const ServerSettingsPatch = Schema.Struct({
   enableLegacyTokenStreaming: Schema.optionalKey(Schema.Boolean),
   enableProviderUpdateChecks: Schema.optionalKey(Schema.Boolean),
   enableAgentBrowserAccess: Schema.optionalKey(Schema.Boolean),
+  localExecutionMode: Schema.optionalKey(LocalExecutionMode),
   backgroundActivity: Schema.optionalKey(
     Schema.Struct({
       schemaVersion: Schema.optionalKey(Schema.Literal(1)),

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -485,8 +485,8 @@ importers:
         specifier: ^1.3.15
         version: 1.15.13
       '@opencoredev/sandbox-sdk':
-        specifier: file:../../../sandbox-sdk/packages/sdk
-        version: file:../sandbox-sdk/packages/sdk(@mastra/core@1.63.0(@bufbuild/protobuf@2.14.0)(bufferutil@4.1.0)(express@5.2.1)(utf-8-validate@6.0.6)(zod@4.4.3))(@modelcontextprotocol/sdk@1.29.0(zod@4.4.3))(@upstash/box@0.5.3(zod@4.4.3))(@vercel/sandbox@2.9.2)(bufferutil@4.1.0)(e2b@2.46.0)(utf-8-validate@6.0.6)(ws@8.21.0(bufferutil@4.1.0)(utf-8-validate@6.0.6))
+        specifier: ^0.2.0
+        version: 0.2.0(@mastra/core@1.63.0(@bufbuild/protobuf@2.14.0)(bufferutil@4.1.0)(express@5.2.1)(utf-8-validate@6.0.6)(zod@4.4.3))(@modelcontextprotocol/sdk@1.29.0(zod@4.4.3))(@upstash/box@0.5.3(zod@4.4.3))(@vercel/sandbox@2.9.2)(bufferutil@4.1.0)(e2b@2.46.0)(utf-8-validate@6.0.6)(ws@8.21.0(bufferutil@4.1.0)(utf-8-validate@6.0.6))
       '@pierre/diffs':
         specifier: 'catalog:'
         version: 1.3.0-beta.10(patch_hash=7ef7cb0cbabb17c15cdb137554068b36f15f6f5265e73fb51452aa3380db91aa)(@shikijs/themes@4.3.0)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
@@ -4209,10 +4209,9 @@ packages:
   '@opencode-ai/sdk@1.15.13':
     resolution: {integrity: sha512-4TwojIoQ8EG6/mVBuUVYZXiFcwNmiiytEnjnvyuvSJjGwFIlw2YIBFxtSVC3FbwwbwHT63teh1RHiQUUC4U5xw==}
 
-  '@opencoredev/sandbox-sdk@file:../sandbox-sdk/packages/sdk':
-    resolution: {directory: ../sandbox-sdk/packages/sdk, type: directory}
+  '@opencoredev/sandbox-sdk@0.2.0':
+    resolution: {integrity: sha512-VBOz1yE+HmZ2iw6WfE5+3aVN8eu490a5nXtE2ikqjHXDZ5OjoDG3T39fIogUXf4N4f7zo+WpNyMP9SIC6b6sBw==}
     engines: {node: '>=22 <26'}
-    hasBin: true
     peerDependencies:
       '@ai-sdk/harness': ^1.0.0
       '@asciidev/box-sdk': ^0.0.24
@@ -13892,7 +13891,7 @@ snapshots:
       '@aws-crypto/sha256-js': 5.2.0
       '@aws-crypto/supports-web-crypto': 5.2.0
       '@aws-crypto/util': 5.2.0
-      '@aws-sdk/types': 3.973.10
+      '@aws-sdk/types': 3.974.5
       '@aws-sdk/util-locate-window': 3.965.5
       '@smithy/util-utf8': 2.3.0
       tslib: 2.8.1
@@ -13900,7 +13899,7 @@ snapshots:
   '@aws-crypto/sha256-js@5.2.0':
     dependencies:
       '@aws-crypto/util': 5.2.0
-      '@aws-sdk/types': 3.973.10
+      '@aws-sdk/types': 3.974.5
       tslib: 2.8.1
 
   '@aws-crypto/supports-web-crypto@5.2.0':
@@ -14267,9 +14266,9 @@ snapshots:
 
   '@aws-sdk/signature-v4-multi-region@3.996.31':
     dependencies:
-      '@aws-sdk/types': 3.973.10
+      '@aws-sdk/types': 3.974.5
       '@smithy/signature-v4': 5.4.6
-      '@smithy/types': 4.14.3
+      '@smithy/types': 4.17.2
       tslib: 2.8.1
 
   '@aws-sdk/signature-v4-multi-region@3.996.46':
@@ -14281,11 +14280,11 @@ snapshots:
 
   '@aws-sdk/token-providers@3.1062.0':
     dependencies:
-      '@aws-sdk/core': 3.974.17
+      '@aws-sdk/core': 3.977.9
       '@aws-sdk/nested-clients': 3.997.16
-      '@aws-sdk/types': 3.973.10
-      '@smithy/core': 3.24.6
-      '@smithy/types': 4.14.3
+      '@aws-sdk/types': 3.974.5
+      '@smithy/core': 3.33.3
+      '@smithy/types': 4.17.2
       tslib: 2.8.1
 
   '@aws-sdk/token-providers@3.1116.0':
@@ -14322,7 +14321,7 @@ snapshots:
 
   '@aws-sdk/xml-builder@3.972.27':
     dependencies:
-      '@smithy/types': 4.14.3
+      '@smithy/types': 4.17.2
       fast-xml-parser: 5.7.3
       tslib: 2.8.1
 
@@ -16915,7 +16914,7 @@ snapshots:
       openai: 6.26.0(ws@8.21.0(bufferutil@4.1.0)(utf-8-validate@6.0.6))(zod@4.4.3)
       partial-json: 0.1.7
       proxy-agent: 6.5.0
-      undici: 7.27.1
+      undici: 7.29.0
       zod-to-json-schema: 3.25.2(zod@4.4.3)
     transitivePeerDependencies:
       - '@modelcontextprotocol/sdk'
@@ -16944,7 +16943,7 @@ snapshots:
       minimatch: 10.2.5
       proper-lockfile: 4.1.2
       strip-ansi: 7.2.0
-      undici: 7.27.1
+      undici: 7.29.0
       yaml: 2.9.0
     optionalDependencies:
       '@mariozechner/clipboard': 0.3.9
@@ -17433,7 +17432,7 @@ snapshots:
     dependencies:
       cross-spawn: 7.0.6
 
-  '@opencoredev/sandbox-sdk@file:../sandbox-sdk/packages/sdk(@mastra/core@1.63.0(@bufbuild/protobuf@2.14.0)(bufferutil@4.1.0)(express@5.2.1)(utf-8-validate@6.0.6)(zod@4.4.3))(@modelcontextprotocol/sdk@1.29.0(zod@4.4.3))(@upstash/box@0.5.3(zod@4.4.3))(@vercel/sandbox@2.9.2)(bufferutil@4.1.0)(e2b@2.46.0)(utf-8-validate@6.0.6)(ws@8.21.0(bufferutil@4.1.0)(utf-8-validate@6.0.6))':
+  '@opencoredev/sandbox-sdk@0.2.0(@mastra/core@1.63.0(@bufbuild/protobuf@2.14.0)(bufferutil@4.1.0)(express@5.2.1)(utf-8-validate@6.0.6)(zod@4.4.3))(@modelcontextprotocol/sdk@1.29.0(zod@4.4.3))(@upstash/box@0.5.3(zod@4.4.3))(@vercel/sandbox@2.9.2)(bufferutil@4.1.0)(e2b@2.46.0)(utf-8-validate@6.0.6)(ws@8.21.0(bufferutil@4.1.0)(utf-8-validate@6.0.6))':
     dependencies:
       '@rivet-dev/agentos-core': 0.2.15(@modelcontextprotocol/sdk@1.29.0(zod@4.4.3))(bufferutil@4.1.0)(utf-8-validate@6.0.6)(ws@8.21.0(bufferutil@4.1.0)(utf-8-validate@6.0.6))
     optionalDependencies:
@@ -18781,8 +18780,8 @@ snapshots:
 
   '@smithy/fetch-http-handler@5.4.6':
     dependencies:
-      '@smithy/core': 3.24.6
-      '@smithy/types': 4.14.3
+      '@smithy/core': 3.33.3
+      '@smithy/types': 4.17.2
       tslib: 2.8.1
 
   '@smithy/fetch-http-handler@5.7.2':
@@ -18808,8 +18807,8 @@ snapshots:
 
   '@smithy/node-http-handler@4.7.7':
     dependencies:
-      '@smithy/core': 3.24.6
-      '@smithy/types': 4.14.3
+      '@smithy/core': 3.33.3
+      '@smithy/types': 4.17.2
       tslib: 2.8.1
 
   '@smithy/shared-ini-file-loader@4.5.6':
@@ -18819,8 +18818,8 @@ snapshots:
 
   '@smithy/signature-v4@5.4.6':
     dependencies:
-      '@smithy/core': 3.24.6
-      '@smithy/types': 4.14.3
+      '@smithy/core': 3.33.3
+      '@smithy/types': 4.17.2
       tslib: 2.8.1
 
   '@smithy/signature-v4@5.7.3':


### PR DESCRIPTION
## What Changed

- Added a server-wide local execution setting with `approval-required` as the default and `full-access` as an explicit opt-in.
- Applied the setting to new web and mobile threads and to local bot and group turns, including existing threads that still store the legacy full-access mode.
- Kept cloud bot sandboxes unattended and kept persisted legacy event decoding separate from new command defaults.
- Updated user documentation and focused coverage for settings, command defaults, drafts, bot creation, sandbox resolution, and follow-up turns.

## Why

Local file and shell tools currently run without approval unless a user changes each thread. Local execution should ask by default, while users who want unattended local work can opt into full access once in General settings.

Sensitive send, pay, delete, production, and secret actions remain on their separate always-ask path.

## UI Changes

Adds a **Local execution** selector to Settings → General. Browser screenshots are not included because browser access was not authorized for this run.

## Testing

- `vp test run packages/contracts/src/settings.test.ts packages/contracts/src/orchestration.test.ts packages/contracts/src/botConfig.test.ts apps/web/src/components/roster/botSandbox.test.ts apps/web/src/composerDraftStore.test.ts apps/web/src/components/settings/settingsSearch.test.ts apps/web/src/components/sidebar/SidebarChrome.test.ts` — 208 tests passed
- `vp run --filter @t3tools/contracts --filter @t3tools/web typecheck`
- Type-aware lint for the changed mobile files
- Targeted lint and formatting for all changed files

## Checklist

- [x] This PR is small and focused
- [x] I explained what changed and why
- [ ] I included before/after screenshots for UI changes
- [x] A video is not applicable because this change adds no animation

LEO-276
