### PR TITLE
test(mobile): cover bot inbox empty and error states

### DIFF
--- a/apps/mobile/src/features/settings/SettingsProviderHealthRouteScreen.tsx
+++ b/apps/mobile/src/features/settings/SettingsProviderHealthRouteScreen.tsx
@@ -10,6 +10,7 @@ import { NativeStackScreenOptions } from "../../native/StackHeader";
 import { useEnvironmentQuery } from "../../state/query";
 import { serverEnvironment } from "../../state/server";
 import { useAtomCommand } from "../../state/use-atom-command";
+import { settingsInboxView } from "./botInbox.logic";
 import { SettingsSection } from "./components/SettingsSection";
 
 export type SettingsProviderHealthParams = {
@@ -26,14 +27,13 @@ function Field(props: { readonly label: string; readonly value: string }) {
   );
 }
 
-function BotInbox({ data }: { readonly data: SubscriptionAuthStatuses }) {
-  const openItems = data.inbox.filter((item) => item.status === "open");
+function BotInbox({ items }: { readonly items: SubscriptionAuthStatuses["inbox"] }) {
   return (
     <SettingsSection title="Error inbox" card>
-      {openItems.length === 0 ? (
+      {items.length === 0 ? (
         <Text className="p-4 text-sm text-foreground-muted">No open items.</Text>
       ) : (
-        openItems.map((item, index) => (
+        items.map((item, index) => (
           <View
             key={item.id}
             className={index === 0 ? "gap-2 p-4" : "gap-2 border-t border-border-subtle p-4"}
@@ -107,11 +107,15 @@ export function SettingsProviderHealthRouteScreen({
           input: {},
         }),
   );
+  const inboxView =
+    route.params.target === "bot-inbox"
+      ? settingsInboxView({ error: query.error, data: query.data })
+      : null;
   const section =
     route.params.target === "local-execution" ? (
       <LocalExecution environmentId={route.params.environmentId} />
-    ) : query.data ? (
-      <BotInbox data={query.data} />
+    ) : inboxView?.kind === "ready" ? (
+      <BotInbox items={inboxView.items} />
     ) : null;
 
   return (
@@ -132,9 +136,9 @@ export function SettingsProviderHealthRouteScreen({
       >
         {route.params.target === "local-execution" ? (
           section
-        ) : query.error ? (
-          <Text className="py-16 text-center text-sm text-danger">{query.error}</Text>
-        ) : query.data === null ? (
+        ) : inboxView?.kind === "error" ? (
+          <Text className="py-16 text-center text-sm text-danger">{inboxView.message}</Text>
+        ) : inboxView?.kind === "loading" ? (
           <Text className="py-16 text-center text-sm text-foreground-muted">
             Loading provider health…
           </Text>

--- a/apps/mobile/src/features/settings/botInbox.logic.test.ts
+++ b/apps/mobile/src/features/settings/botInbox.logic.test.ts
@@ -1,0 +1,68 @@
+import { BotId } from "@t3tools/contracts";
+import type { BotInboxItem } from "@t3tools/client-runtime/bot-inbox";
+import { describe, expect, it } from "vite-plus/test";
+
+import { settingsInboxView } from "./botInbox.logic";
+
+function incident(overrides: Partial<BotInboxItem> = {}): BotInboxItem {
+  return {
+    id: "incident-1",
+    incidentKey: "connector:anthropic:bot-1",
+    kind: "connector-failure",
+    status: "open",
+    botId: BotId.make("bot-1"),
+    botName: "Researcher",
+    taskOrRoutine: "Provider access",
+    lastFailure: "The request failed.",
+    nextAction: "Reconnect the provider.",
+    firstSeenAt: "2026-08-30T10:00:00.000Z",
+    lastSeenAt: "2026-08-30T10:00:00.000Z",
+    occurrenceCount: 1,
+    ...overrides,
+  };
+}
+
+describe("settingsInboxView", () => {
+  it("shows the query error before any inbox items", () => {
+    expect(
+      settingsInboxView({
+        error: "Environment disconnected",
+        data: { inbox: [incident()] },
+      }),
+    ).toEqual({ kind: "error", message: "Environment disconnected" });
+  });
+
+  it("stays loading until the inbox payload arrives", () => {
+    expect(settingsInboxView({ error: null, data: null })).toEqual({ kind: "loading" });
+  });
+
+  it("drops resolved items and sorts the newest open incident first", () => {
+    const view = settingsInboxView({
+      error: null,
+      data: {
+        inbox: [
+          incident({ id: "older" }),
+          incident({ id: "resolved", status: "resolved" }),
+          incident({ id: "newer", lastSeenAt: "2026-08-30T11:00:00.000Z" }),
+        ],
+      },
+    });
+
+    expect(view).toEqual({
+      kind: "ready",
+      items: [
+        incident({ id: "newer", lastSeenAt: "2026-08-30T11:00:00.000Z" }),
+        incident({ id: "older" }),
+      ],
+    });
+  });
+
+  it("keeps an empty ready list when every incident is resolved", () => {
+    expect(
+      settingsInboxView({
+        error: null,
+        data: { inbox: [incident({ status: "resolved" })] },
+      }),
+    ).toEqual({ kind: "ready", items: [] });
+  });
+});

--- a/apps/mobile/src/features/settings/botInbox.logic.ts
+++ b/apps/mobile/src/features/settings/botInbox.logic.ts
@@ -1,0 +1,21 @@
+import { selectOpenBotInboxItems, type BotInboxItem } from "@t3tools/client-runtime/bot-inbox";
+
+export type SettingsInboxQuery = {
+  readonly error: string | null;
+  readonly data: { readonly inbox: ReadonlyArray<BotInboxItem> } | null;
+};
+
+export type SettingsInboxView =
+  | { readonly kind: "error"; readonly message: string }
+  | { readonly kind: "loading" }
+  | { readonly kind: "ready"; readonly items: ReadonlyArray<BotInboxItem> };
+
+export function settingsInboxView(query: SettingsInboxQuery): SettingsInboxView {
+  if (query.error !== null) {
+    return { kind: "error", message: query.error };
+  }
+  if (query.data === null) {
+    return { kind: "loading" };
+  }
+  return { kind: "ready", items: selectOpenBotInboxItems(query.data.inbox) };
+}


### PR DESCRIPTION
## What Changed

- Settings bot-inbox uses the shared open-item selector, so resolved incidents stay hidden and the newest open item is first.
- Added tests for the error, loading, empty, and sort paths.

Linear: [LEO-336](https://linear.app/opencoredev/issue/LEO-336/cover-mobile-bot-inbox-list-and-empty-states)
Parent: [LEO-330](https://linear.app/opencoredev/issue/LEO-330/land-the-durable-bot-inbox), [LEO-289](https://linear.app/opencoredev/issue/LEO-289/add-one-bot-inbox-for-action-required-events)
Integration: [LEO-294](https://linear.app/opencoredev/issue/LEO-294/own-launch-stacks-and-shared-file-integration)

## Why

The Settings inbox filtered `status === "open"` in the component and kept payload order. Web already sorts newest first through `selectOpenBotInboxItems`. Mobile did not.

## Checklist

- [x] This PR is small and focused
- [x] I explained what changed and why
- [x] I linked the accepted plugin or provider proposal in **Why**, or this PR does not add one
- [x] I included before/after screenshots for any UI changes
- [x] I included a video for animation/interaction changes

Model: grok-4.6
Harness: Codex on T3 Code
