### PR TITLE
fix(usage): stabilize provider logos and labels

### DIFF
--- a/apps/mobile/src/features/usage/usageProviders.ts
+++ b/apps/mobile/src/features/usage/usageProviders.ts
@@ -8,7 +8,7 @@ import { useAppearancePreferences } from "../settings/appearance/AppearancePrefe
 export const PROVIDER_ORDER: readonly UsageProviderKind[] = ["codex", "claude"];
 
 export const PROVIDER_LABEL: Record<UsageProviderKind, string> = {
-  claude: "Claude Code",
+  claude: "Claude",
   codex: "Codex",
 };
 

--- a/apps/web/src/components/usage/UsageCharts.test.tsx
+++ b/apps/web/src/components/usage/UsageCharts.test.tsx
@@ -1,0 +1,24 @@
+import { renderToStaticMarkup } from "react-dom/server";
+import { describe, expect, it } from "vite-plus/test";
+
+import { UsagePlanMeters } from "./UsageCharts";
+
+describe("UsagePlanMeters", () => {
+  it("renders the ChatGPT logo without a public asset request", () => {
+    const markup = renderToStaticMarkup(
+      <UsagePlanMeters
+        limits={{
+          provider: "openai-codex",
+          status: "ok",
+          plan: "Pro",
+          message: null,
+          windows: [],
+        }}
+      />,
+    );
+
+    expect(markup).toContain("ChatGPT · Pro");
+    expect(markup).toContain("<svg");
+    expect(markup).not.toContain("/provider-icons/openai.svg");
+  });
+});

--- a/apps/web/src/components/usage/UsageCharts.tsx
+++ b/apps/web/src/components/usage/UsageCharts.tsx
@@ -18,7 +18,7 @@ import { Grid } from "../dither-kit/grid";
 import { Tooltip } from "../dither-kit/tooltip";
 import { XAxis } from "../dither-kit/x-axis";
 import { YAxis } from "../dither-kit/y-axis";
-import { ClaudeAI, CursorIcon, type Icon } from "../Icons";
+import { ClaudeAI, CursorIcon, GrokIcon, type Icon, OpenAI } from "../Icons";
 import { PROVIDER_ORDER, PROVIDER_PRESENTATION, providersWithUsage } from "./usageProviders";
 
 export const PLAN_PROVIDER_PRESENTATION: Record<
@@ -29,10 +29,10 @@ export const PLAN_PROVIDER_PRESENTATION: Record<
     readonly color: DitherColor;
   }
 > = {
-  "openai-codex": { label: "ChatGPT", icon: "/provider-icons/openai.svg", color: "green" },
+  "openai-codex": { label: "ChatGPT", icon: OpenAI, color: "green" },
   anthropic: { label: "Claude", icon: ClaudeAI, color: "orange" },
   cursor: { label: "Cursor", icon: CursorIcon, color: "blue" },
-  xai: { label: "Grok", icon: "/provider-icons/xai.svg", color: "grey" },
+  xai: { label: "Grok", icon: GrokIcon, color: "grey" },
   "kimi-for-coding": {
     label: "Kimi For Coding",
     icon: "/provider-icons/kimi-for-coding.svg",

--- a/apps/web/src/components/usage/UsagePage.test.tsx
+++ b/apps/web/src/components/usage/UsagePage.test.tsx
@@ -182,4 +182,48 @@ describe("UsagePage", () => {
     const markup = renderToStaticMarkup(<UsagePage />);
     expect(markup).toContain("anthropic");
   });
+
+  it("labels model activity by its transcript provider, not its model name", () => {
+    testState.useUsage.mockReturnValue({
+      merged: {
+        ...mergeUsage([], USAGE_CONTRACT_VERSION),
+        models: [
+          {
+            provider: "codex" as const,
+            model: "claude-opus-5",
+            costUsd: 0,
+            totalTokens: 31_000_000,
+            records: 1,
+            costShare: 0,
+          },
+          {
+            provider: "claude" as const,
+            model: "gpt-5.6-sol",
+            costUsd: 0,
+            totalTokens: 1_000,
+            records: 1,
+            costShare: 0,
+          },
+        ],
+      },
+      environments: [
+        {
+          environmentId: "env-1",
+          label: "This Mac",
+          isPending: false,
+          error: null,
+          summary: { contractVersion: USAGE_CONTRACT_VERSION },
+        },
+      ],
+      isPending: false,
+      isPartial: false,
+      refresh: vi.fn(),
+    });
+
+    const markup = renderToStaticMarkup(<UsagePage />);
+
+    expect(markup).toContain("Codex · claude-opus-5");
+    expect(markup).toContain("Claude · gpt-5.6-sol");
+    expect(markup).not.toContain("Claude · claude-opus-5");
+  });
 });

--- a/apps/web/src/components/usage/usageProviders.ts
+++ b/apps/web/src/components/usage/usageProviders.ts
@@ -20,7 +20,7 @@ export const PROVIDER_PRESENTATION = {
     mark: OpenAI,
   },
   claude: {
-    label: "Claude Code",
+    label: "Claude",
     color: "#d97757",
     mark: ClaudeAI,
   },


### PR DESCRIPTION
The Usage view loaded some provider logos through root-relative public assets, which could fail in packaged and remote clients. It also called transcript activity "Claude Code" even when Akeru did not enable that driver.

This uses bundled SVG components for the ChatGPT and Grok marks, labels Claude transcript activity as Claude across web and mobile, and keeps model rows attributed to the transcript provider instead of inferring the provider from the model name. Focused tests cover inline logo rendering and cross-provider model names.

Built with GPT-5.6 Sol through the Codex harness.