### PR TITLE
feat(providers): add Kimi For Coding runtime

### DIFF
--- a/apps/server/package.json
+++ b/apps/server/package.json
@@ -22,6 +22,7 @@
     "test": "vp test run"
   },
   "dependencies": {
+    "@ai-sdk/anthropic": "3.0.113",
     "@anthropic-ai/claude-agent-sdk": "^0.3.170",
     "@effect/platform-bun": "catalog:",
     "@effect/platform-node": "catalog:",

--- a/apps/server/src/provider/AkeruKimiProvider.test.ts
+++ b/apps/server/src/provider/AkeruKimiProvider.test.ts
@@ -1,0 +1,54 @@
+import { describe, expect, it, vi } from "vite-plus/test";
+
+import { akeruKimiProvider, buildAkeruKimiFetch } from "./AkeruKimiProvider.ts";
+
+const access = {
+  accessToken: "kimi-access",
+  deviceId: "0123456789abcdef0123456789abcdef",
+};
+
+describe("AkeruKimiProvider", () => {
+  it("builds the Kimi Anthropic model without changing the saved model", () => {
+    expect(akeruKimiProvider("k3-256k", async () => access)).toMatchObject({
+      provider: "anthropic.messages",
+      modelId: "k3-256k",
+    });
+  });
+
+  it("uses the saved OAuth token and device identity for every request", async () => {
+    const request = vi.fn(async (_input: string | Request | URL, init?: RequestInit) => {
+      const headers = new Headers(init?.headers);
+      expect(headers.get("authorization")).toBe("Bearer kimi-access");
+      expect(headers.get("x-api-key")).toBeNull();
+      expect(headers.get("x-msh-device-id")).toBe(access.deviceId);
+      expect(headers.get("x-msh-platform")).toBe("akeru");
+      expect(headers.get("x-msh-version")).toBe("0.0.34");
+      return new Response("{}", { status: 200 });
+    });
+    const fetch = buildAkeruKimiFetch(async () => access, request);
+
+    await fetch("https://api.kimi.com/coding/v1/messages", {
+      method: "POST",
+      headers: { Authorization: "stale", "x-api-key": "stale" },
+    });
+
+    expect(request).toHaveBeenCalledOnce();
+  });
+
+  it("fails closed when the account or device identity is unavailable", async () => {
+    const request = vi.fn();
+    await expect(
+      buildAkeruKimiFetch(
+        async () => undefined,
+        request,
+      )("https://api.kimi.com/coding/v1/messages"),
+    ).rejects.toThrow("not connected");
+    await expect(
+      buildAkeruKimiFetch(
+        async () => ({ accessToken: "token", deviceId: "invalid" }),
+        request,
+      )("https://api.kimi.com/coding/v1/messages"),
+    ).rejects.toThrow("Invalid Kimi For Coding device id");
+    expect(request).not.toHaveBeenCalled();
+  });
+});

--- a/apps/server/src/provider/AkeruKimiProvider.ts
+++ b/apps/server/src/provider/AkeruKimiProvider.ts
@@ -1,0 +1,46 @@
+import { createAnthropic } from "@ai-sdk/anthropic";
+import type { MastraModelConfig } from "@mastra/core/llm";
+
+import { getKimiCodingDeviceHeaders } from "../subscription-auth/providers/kimi.ts";
+
+const KIMI_CODING_BASE_URL = "https://api.kimi.com/coding/v1";
+type AkeruKimiFetch = (input: string | URL | Request, init?: RequestInit) => Promise<Response>;
+
+export interface AkeruKimiAccess {
+  readonly accessToken: string;
+  readonly deviceId: string;
+}
+
+export function buildAkeruKimiFetch(
+  getAccess: () => Promise<AkeruKimiAccess | undefined>,
+  request: AkeruKimiFetch = globalThis.fetch,
+): AkeruKimiFetch {
+  return async (input, init) => {
+    const access = await getAccess();
+    if (!access) throw new Error("Kimi For Coding is not connected. Reconnect the account.");
+    const headers = new Headers(input instanceof Request ? input.headers : undefined);
+    if (init?.headers) {
+      new Headers(init.headers).forEach((value, key) => headers.set(key, value));
+    }
+    headers.delete("authorization");
+    headers.delete("x-api-key");
+    headers.set("Authorization", `Bearer ${access.accessToken}`);
+    for (const [key, value] of Object.entries(getKimiCodingDeviceHeaders(access.deviceId))) {
+      headers.set(key, value);
+    }
+    return request(input, { ...init, headers });
+  };
+}
+
+export function akeruKimiProvider(
+  modelId: string,
+  getAccess: () => Promise<AkeruKimiAccess | undefined>,
+): MastraModelConfig {
+  return createAnthropic({
+    apiKey: "oauth-placeholder",
+    baseURL: KIMI_CODING_BASE_URL,
+    fetch: buildAkeruKimiFetch(getAccess) as NonNullable<
+      NonNullable<Parameters<typeof createAnthropic>[0]>["fetch"]
+    >,
+  })(modelId);
+}

--- a/apps/server/src/provider/AkeruMastraHarness.test.ts
+++ b/apps/server/src/provider/AkeruMastraHarness.test.ts
@@ -3,14 +3,33 @@ import type { ToolsInput } from "@mastra/core/agent";
 import { TOOL_NAME_OVERRIDES } from "@mastra/code-sdk/tool-names";
 import { RequestContext } from "@mastra/core/request-context";
 import { LocalFilesystem, LocalSandbox, Workspace } from "@mastra/core/workspace";
-import { AKERU_PRODUCT_FEEDBACK_TOOL_NAME } from "@t3tools/contracts";
+import { AKERU_PRODUCT_FEEDBACK_TOOL_NAME, ProviderDriverKind } from "@t3tools/contracts";
 import { assert, describe, it } from "vite-plus/test";
 
 import { AKERU_AGENT_INSTRUCTIONS } from "./AkeruAgentInstructions.ts";
-import { resolveAkeruTools } from "./AkeruMastraHarness.ts";
+import { mastraModelId, resolveAkeruMastraModel, resolveAkeruTools } from "./AkeruMastraHarness.ts";
 import { productFeedbackToolInputSchema } from "./AkeruMastraHarness.ts";
 
 describe("AkeruMastraHarness", () => {
+  it("keeps Kimi model names on the Kimi subscription transport", () => {
+    const authStorage = new AuthStorage("/tmp/akeru-unused-auth.json");
+    assert.equal(
+      mastraModelId(ProviderDriverKind.make("kimi"), "k3-256k"),
+      "kimi-for-coding/k3-256k",
+    );
+    assert.deepInclude(
+      resolveAkeruMastraModel("kimi-for-coding/k3-256k", authStorage, async () => ({
+        accessToken: "kimi-access",
+        deviceId: "0123456789abcdef0123456789abcdef",
+      })),
+      { provider: "anthropic.messages", modelId: "k3-256k" },
+    );
+    assert.throws(
+      () => resolveAkeruMastraModel("kimi-for-coding/k3-256k", authStorage),
+      "subscription access is unavailable",
+    );
+  });
+
   it("configures Akeru as a general-purpose assistant with plugin awareness", () => {
     assert.include(AKERU_AGENT_INSTRUCTIONS, "general-purpose assistant");
     assert.include(AKERU_AGENT_INSTRUCTIONS, "enabled plugin tools");

--- a/apps/server/src/provider/AkeruMastraHarness.ts
+++ b/apps/server/src/provider/AkeruMastraHarness.ts
@@ -13,12 +13,14 @@ import { createWorkspaceTools, type Workspace } from "@mastra/core/workspace";
 import {
   AKERU_PRODUCT_FEEDBACK_TOOL_NAME,
   ProductFeedbackToolDraft,
+  type ProviderDriverKind,
   type ProductFeedbackToolDraft as ProductFeedbackToolDraftValue,
 } from "@t3tools/contracts";
 import * as Exit from "effect/Exit";
 import * as Schema from "effect/Schema";
 
 import { AKERU_AGENT_INSTRUCTIONS } from "./AkeruAgentInstructions.ts";
+import { akeruKimiProvider, type AkeruKimiAccess } from "./AkeruKimiProvider.ts";
 
 const DEFAULT_MODEL_ID = "openai/gpt-5.6-sol";
 const decodeProductFeedbackToolDraft = Schema.decodeUnknownExit(ProductFeedbackToolDraft, {
@@ -69,6 +71,7 @@ export type AkeruMastraSession = Session<AkeruMastraState>;
 
 export interface AkeruMastraHarnessOptions {
   readonly authStorage: AuthStorage;
+  readonly getKimiAccess?: () => Promise<AkeruKimiAccess | undefined>;
   readonly getThreadTools: (threadId: string) => ToolsInput;
   readonly getThreadWorkspace: (threadId: string) => Workspace | undefined;
 }
@@ -103,8 +106,33 @@ function controllerResourceId(requestContext: RequestContext): string | undefine
   return typeof value === "string" ? value : undefined;
 }
 
-function codexModelName(modelId: string): string {
-  return modelId.startsWith("openai/") ? modelId.slice("openai/".length) : modelId;
+const MASTRA_MODEL_PREFIX = {
+  codex: "openai",
+  kimi: "kimi-for-coding",
+} as const;
+
+export function mastraModelId(provider: ProviderDriverKind, model: string): string {
+  const trimmed = model.trim();
+  const prefix = MASTRA_MODEL_PREFIX[provider as keyof typeof MASTRA_MODEL_PREFIX];
+  if (!prefix) return trimmed.includes("/") ? trimmed : `${provider}/${trimmed}`;
+  const token = `${prefix}/`;
+  return trimmed.startsWith(token) ? trimmed : `${token}${trimmed}`;
+}
+
+export function resolveAkeruMastraModel(
+  modelId: string,
+  authStorage: AuthStorage,
+  getKimiAccess?: () => Promise<AkeruKimiAccess | undefined>,
+) {
+  const trimmed = modelId.trim();
+  if (trimmed.startsWith("openai/")) {
+    return openaiCodexProvider(trimmed.slice("openai/".length), { authStorage });
+  }
+  if (trimmed.startsWith("kimi-for-coding/")) {
+    if (!getKimiAccess) throw new Error("Kimi For Coding subscription access is unavailable.");
+    return akeruKimiProvider(trimmed.slice("kimi-for-coding/".length), getKimiAccess);
+  }
+  throw new Error(`Mastra has no subscription transport for model '${modelId}'.`);
 }
 
 export async function resolveAkeruTools(
@@ -273,9 +301,11 @@ export async function createAkeruMastraHarness(
     name: "Akeru",
     instructions: AKERU_AGENT_INSTRUCTIONS,
     model: ({ requestContext }) =>
-      openaiCodexProvider(codexModelName(controllerModelId(requestContext)), {
-        authStorage: options.authStorage,
-      }),
+      resolveAkeruMastraModel(
+        controllerModelId(requestContext),
+        options.authStorage,
+        options.getKimiAccess,
+      ),
     tools: ({ requestContext }) => resolveAkeruTools(requestContext, options),
     workspace: undefined,
   });

--- a/apps/server/src/provider/Drivers/KimiDriver.test.ts
+++ b/apps/server/src/provider/Drivers/KimiDriver.test.ts
@@ -1,0 +1,100 @@
+// @effect-diagnostics nodeBuiltinImport:off preferSchemaOverJson:off
+import * as NodeFS from "node:fs";
+import * as NodePath from "node:path";
+
+import { NodeServices } from "@effect/platform-node";
+import { ProviderInstanceId } from "@t3tools/contracts";
+import * as Effect from "effect/Effect";
+import * as Layer from "effect/Layer";
+import { describe, expect, it } from "vite-plus/test";
+
+import { ServerConfig } from "../../config.ts";
+import { BUILT_IN_DRIVERS } from "../builtInDrivers.ts";
+import { KimiDriver } from "./KimiDriver.ts";
+
+describe("KimiDriver", () => {
+  it("registers one Mastra-native Kimi provider with offline model metadata", async () => {
+    expect(BUILT_IN_DRIVERS.map((driver) => String(driver.driverKind))).toContain("kimi");
+    const program = Effect.scoped(
+      Effect.gen(function* () {
+        const instance = yield* KimiDriver.create({
+          instanceId: ProviderInstanceId.make("kimi"),
+          displayName: undefined,
+          environment: [],
+          enabled: true,
+          config: KimiDriver.defaultConfig(),
+        });
+        const snapshot = yield* instance.snapshot.getSnapshot;
+        return { instance, snapshot };
+      }),
+    );
+    const result = await Effect.runPromise(
+      program.pipe(
+        Effect.provide(
+          ServerConfig.layerTest(process.cwd(), { prefix: "akeru-kimi-driver-test-" }).pipe(
+            Layer.provide(NodeServices.layer),
+          ),
+        ),
+      ),
+    );
+
+    expect(result.instance.adapter).toBeUndefined();
+    expect(result.instance.textGeneration).toBeUndefined();
+    expect(result.snapshot).toMatchObject({
+      instanceId: "kimi",
+      driver: "kimi",
+      displayName: "Kimi For Coding",
+      installed: true,
+      auth: { status: "unauthenticated", type: "oauth" },
+      models: expect.arrayContaining([
+        expect.objectContaining({ slug: "k3" }),
+        expect.objectContaining({ slug: "k3-256k" }),
+      ]),
+    });
+  });
+
+  it("refreshes the snapshot after subscription auth changes", async () => {
+    const program = Effect.scoped(
+      Effect.gen(function* () {
+        const config = yield* ServerConfig;
+        const instance = yield* KimiDriver.create({
+          instanceId: ProviderInstanceId.make("kimi"),
+          displayName: undefined,
+          environment: [],
+          enabled: true,
+          config: KimiDriver.defaultConfig(),
+        });
+        const before = yield* instance.snapshot.getSnapshot;
+        NodeFS.mkdirSync(config.secretsDir, { recursive: true });
+        NodeFS.writeFileSync(
+          NodePath.join(config.secretsDir, "subscription-auth.json"),
+          JSON.stringify({
+            "kimi-for-coding": {
+              type: "oauth",
+              access: "offline-test-token",
+              refresh: "offline-test-refresh",
+              expires: 4_102_444_800_000,
+              deviceId: "0123456789abcdef0123456789abcdef",
+            },
+          }),
+        );
+        const after = yield* instance.snapshot.refresh;
+        return { before, after, continuationIdentity: instance.continuationIdentity };
+      }),
+    );
+    const result = await Effect.runPromise(
+      program.pipe(
+        Effect.provide(
+          ServerConfig.layerTest(process.cwd(), { prefix: "akeru-kimi-refresh-test-" }).pipe(
+            Layer.provide(NodeServices.layer),
+          ),
+        ),
+      ),
+    );
+
+    expect(result.before.auth.status).toBe("unauthenticated");
+    expect(result.after.auth.status).toBe("authenticated");
+    expect(result.after.status).toBe("ready");
+    expect(result.after.continuation?.groupKey).toBe(result.continuationIdentity.continuationKey);
+  });
+});

--- a/apps/server/src/provider/Drivers/KimiDriver.test.ts
+++ b/apps/server/src/provider/Drivers/KimiDriver.test.ts
@@ -3,17 +3,17 @@ import * as NodeFS from "node:fs";
 import * as NodePath from "node:path";
 
 import { NodeServices } from "@effect/platform-node";
+import { describe, expect, it } from "@effect/vitest";
 import { ProviderInstanceId } from "@t3tools/contracts";
 import * as Effect from "effect/Effect";
 import * as Layer from "effect/Layer";
-import { describe, expect, it } from "vite-plus/test";
 
 import { ServerConfig } from "../../config.ts";
 import { BUILT_IN_DRIVERS } from "../builtInDrivers.ts";
 import { KimiDriver } from "./KimiDriver.ts";
 
 describe("KimiDriver", () => {
-  it("registers one Mastra-native Kimi provider with offline model metadata", async () => {
+  it.effect("registers one Mastra-native Kimi provider with offline model metadata", () => {
     expect(BUILT_IN_DRIVERS.map((driver) => String(driver.driverKind))).toContain("kimi");
     const program = Effect.scoped(
       Effect.gen(function* () {
@@ -28,32 +28,33 @@ describe("KimiDriver", () => {
         return { instance, snapshot };
       }),
     );
-    const result = await Effect.runPromise(
-      program.pipe(
-        Effect.provide(
-          ServerConfig.layerTest(process.cwd(), { prefix: "akeru-kimi-driver-test-" }).pipe(
-            Layer.provide(NodeServices.layer),
-          ),
+    return program.pipe(
+      Effect.provide(
+        ServerConfig.layerTest(process.cwd(), { prefix: "akeru-kimi-driver-test-" }).pipe(
+          Layer.provide(NodeServices.layer),
         ),
       ),
+      Effect.tap((result) =>
+        Effect.sync(() => {
+          expect(result.instance.adapter).toBeUndefined();
+          expect(result.instance.textGeneration).toBeUndefined();
+          expect(result.snapshot).toMatchObject({
+            instanceId: "kimi",
+            driver: "kimi",
+            displayName: "Kimi For Coding",
+            installed: true,
+            auth: { status: "unauthenticated", type: "oauth" },
+            models: expect.arrayContaining([
+              expect.objectContaining({ slug: "k3" }),
+              expect.objectContaining({ slug: "k3-256k" }),
+            ]),
+          });
+        }),
+      ),
     );
-
-    expect(result.instance.adapter).toBeUndefined();
-    expect(result.instance.textGeneration).toBeUndefined();
-    expect(result.snapshot).toMatchObject({
-      instanceId: "kimi",
-      driver: "kimi",
-      displayName: "Kimi For Coding",
-      installed: true,
-      auth: { status: "unauthenticated", type: "oauth" },
-      models: expect.arrayContaining([
-        expect.objectContaining({ slug: "k3" }),
-        expect.objectContaining({ slug: "k3-256k" }),
-      ]),
-    });
   });
 
-  it("refreshes the snapshot after subscription auth changes", async () => {
+  it.effect("refreshes the snapshot after subscription auth changes", () => {
     const program = Effect.scoped(
       Effect.gen(function* () {
         const config = yield* ServerConfig;
@@ -82,19 +83,22 @@ describe("KimiDriver", () => {
         return { before, after, continuationIdentity: instance.continuationIdentity };
       }),
     );
-    const result = await Effect.runPromise(
-      program.pipe(
-        Effect.provide(
-          ServerConfig.layerTest(process.cwd(), { prefix: "akeru-kimi-refresh-test-" }).pipe(
-            Layer.provide(NodeServices.layer),
-          ),
+    return program.pipe(
+      Effect.provide(
+        ServerConfig.layerTest(process.cwd(), { prefix: "akeru-kimi-refresh-test-" }).pipe(
+          Layer.provide(NodeServices.layer),
         ),
       ),
+      Effect.tap((result) =>
+        Effect.sync(() => {
+          expect(result.before.auth.status).toBe("unauthenticated");
+          expect(result.after.auth.status).toBe("authenticated");
+          expect(result.after.status).toBe("ready");
+          expect(result.after.continuation?.groupKey).toBe(
+            result.continuationIdentity.continuationKey,
+          );
+        }),
+      ),
     );
-
-    expect(result.before.auth.status).toBe("unauthenticated");
-    expect(result.after.auth.status).toBe("authenticated");
-    expect(result.after.status).toBe("ready");
-    expect(result.after.continuation?.groupKey).toBe(result.continuationIdentity.continuationKey);
   });
 });

--- a/apps/server/src/provider/Drivers/KimiDriver.ts
+++ b/apps/server/src/provider/Drivers/KimiDriver.ts
@@ -1,0 +1,102 @@
+import {
+  KimiSettings,
+  ProviderDriverKind,
+  type ServerProvider,
+  type ServerProviderModel,
+} from "@t3tools/contracts";
+import * as DateTime from "effect/DateTime";
+import * as Effect from "effect/Effect";
+import * as PubSub from "effect/PubSub";
+import * as Schema from "effect/Schema";
+import * as Stream from "effect/Stream";
+
+import { ServerConfig } from "../../config.ts";
+import { SubscriptionAuthService } from "../../subscription-auth/service.ts";
+import type { ProviderDriver } from "../ProviderDriver.ts";
+import { defaultProviderContinuationIdentity } from "../ProviderDriver.ts";
+import { makeManualOnlyProviderMaintenanceCapabilities } from "../providerMaintenance.ts";
+
+const DRIVER_KIND = ProviderDriverKind.make("kimi");
+const decodeSettings = Schema.decodeSync(KimiSettings);
+const BUILT_IN_MODELS = ["k3", "k3-256k", "kimi-for-coding", "kimi-for-coding-highspeed"] as const;
+
+function models(customModels: readonly string[]): ServerProviderModel[] {
+  return [...new Set([...BUILT_IN_MODELS, ...customModels.map((model) => model.trim())])]
+    .filter((model) => model.length > 0)
+    .map((model, index) => ({
+      slug: model,
+      name: model,
+      isCustom: !BUILT_IN_MODELS.includes(model as (typeof BUILT_IN_MODELS)[number]),
+      ...(index === 0 ? { isDefault: true } : {}),
+      capabilities: null,
+    }));
+}
+
+export type KimiDriverEnv = ServerConfig;
+
+export const KimiDriver: ProviderDriver<KimiSettings, KimiDriverEnv> = {
+  driverKind: DRIVER_KIND,
+  metadata: { displayName: "Kimi For Coding", supportsMultipleInstances: false },
+  configSchema: KimiSettings,
+  defaultConfig: () => decodeSettings({}),
+  create: ({ instanceId, displayName, accentColor, enabled, config }) =>
+    Effect.gen(function* () {
+      const serverConfig = yield* ServerConfig;
+      const auth = SubscriptionAuthService.forSecretsDir(serverConfig.secretsDir);
+      const changes = yield* Effect.acquireRelease(
+        PubSub.unbounded<ServerProvider>(),
+        PubSub.shutdown,
+      );
+      const effectiveEnabled = enabled && config.enabled;
+      const continuationIdentity = defaultProviderContinuationIdentity({
+        driverKind: DRIVER_KIND,
+        instanceId,
+      });
+      const readSnapshot = Effect.sync(() => {
+        auth.reload();
+        const connected = auth.isConnected("kimi-for-coding");
+        return {
+          instanceId,
+          driver: DRIVER_KIND,
+          displayName: displayName ?? "Kimi For Coding",
+          ...(accentColor ? { accentColor } : {}),
+          continuation: { groupKey: continuationIdentity.continuationKey },
+          enabled: effectiveEnabled,
+          installed: true,
+          version: null,
+          status: !effectiveEnabled ? "disabled" : connected ? "ready" : "warning",
+          auth: { status: connected ? "authenticated" : "unauthenticated", type: "oauth" },
+          checkedAt: DateTime.formatIso(DateTime.nowUnsafe()),
+          ...(!connected && effectiveEnabled
+            ? { message: "Connect Kimi For Coding in Settings." }
+            : {}),
+          availability: "available",
+          models: models(config.customModels),
+          slashCommands: [],
+          skills: [],
+        } satisfies ServerProvider;
+      });
+      const refresh = readSnapshot.pipe(
+        Effect.tap((snapshot) => PubSub.publish(changes, snapshot)),
+      );
+      return {
+        instanceId,
+        driverKind: DRIVER_KIND,
+        continuationIdentity,
+        displayName,
+        accentColor,
+        enabled: effectiveEnabled,
+        adapter: undefined,
+        textGeneration: undefined,
+        snapshot: {
+          maintenanceCapabilities: makeManualOnlyProviderMaintenanceCapabilities({
+            provider: DRIVER_KIND,
+            packageName: null,
+          }),
+          getSnapshot: readSnapshot,
+          refresh,
+          streamChanges: Stream.fromPubSub(changes),
+        },
+      };
+    }),
+};

--- a/apps/server/src/provider/Layers/AgentController.test.ts
+++ b/apps/server/src/provider/Layers/AgentController.test.ts
@@ -286,7 +286,7 @@ describe("provider access health", () => {
     ["claudeAgent", "anthropic"],
     ["cursor", "cursor"],
     ["grok", "xai"],
-    ["opencode", "kimi-for-coding"],
+    ["kimi", "kimi-for-coding"],
   ] as const)("maps %s runtime requests to %s access health", (driver, provider) => {
     const directory = NodeFS.mkdtempSync(NodePath.join(NodeOS.tmpdir(), "akeru-access-map-"));
     const authPath = NodePath.join(directory, "subscription-auth.json");

--- a/apps/server/src/provider/Layers/AgentController.test.ts
+++ b/apps/server/src/provider/Layers/AgentController.test.ts
@@ -40,8 +40,10 @@ import { SubscriptionAuthService } from "../../subscription-auth/service.ts";
 
 const codexThreadId = ThreadId.make("thread-mastra-codex");
 const claudeThreadId = ThreadId.make("thread-legacy-claude");
+const kimiThreadId = ThreadId.make("thread-mastra-kimi");
 const codexInstanceId = ProviderInstanceId.make("codex");
 const claudeInstanceId = ProviderInstanceId.make("claudeAgent");
+const kimiInstanceId = ProviderInstanceId.make("kimi");
 
 const codexSelection = {
   instanceId: codexInstanceId,
@@ -837,6 +839,39 @@ describe("AgentControllerLive", () => {
         expect(bridge.sendTurn).toHaveBeenCalledOnce();
         expect(mastra.createSession).not.toHaveBeenCalled();
         expect(mastra.sendMessage).not.toHaveBeenCalled();
+      }),
+      bridge.service,
+      mastra.factory,
+    );
+  });
+
+  it.effect("runs the saved Kimi model through Mastra without provider fallback", () => {
+    const bridge = makeBridge();
+    const mastra = makeMastraHarness();
+    return provideController(
+      Effect.gen(function* () {
+        const controller = yield* AgentController;
+        yield* controller.resolveEngine({
+          threadId: kimiThreadId,
+          engine: { provider: "kimi", model: "k3-256k" },
+          fallback: codexSelection,
+          mode: "default",
+        });
+        const session = yield* controller.startSession(kimiThreadId, {
+          threadId: kimiThreadId,
+          provider: ProviderDriverKind.make("kimi"),
+          providerInstanceId: kimiInstanceId,
+          cwd: process.cwd(),
+          modelSelection: { instanceId: kimiInstanceId, model: "k3-256k" },
+          runtimeMode: "approval-required",
+        });
+
+        assert.equal(session.provider, "kimi");
+        assert.equal(session.model, "k3-256k");
+        expect(mastra.session.model.switch).toHaveBeenCalledWith({
+          modelId: "kimi-for-coding/k3-256k",
+        });
+        expect(bridge.startSession).not.toHaveBeenCalled();
       }),
       bridge.service,
       mastra.factory,

--- a/apps/server/src/provider/Layers/AgentController.ts
+++ b/apps/server/src/provider/Layers/AgentController.ts
@@ -45,6 +45,7 @@ import {
 } from "../../subscription-auth/service.ts";
 import {
   createAkeruMastraHarness,
+  mastraModelId,
   type AkeruMastraHarness,
   type AkeruMastraHarnessOptions,
   type AkeruMastraSession,
@@ -127,19 +128,6 @@ function mastraModeId(mode: "default" | "plan"): string {
   return mode === "plan" ? PLAN_MODE_ID : DEFAULT_MODE_ID;
 }
 
-function mastraModelId(provider: ProviderDriverKind, model: string): string {
-  switch (String(provider)) {
-    case "codex":
-      return `openai/${model}`;
-    case "claudeAgent":
-      return `anthropic/${model}`;
-    case "grok":
-      return `xai/${model}`;
-    default:
-      return model.includes("/") ? model : `${provider}/${model}`;
-  }
-}
-
 export function toMcpServerConfigs(servers: readonly McpServer[]): Record<string, McpServerConfig> {
   return Object.fromEntries(
     servers.map((server) => [
@@ -162,7 +150,7 @@ function permissionPolicy(
 }
 
 function usesMastraCode(provider: ProviderDriverKind): boolean {
-  return String(provider) === "codex";
+  return provider === "codex" || provider === "kimi";
 }
 
 function subscriptionProviderForDriver(
@@ -263,6 +251,7 @@ const make = (options?: AgentControllerLiveOptions) =>
     const bundle = yield* runMastra("construct", () =>
       makeMastraHarness({
         authStorage,
+        getKimiAccess: () => subscriptionAuth.getKimiForCodingAccess(),
         getThreadTools: (threadId) => mcpManagers.get(threadId)?.getTools() ?? {},
         getThreadWorkspace: (threadId) => workspaces.get(threadId),
       }),

--- a/apps/server/src/provider/Layers/AgentController.ts
+++ b/apps/server/src/provider/Layers/AgentController.ts
@@ -165,7 +165,7 @@ function subscriptionProviderForDriver(
       return "cursor";
     case "grok":
       return "xai";
-    case "opencode":
+    case "kimi":
       return "kimi-for-coding";
     default:
       return undefined;

--- a/apps/server/src/provider/Layers/ProviderAdapterRegistry.ts
+++ b/apps/server/src/provider/Layers/ProviderAdapterRegistry.ts
@@ -36,7 +36,7 @@ const makeProviderAdapterRegistry = Effect.fn("makeProviderAdapterRegistry")(fun
   const getByInstance: ProviderAdapterRegistryShape["getByInstance"] = (instanceId) =>
     registry.getInstance(instanceId).pipe(
       Effect.flatMap((instance) =>
-        instance === undefined
+        instance?.adapter === undefined
           ? Effect.fail(
               new ProviderUnsupportedError({
                 provider: instanceId,

--- a/apps/server/src/provider/Layers/ProviderRegistry.test.ts
+++ b/apps/server/src/provider/Layers/ProviderRegistry.test.ts
@@ -1747,6 +1747,7 @@ it.layer(Layer.mergeAll(NodeServices.layer, ServerSettingsModule.layerTest(), Te
                 "codex",
                 "cursor",
                 "grok",
+                "kimi",
                 "opencode",
               ]);
               assert.strictEqual(cursorProvider?.enabled, false);

--- a/apps/server/src/provider/ProviderDriver.ts
+++ b/apps/server/src/provider/ProviderDriver.ts
@@ -69,8 +69,10 @@ export interface ProviderInstance {
   readonly accentColor?: string | undefined;
   readonly enabled: boolean;
   readonly snapshot: ServerProviderShape;
-  readonly adapter: ProviderAdapterShape<ProviderAdapterError>;
-  readonly textGeneration: TextGeneration.TextGeneration["Service"];
+  /** Present for legacy/provider-native session transports. Mastra-native drivers omit it. */
+  readonly adapter: ProviderAdapterShape<ProviderAdapterError> | undefined;
+  /** Present when the provider supports app-level title and source-control writing. */
+  readonly textGeneration: TextGeneration.TextGeneration["Service"] | undefined;
 }
 
 export interface ProviderContinuationIdentity {

--- a/apps/server/src/provider/builtInDrivers.ts
+++ b/apps/server/src/provider/builtInDrivers.ts
@@ -24,6 +24,7 @@ import { ClaudeDriver, type ClaudeDriverEnv } from "./Drivers/ClaudeDriver.ts";
 import { CodexDriver, type CodexDriverEnv } from "./Drivers/CodexDriver.ts";
 import { CursorDriver, type CursorDriverEnv } from "./Drivers/CursorDriver.ts";
 import { GrokDriver, type GrokDriverEnv } from "./Drivers/GrokDriver.ts";
+import { KimiDriver, type KimiDriverEnv } from "./Drivers/KimiDriver.ts";
 import { OpenCodeDriver, type OpenCodeDriverEnv } from "./Drivers/OpenCodeDriver.ts";
 import type { AnyProviderDriver } from "./ProviderDriver.ts";
 
@@ -37,6 +38,7 @@ export type BuiltInDriversEnv =
   | CodexDriverEnv
   | CursorDriverEnv
   | GrokDriverEnv
+  | KimiDriverEnv
   | OpenCodeDriverEnv;
 
 /**
@@ -49,5 +51,6 @@ export const BUILT_IN_DRIVERS: ReadonlyArray<AnyProviderDriver<BuiltInDriversEnv
   ClaudeDriver,
   CursorDriver,
   GrokDriver,
+  KimiDriver,
   OpenCodeDriver,
 ];

--- a/apps/server/src/serverSettings.ts
+++ b/apps/server/src/serverSettings.ts
@@ -236,6 +236,7 @@ const PersistedOptionalProviderSettings = Schema.Struct({
     Schema.Struct({
       cursor: Schema.optionalKey(Schema.Struct({ enabled: Schema.optionalKey(Schema.Boolean) })),
       grok: Schema.optionalKey(Schema.Struct({ enabled: Schema.optionalKey(Schema.Boolean) })),
+      kimi: Schema.optionalKey(Schema.Struct({ enabled: Schema.optionalKey(Schema.Boolean) })),
       opencode: Schema.optionalKey(Schema.Struct({ enabled: Schema.optionalKey(Schema.Boolean) })),
     }),
   ),
@@ -282,6 +283,10 @@ function restoreUsedProviders(
       grok: {
         ...settings.providers.grok,
         enabled: persisted.providers?.grok?.enabled ?? usedProviders.has("grok"),
+      },
+      kimi: {
+        ...settings.providers.kimi,
+        enabled: persisted.providers?.kimi?.enabled ?? true,
       },
       opencode: {
         ...settings.providers.opencode,

--- a/apps/server/src/subscription-auth/providers/kimi.test.ts
+++ b/apps/server/src/subscription-auth/providers/kimi.test.ts
@@ -1,0 +1,21 @@
+import { describe, expect, it } from "vite-plus/test";
+
+import { createDeviceCodePollState } from "../deviceCode.ts";
+import { pollKimiDeviceLogin, type KimiDeviceLoginPending } from "./kimi.ts";
+
+describe("Kimi For Coding OAuth", () => {
+  it("fails legacy pending logins without throwing", async () => {
+    const pending = {
+      deviceCode: "legacy-device-code",
+      userCode: "ABCD-EFGH",
+      url: "https://auth.kimi.com/device",
+      instructions: "Enter code: ABCD-EFGH",
+      state: createDeviceCodePollState({ intervalSeconds: 5, expiresInSeconds: 900 }),
+    } as KimiDeviceLoginPending;
+
+    await expect(pollKimiDeviceLogin(pending)).resolves.toEqual({
+      status: "failed",
+      error: "Kimi For Coding login is missing its device identity. Restart the login.",
+    });
+  });
+});

--- a/apps/server/src/subscription-auth/providers/kimi.ts
+++ b/apps/server/src/subscription-auth/providers/kimi.ts
@@ -225,6 +225,12 @@ export async function pollKimiDeviceLogin(
   pending: KimiDeviceLoginPending,
   options?: { signal?: AbortSignal },
 ): Promise<KimiDevicePollResult> {
+  if (!isKimiCodingDeviceId(pending.deviceId)) {
+    return {
+      status: "failed",
+      error: "Kimi For Coding login is missing its device identity. Restart the login.",
+    };
+  }
   const step = await stepDeviceCodePoll(pending.state, () =>
     pollKimiTokenOnce(pending, options?.signal),
   );

--- a/apps/server/src/textGeneration/TextGeneration.ts
+++ b/apps/server/src/textGeneration/TextGeneration.ts
@@ -129,15 +129,15 @@ const resolveInstance = (
   registry: ProviderInstanceRegistry.ProviderInstanceRegistry["Service"],
   operation: TextGenerationOp,
   instanceId: ProviderInstanceId,
-): Effect.Effect<ProviderInstance["textGeneration"], TextGenerationError> =>
+): Effect.Effect<NonNullable<ProviderInstance["textGeneration"]>, TextGenerationError> =>
   registry.getInstance(instanceId).pipe(
     Effect.flatMap((instance) =>
-      instance
+      instance?.textGeneration
         ? Effect.succeed(instance.textGeneration)
         : Effect.fail(
             new TextGenerationError({
               operation,
-              detail: `No provider instance registered for id '${instanceId}'.`,
+              detail: `Provider instance '${instanceId}' does not support text generation.`,
             }),
           ),
     ),

--- a/apps/web/src/components/Icons.tsx
+++ b/apps/web/src/components/Icons.tsx
@@ -214,6 +214,12 @@ export const GrokIcon: Icon = ({ className, ...props }) => (
   </svg>
 );
 
+export const KimiIcon: Icon = (props) => (
+  <svg {...props} viewBox="0 0 24 24">
+    <image href="/provider-icons/kimi-for-coding.svg" width="24" height="24" />
+  </svg>
+);
+
 export const TraeIcon: Icon = (props) => (
   <svg {...props} viewBox="0 0 24 24" fill="currentColor">
     {/* Back rectangle: left strip + bottom strip drawn separately — empty bottom-left corner is the gap between them */}

--- a/apps/web/src/components/chat/providerIconUtils.ts
+++ b/apps/web/src/components/chat/providerIconUtils.ts
@@ -1,5 +1,5 @@
 import { ProviderDriverKind } from "@t3tools/contracts";
-import { ClaudeAI, CursorIcon, GrokIcon, Icon, OpenAI, OpenCodeIcon } from "../Icons";
+import { ClaudeAI, CursorIcon, GrokIcon, Icon, KimiIcon, OpenAI, OpenCodeIcon } from "../Icons";
 import { PROVIDER_OPTIONS } from "../../session-logic";
 
 export const PROVIDER_ICON_BY_PROVIDER: Partial<Record<ProviderDriverKind, Icon>> = {
@@ -8,6 +8,7 @@ export const PROVIDER_ICON_BY_PROVIDER: Partial<Record<ProviderDriverKind, Icon>
   [ProviderDriverKind.make("opencode")]: OpenCodeIcon,
   [ProviderDriverKind.make("cursor")]: CursorIcon,
   [ProviderDriverKind.make("grok")]: GrokIcon,
+  [ProviderDriverKind.make("kimi")]: KimiIcon,
 };
 
 function isAvailableProviderOption(option: (typeof PROVIDER_OPTIONS)[number]): option is {

--- a/apps/web/src/components/settings/ProviderModelsSection.tsx
+++ b/apps/web/src/components/settings/ProviderModelsSection.tsx
@@ -34,6 +34,7 @@ const CUSTOM_MODEL_PLACEHOLDER_BY_KIND: Partial<Record<ProviderDriverKind, strin
   [ProviderDriverKind.make("codex")]: "gpt-6.7-codex-ultra-preview",
   [ProviderDriverKind.make("claudeAgent")]: "claude-sonnet-5",
   [ProviderDriverKind.make("cursor")]: "claude-sonnet-4-6",
+  [ProviderDriverKind.make("kimi")]: "k3-256k",
   [ProviderDriverKind.make("opencode")]: "openai/gpt-5",
 };
 

--- a/apps/web/src/components/settings/ProviderSettingsForm.test.ts
+++ b/apps/web/src/components/settings/ProviderSettingsForm.test.ts
@@ -49,6 +49,13 @@ describe("ProviderSettingsForm helpers", () => {
     ]);
   });
 
+  it("registers Kimi settings in the provider picker", () => {
+    const kimi = DRIVER_OPTION_BY_VALUE[ProviderDriverKind.make("kimi")];
+
+    expect(kimi).toMatchObject({ label: "Kimi For Coding" });
+    expect(deriveProviderSettingsFields(kimi!)).toEqual([]);
+  });
+
   it("preserves unknown config keys while omitting empty configurable fields", () => {
     const opencode = DRIVER_OPTION_BY_VALUE[ProviderDriverKind.make("opencode")];
     expect(opencode).toBeDefined();

--- a/apps/web/src/components/settings/providerDriverMeta.ts
+++ b/apps/web/src/components/settings/providerDriverMeta.ts
@@ -3,11 +3,20 @@ import {
   CodexSettings,
   CursorSettings,
   GrokSettings,
+  KimiSettings,
   OpenCodeSettings,
   ProviderDriverKind,
 } from "@t3tools/contracts";
 import type * as Schema from "effect/Schema";
-import { ClaudeAI, CursorIcon, GrokIcon, type Icon, OpenAI, OpenCodeIcon } from "../Icons";
+import {
+  ClaudeAI,
+  CursorIcon,
+  GrokIcon,
+  KimiIcon,
+  type Icon,
+  OpenAI,
+  OpenCodeIcon,
+} from "../Icons";
 
 type ProviderSettingsSchema = {
   readonly fields: Readonly<Record<string, Schema.Top>>;
@@ -60,6 +69,13 @@ export const PROVIDER_CLIENT_DEFINITIONS: readonly ProviderClientDefinition[] = 
     icon: GrokIcon,
     badgeLabel: "Early Access",
     settingsSchema: GrokSettings,
+  },
+  {
+    value: ProviderDriverKind.make("kimi"),
+    label: "Kimi For Coding",
+    icon: KimiIcon,
+    badgeLabel: "Early Access",
+    settingsSchema: KimiSettings,
   },
   {
     value: ProviderDriverKind.make("opencode"),

--- a/apps/web/src/session-logic.ts
+++ b/apps/web/src/session-logic.ts
@@ -55,6 +55,12 @@ export const PROVIDER_OPTIONS: Array<{
     available: true,
     pickerSidebarBadge: "new",
   },
+  {
+    value: ProviderDriverKind.make("kimi"),
+    label: "Kimi For Coding",
+    available: true,
+    pickerSidebarBadge: "new",
+  },
 ];
 
 export type WorkLogToolLifecycleStatus =

--- a/packages/contracts/src/model.ts
+++ b/packages/contracts/src/model.ts
@@ -131,6 +131,7 @@ const CODEX_DRIVER_KIND = ProviderDriverKind.make("codex");
 const CLAUDE_DRIVER_KIND = ProviderDriverKind.make("claudeAgent");
 const CURSOR_DRIVER_KIND = ProviderDriverKind.make("cursor");
 const GROK_DRIVER_KIND = ProviderDriverKind.make("grok");
+const KIMI_DRIVER_KIND = ProviderDriverKind.make("kimi");
 const OPENCODE_DRIVER_KIND = ProviderDriverKind.make("opencode");
 
 export const DEFAULT_MODEL = "gpt-5.6-sol";
@@ -152,6 +153,7 @@ export const DEFAULT_MODEL_BY_PROVIDER: Partial<Record<ProviderDriverKind, strin
   [CLAUDE_DRIVER_KIND]: "claude-sonnet-5",
   [CURSOR_DRIVER_KIND]: "auto",
   [GROK_DRIVER_KIND]: "grok-build",
+  [KIMI_DRIVER_KIND]: "k3",
   [OPENCODE_DRIVER_KIND]: "openai/gpt-5",
 };
 
@@ -221,5 +223,6 @@ export const PROVIDER_DISPLAY_NAMES: Partial<Record<ProviderDriverKind, string>>
   [CLAUDE_DRIVER_KIND]: "Claude",
   [CURSOR_DRIVER_KIND]: "Cursor",
   [GROK_DRIVER_KIND]: "Grok",
+  [KIMI_DRIVER_KIND]: "Kimi For Coding",
   [OPENCODE_DRIVER_KIND]: "OpenCode",
 };

--- a/packages/contracts/src/settings.ts
+++ b/packages/contracts/src/settings.ts
@@ -522,6 +522,18 @@ export const GrokSettings = makeProviderSettingsSchema(
 );
 export type GrokSettings = typeof GrokSettings.Type;
 
+export const KimiSettings = makeProviderSettingsSchema({
+  enabled: Schema.Boolean.pipe(
+    Schema.withDecodingDefault(Effect.succeed(true)),
+    Schema.annotateKey({ providerSettingsForm: { hidden: true } }),
+  ),
+  customModels: Schema.Array(Schema.String).pipe(
+    Schema.withDecodingDefault(Effect.succeed([])),
+    Schema.annotateKey({ providerSettingsForm: { hidden: true } }),
+  ),
+});
+export type KimiSettings = typeof KimiSettings.Type;
+
 export const OpenCodeSettings = makeProviderSettingsSchema(
   {
     // Off by default (like Cursor and Grok): the binding is not yet stable
@@ -720,6 +732,7 @@ export const ServerSettings = Schema.Struct({
     claudeAgent: ClaudeSettings.pipe(Schema.withDecodingDefault(Effect.succeed({}))),
     cursor: CursorSettings.pipe(Schema.withDecodingDefault(Effect.succeed({}))),
     grok: GrokSettings.pipe(Schema.withDecodingDefault(Effect.succeed({}))),
+    kimi: KimiSettings.pipe(Schema.withDecodingDefault(Effect.succeed({}))),
     opencode: OpenCodeSettings.pipe(Schema.withDecodingDefault(Effect.succeed({}))),
   }).pipe(Schema.withDecodingDefault(Effect.succeed({}))),
   // New driver-agnostic instance map. Keyed by `ProviderInstanceId`; values
@@ -866,6 +879,11 @@ const GrokSettingsPatch = Schema.Struct({
   customModels: Schema.optionalKey(Schema.Array(Schema.String)),
 });
 
+const KimiSettingsPatch = Schema.Struct({
+  enabled: Schema.optionalKey(Schema.Boolean),
+  customModels: Schema.optionalKey(Schema.Array(Schema.String)),
+});
+
 const OpenCodeSettingsPatch = Schema.Struct({
   enabled: Schema.optionalKey(Schema.Boolean),
   binaryPath: Schema.optionalKey(TrimmedString),
@@ -923,6 +941,7 @@ export const ServerSettingsPatch = Schema.Struct({
       claudeAgent: Schema.optionalKey(ClaudeSettingsPatch),
       cursor: Schema.optionalKey(CursorSettingsPatch),
       grok: Schema.optionalKey(GrokSettingsPatch),
+      kimi: Schema.optionalKey(KimiSettingsPatch),
       opencode: Schema.optionalKey(OpenCodeSettingsPatch),
     }),
   ),

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -457,6 +457,9 @@ importers:
 
   apps/server:
     dependencies:
+      '@ai-sdk/anthropic':
+        specifier: 3.0.113
+        version: 3.0.113(zod@4.4.3)
       '@anthropic-ai/claude-agent-sdk':
         specifier: ^0.3.170
         version: 0.3.170(@anthropic-ai/sdk@0.93.0(zod@4.4.3))(@modelcontextprotocol/sdk@1.29.0(zod@4.4.3))(zod@4.4.3)


### PR DESCRIPTION
Kimi For Coding accounts could connect through OAuth, but bots could not select Kimi as a provider or run the saved Kimi model.

This change registers Kimi in contracts, server settings, provider discovery, and the web picker. Kimi sessions use the custom Mastra controller with the saved OAuth token and device identity. Missing access fails closed. The legacy provider adapter and text-generation paths now report unsupported behavior for Mastra-native drivers.

Tests:
- `vp test run apps/server/src/subscription-auth/service.test.ts apps/server/src/provider/AkeruKimiProvider.test.ts apps/server/src/provider/AkeruMastraHarness.test.ts apps/server/src/provider/Drivers/KimiDriver.test.ts apps/server/src/provider/Layers/AgentController.test.ts apps/server/src/provider/Layers/ProviderRegistry.test.ts apps/web/src/components/settings/ProviderSettingsForm.test.ts`
- `vp run --filter akeru-bot typecheck`
- `vp run --filter @t3tools/contracts typecheck`
- `vp run --filter @t3tools/web typecheck`

Linear:
- [LEO-326](https://linear.app/opencoredev/issue/LEO-326)
- [LEO-288](https://linear.app/opencoredev/issue/LEO-288/verify-per-bot-model-routing-for-every-provider)
- [LEO-295](https://linear.app/opencoredev/issue/LEO-295/expose-the-complete-akeru-tool-catalog-through-mastra)
- [LEO-294](https://linear.app/opencoredev/issue/LEO-294/own-launch-stacks-and-shared-file-integration)

Model: gpt-5.6-sol
Harness: Codex in T3 Code