### PR TITLE
feat(server): add bot inbox controls

### DIFF
--- a/apps/server/src/auth/RpcAuthorization.ts
+++ b/apps/server/src/auth/RpcAuthorization.ts
@@ -46,6 +46,8 @@ export const RPC_REQUIRED_SCOPES = {
   [WS_METHODS.subscriptionAuthCancel]: AuthOrchestrationOperateScope,
   [WS_METHODS.subscriptionAuthLogout]: AuthOrchestrationOperateScope,
   [WS_METHODS.subscriptionAuthHealthTest]: AuthOrchestrationOperateScope,
+  [WS_METHODS.botInboxList]: AuthOrchestrationReadScope,
+  [WS_METHODS.botInboxResolve]: AuthOrchestrationOperateScope,
   [WS_METHODS.voiceCallGet]: AuthOrchestrationReadScope,
   [WS_METHODS.voiceCallStart]: AuthOrchestrationOperateScope,
   [WS_METHODS.voiceCallHangup]: AuthOrchestrationOperateScope,

--- a/apps/server/src/bot-inbox/connectorIncidents.test.ts
+++ b/apps/server/src/bot-inbox/connectorIncidents.test.ts
@@ -74,6 +74,21 @@ describe("connector inbox incidents", () => {
     expect(inbox.list().filter((item) => item.status === "open")).toHaveLength(0);
   });
 
+  it("keeps an acknowledged failure closed until the connector recovers", () => {
+    const inbox = fixture();
+    syncConnectorIncidents(inbox, [status("failed")]);
+    const first = inbox.list()[0]!;
+    inbox.resolveById(first.id);
+
+    syncConnectorIncidents(inbox, [status("failed")]);
+    expect(inbox.list().filter((item) => item.status === "open")).toHaveLength(0);
+
+    syncConnectorIncidents(inbox, [status("recovered")]);
+    syncConnectorIncidents(inbox, [status("failed")]);
+    const reopened = inbox.list().find((item) => item.status === "open");
+    expect(reopened?.id).not.toBe(first.id);
+  });
+
   it("resolves the incident when the dependent bot is removed", () => {
     const inbox = fixture();
     syncConnectorIncidents(inbox, [status("failed")]);
@@ -85,9 +100,12 @@ describe("connector inbox incidents", () => {
   it("resolves the incident when the provider status is removed", () => {
     const inbox = fixture();
     syncConnectorIncidents(inbox, [status("failed")]);
+    const first = inbox.list()[0]!;
+    inbox.resolveById(first.id);
     syncConnectorIncidents(inbox, []);
+    syncConnectorIncidents(inbox, [status("failed")]);
 
-    expect(inbox.list()[0]?.status).toBe("resolved");
+    expect(inbox.list().find((item) => item.status === "open")?.id).not.toBe(first.id);
   });
 
   it.each([

--- a/apps/server/src/bot-inbox/connectorIncidents.ts
+++ b/apps/server/src/bot-inbox/connectorIncidents.ts
@@ -43,7 +43,7 @@ export function syncConnectorIncidents(
 
   for (const incident of botInbox.list()) {
     if (
-      incident.status === "open" &&
+      (incident.status === "open" || incident.acknowledgedAt !== undefined) &&
       incident.incidentKey.startsWith("connector:") &&
       !currentIncidentKeys.has(incident.incidentKey)
     ) {

--- a/apps/server/src/bot-inbox/service.test.ts
+++ b/apps/server/src/bot-inbox/service.test.ts
@@ -89,6 +89,15 @@ describe("bot inbox incidents", () => {
     expect(new BotInboxService(filePath).list()).toHaveLength(2);
   });
 
+  it("resolves an open incident by id", () => {
+    const { service } = makeService(["2026-08-30T20:00:00.000Z", "2026-08-30T20:01:00.000Z"]);
+    const item = service.upsert(incident);
+
+    expect(service.resolveById(item.id)).toBe(true);
+    expect(service.list()[0]?.status).toBe("resolved");
+    expect(service.resolveById(item.id)).toBe(false);
+  });
+
   it("preserves incidents written by another service instance", () => {
     const { filePath, service: approvalWriter } = makeService([
       "2026-08-30T20:00:00.000Z",

--- a/apps/server/src/bot-inbox/service.test.ts
+++ b/apps/server/src/bot-inbox/service.test.ts
@@ -98,6 +98,21 @@ describe("bot inbox incidents", () => {
     expect(service.resolveById(item.id)).toBe(false);
   });
 
+  it("resolves only the incident with the matching id", () => {
+    const { filePath, service } = makeService([
+      "2026-08-30T20:00:00.000Z",
+      "2026-08-30T20:01:00.000Z",
+    ]);
+    const item = service.upsert(incident);
+    NodeFS.writeFileSync(filePath, JSON.stringify([item, { ...item, id: "replacement-incident" }]));
+
+    expect(service.resolveById(item.id)).toBe(true);
+    expect(service.list().map(({ id, status }) => ({ id, status }))).toEqual([
+      { id: item.id, status: "resolved" },
+      { id: "replacement-incident", status: "open" },
+    ]);
+  });
+
   it("preserves incidents written by another service instance", () => {
     const { filePath, service: approvalWriter } = makeService([
       "2026-08-30T20:00:00.000Z",

--- a/apps/server/src/bot-inbox/service.ts
+++ b/apps/server/src/bot-inbox/service.ts
@@ -144,8 +144,15 @@ export class BotInboxService {
 
   resolveById(id: string): boolean {
     this.reload();
-    const incident = this.items.find((item) => item.id === id && item.status === "open");
-    return incident ? this.resolve(incident.incidentKey) : false;
+    const resolvedAt = this.now();
+    let changed = false;
+    this.items = this.items.map((item) => {
+      if (item.id !== id || item.status === "resolved") return item;
+      changed = true;
+      return { ...item, status: "resolved", resolvedAt, lastSeenAt: resolvedAt };
+    });
+    if (changed) this.save();
+    return changed;
   }
 
   private save(): void {

--- a/apps/server/src/bot-inbox/service.ts
+++ b/apps/server/src/bot-inbox/service.ts
@@ -142,6 +142,12 @@ export class BotInboxService {
     return changed;
   }
 
+  resolveById(id: string): boolean {
+    this.reload();
+    const incident = this.items.find((item) => item.id === id && item.status === "open");
+    return incident ? this.resolve(incident.incidentKey) : false;
+  }
+
   private save(): void {
     const directory = NodePath.dirname(this.filePath);
     NodeFS.mkdirSync(directory, { recursive: true, mode: 0o700 });

--- a/apps/server/src/bot-inbox/service.ts
+++ b/apps/server/src/bot-inbox/service.ts
@@ -28,6 +28,7 @@ export interface BotInboxItem {
   readonly firstSeenAt: string;
   readonly lastSeenAt: string;
   readonly resolvedAt?: string;
+  readonly acknowledgedAt?: string;
   readonly occurrenceCount: number;
 }
 
@@ -102,9 +103,14 @@ export class BotInboxService {
 
   ensureOpen(incident: BotInboxIncident): BotInboxItem {
     this.reload();
-    const existingIndex = this.items.findIndex(
+    let existingIndex = this.items.findIndex(
       (item) => item.incidentKey === incident.incidentKey && item.status === "open",
     );
+    if (existingIndex < 0) {
+      existingIndex = this.items.findLastIndex(
+        (item) => item.incidentKey === incident.incidentKey && item.acknowledgedAt !== undefined,
+      );
+    }
     if (existingIndex < 0) return this.upsert(incident);
 
     const existing = this.items[existingIndex]!;
@@ -134,9 +140,20 @@ export class BotInboxService {
     const resolvedAt = this.now();
     let changed = false;
     this.items = this.items.map((item) => {
-      if (item.incidentKey !== incidentKey || item.status === "resolved") return item;
+      if (
+        item.incidentKey !== incidentKey ||
+        (item.status === "resolved" && item.acknowledgedAt === undefined)
+      ) {
+        return item;
+      }
       changed = true;
-      return { ...item, status: "resolved", resolvedAt, lastSeenAt: resolvedAt };
+      const { acknowledgedAt: _acknowledgedAt, ...resolvedItem } = item;
+      return {
+        ...resolvedItem,
+        status: "resolved",
+        resolvedAt,
+        lastSeenAt: resolvedAt,
+      };
     });
     if (changed) this.save();
     return changed;
@@ -149,7 +166,13 @@ export class BotInboxService {
     this.items = this.items.map((item) => {
       if (item.id !== id || item.status === "resolved") return item;
       changed = true;
-      return { ...item, status: "resolved", resolvedAt, lastSeenAt: resolvedAt };
+      return {
+        ...item,
+        status: "resolved",
+        resolvedAt,
+        lastSeenAt: resolvedAt,
+        acknowledgedAt: resolvedAt,
+      };
     });
     if (changed) this.save();
     return changed;

--- a/apps/server/src/server.test.ts
+++ b/apps/server/src/server.test.ts
@@ -4596,6 +4596,9 @@ it.layer(NodeServices.layer)("server router seam", (it) => {
             assert.equal(failed[0]?.botId, bot.botId);
             assert.equal(failed[0]?.lastFailure, "The first request failed.");
 
+            yield* client[WS_METHODS.botInboxResolve]({ id: failed[0]!.id });
+            assert.deepEqual(yield* client[WS_METHODS.botInboxList]({}), []);
+
             yield* fileSystem.writeFileString(
               `${authPath}.health`,
               // @effect-diagnostics-next-line preferSchemaOverJson:off
@@ -4612,6 +4615,24 @@ it.layer(NodeServices.layer)("server router seam", (it) => {
             );
 
             assert.deepEqual(yield* client[WS_METHODS.botInboxList]({}), []);
+
+            yield* fileSystem.writeFileString(
+              `${authPath}.health`,
+              // @effect-diagnostics-next-line preferSchemaOverJson:off
+              JSON.stringify({
+                xai: {
+                  lastFailedRequest: {
+                    at: "2026-08-30T20:02:00.000Z",
+                    message: "The first request failed.",
+                  },
+                  failureKind: "request",
+                },
+              }),
+            );
+
+            const reopened = yield* client[WS_METHODS.botInboxList]({});
+            assert.equal(reopened.length, 1);
+            assert.notEqual(reopened[0]?.id, failed[0]?.id);
           }),
         ),
       );

--- a/apps/server/src/server.test.ts
+++ b/apps/server/src/server.test.ts
@@ -8,6 +8,7 @@ import {
   AuthAccessTokenType,
   AuthEnvironmentBootstrapTokenType,
   AuthTokenExchangeGrantType,
+  BotId,
   CommandId,
   DEFAULT_SERVER_SETTINGS,
   EnvironmentId,
@@ -416,6 +417,7 @@ const buildAppUnderTest = (options?: {
     orchestrationEngine?: Partial<OrchestrationEngine.OrchestrationEngineService["Service"]>;
     analyticsService?: Partial<AnalyticsService.AnalyticsService["Service"]>;
     projectionSnapshotQuery?: Partial<ProjectionSnapshotQuery.ProjectionSnapshotQuery["Service"]>;
+    projectionBots?: Partial<ProjectionBots.ProjectionBotRepositoryShape>;
     checkpointDiffQuery?: Partial<CheckpointDiffQuery.CheckpointDiffQuery["Service"]>;
     browserTraceCollector?: Partial<BrowserTraceCollector.BrowserTraceCollector["Service"]>;
     serverLifecycleEvents?: Partial<ServerLifecycleEvents.ServerLifecycleEvents["Service"]>;
@@ -804,6 +806,7 @@ const buildAppUnderTest = (options?: {
             upsert: () => Effect.void,
             getById: () => Effect.succeed(Option.none()),
             listAll: () => Effect.succeed([]),
+            ...options?.layers?.projectionBots,
           } satisfies ProjectionBots.ProjectionBotRepositoryShape),
           Layer.succeed(ProjectionGroups.ProjectionGroupRepository, {
             upsert: () => Effect.void,
@@ -4529,6 +4532,89 @@ it.layer(NodeServices.layer)("server router seam", (it) => {
 
       assert.deepEqual(response.issues, []);
       assert.deepEqual(response.keybindings, [resolved]);
+    }).pipe(Effect.provide(NodeHttpServer.layerTest)),
+  );
+
+  it.effect("syncs connector incidents through botInbox.list", () =>
+    Effect.gen(function* () {
+      const bot = {
+        botId: BotId.make("bot-akeru"),
+        name: "Akeru",
+        title: "Research bot",
+        label: null,
+        description: null,
+        disabledMcpServerIds: [],
+        avatar: { kind: "dither" as const, seed: "akeru" },
+        engine: { provider: "grok", model: "grok-4.6" },
+        sandbox: null,
+        runtimeMode: "approval-required" as const,
+        usageCap: null,
+        voiceEnabled: false,
+        groupId: null,
+        archivedAt: null,
+        createdAt: "2026-08-30T20:00:00.000Z",
+        updatedAt: "2026-08-30T20:00:00.000Z",
+      } satisfies ProjectionBots.ProjectionBot;
+      const config = yield* buildAppUnderTest({
+        layers: {
+          projectionBots: {
+            listAll: () => Effect.succeed([bot]),
+          },
+        },
+      });
+      const fileSystem = yield* FileSystem.FileSystem;
+      const path = yield* Path.Path;
+      const authPath = path.join(config.secretsDir, "subscription-auth.json");
+      yield* fileSystem.makeDirectory(config.secretsDir, { recursive: true });
+      yield* fileSystem.writeFileString(
+        authPath,
+        // @effect-diagnostics-next-line preferSchemaOverJson:off
+        JSON.stringify({ xai: { type: "oauth", access: "a", refresh: "r", expires: 4e12 } }),
+      );
+      yield* fileSystem.writeFileString(
+        `${authPath}.health`,
+        // @effect-diagnostics-next-line preferSchemaOverJson:off
+        JSON.stringify({
+          xai: {
+            lastFailedRequest: {
+              at: "2026-08-30T20:00:00.000Z",
+              message: "The first request failed.",
+            },
+            failureKind: "request",
+          },
+        }),
+      );
+
+      const wsUrl = yield* getWsServerUrl("/ws");
+      yield* Effect.scoped(
+        withWsRpcClient(wsUrl, (client) =>
+          Effect.gen(function* () {
+            const failed = yield* client[WS_METHODS.botInboxList]({});
+            assert.equal(failed.length, 1);
+            assert.equal(failed[0]?.kind, "connector-failure");
+            assert.equal(failed[0]?.status, "open");
+            assert.equal(failed[0]?.botId, bot.botId);
+            assert.equal(failed[0]?.lastFailure, "The first request failed.");
+
+            yield* fileSystem.writeFileString(
+              `${authPath}.health`,
+              // @effect-diagnostics-next-line preferSchemaOverJson:off
+              JSON.stringify({
+                xai: {
+                  lastSuccessfulRequestAt: "2026-08-30T20:01:00.000Z",
+                  lastFailedRequest: {
+                    at: "2026-08-30T20:00:00.000Z",
+                    message: "The first request failed.",
+                  },
+                  failureKind: "request",
+                },
+              }),
+            );
+
+            assert.deepEqual(yield* client[WS_METHODS.botInboxList]({}), []);
+          }),
+        ),
+      );
     }).pipe(Effect.provide(NodeHttpServer.layerTest)),
   );
 

--- a/apps/server/src/ws.ts
+++ b/apps/server/src/ws.ts
@@ -1986,6 +1986,23 @@ const makeWsRpcLayer = (
           observeRpcEffect(WS_METHODS.subscriptionAuthList, getAccessHealthSnapshot(), {
             "rpc.aggregate": "server",
           }),
+        [WS_METHODS.botInboxList]: (_input) =>
+          observeRpcEffect(
+            WS_METHODS.botInboxList,
+            Effect.sync(() => {
+              botInbox.reload();
+              return botInbox.list().filter((item) => item.status === "open");
+            }),
+            { "rpc.aggregate": "bot" },
+          ),
+        [WS_METHODS.botInboxResolve]: ({ id }) =>
+          observeRpcEffect(
+            WS_METHODS.botInboxResolve,
+            Effect.sync(() => {
+              botInbox.resolveById(id);
+            }),
+            { "rpc.aggregate": "bot" },
+          ),
         [WS_METHODS.subscriptionAuthStart]: ({ provider }) =>
           observeRpcEffect(
             WS_METHODS.subscriptionAuthStart,

--- a/apps/server/src/ws.ts
+++ b/apps/server/src/ws.ts
@@ -1989,10 +1989,9 @@ const makeWsRpcLayer = (
         [WS_METHODS.botInboxList]: (_input) =>
           observeRpcEffect(
             WS_METHODS.botInboxList,
-            Effect.sync(() => {
-              botInbox.reload();
-              return botInbox.list().filter((item) => item.status === "open");
-            }),
+            getAccessHealthSnapshot().pipe(
+              Effect.map(({ inbox }) => inbox.filter((item) => item.status === "open")),
+            ),
             { "rpc.aggregate": "bot" },
           ),
         [WS_METHODS.botInboxResolve]: ({ id }) =>

--- a/packages/client-runtime/package.json
+++ b/packages/client-runtime/package.json
@@ -131,6 +131,10 @@
       "types": "./src/state/server.ts",
       "default": "./src/state/server.ts"
     },
+    "./state/bot-inbox": {
+      "types": "./src/state/botInbox.ts",
+      "default": "./src/state/botInbox.ts"
+    },
     "./state/session": {
       "types": "./src/state/session.ts",
       "default": "./src/state/session.ts"

--- a/packages/client-runtime/src/state/botInbox.test.ts
+++ b/packages/client-runtime/src/state/botInbox.test.ts
@@ -1,0 +1,89 @@
+import { EnvironmentId, WS_METHODS } from "@t3tools/contracts";
+import { expect, it } from "@effect/vitest";
+import * as Effect from "effect/Effect";
+import * as Layer from "effect/Layer";
+import * as Option from "effect/Option";
+import * as SubscriptionRef from "effect/SubscriptionRef";
+import { AsyncResult, Atom, AtomRegistry } from "effect/unstable/reactivity";
+import { vi } from "vite-plus/test";
+
+import {
+  AVAILABLE_CONNECTION_STATE,
+  PrimaryConnectionTarget,
+  type PreparedConnection,
+  type SupervisorConnectionState,
+} from "../connection/model.ts";
+import * as EnvironmentRegistry from "../connection/registry.ts";
+import * as EnvironmentSupervisor from "../connection/supervisor.ts";
+import type { WsRpcProtocolClient } from "../rpc/protocol.ts";
+import type { RpcSession } from "../rpc/session.ts";
+import { createBotInboxEnvironmentAtoms } from "./botInbox.ts";
+
+const environmentId = EnvironmentId.make("inbox-environment");
+const session = (client: WsRpcProtocolClient): RpcSession => ({
+  client,
+  initialConfig: Effect.never,
+  ready: Effect.void,
+  probe: Effect.void,
+  closed: Effect.never,
+});
+
+it.effect("routes incident resolution and refreshes the environment inbox", () =>
+  Effect.scoped(
+    Effect.gen(function* () {
+      const resolved: string[] = [];
+      const client = {
+        [WS_METHODS.botInboxResolve]: ({ id }: { id: string }) =>
+          Effect.sync(() => resolved.push(id)),
+      } as unknown as WsRpcProtocolClient;
+      const supervisor = EnvironmentSupervisor.EnvironmentSupervisor.of({
+        target: new PrimaryConnectionTarget({
+          environmentId,
+          label: "Inbox environment",
+          httpBaseUrl: "https://inbox.example.test",
+          wsBaseUrl: "wss://inbox.example.test",
+        }),
+        state: yield* SubscriptionRef.make<SupervisorConnectionState>({
+          ...AVAILABLE_CONNECTION_STATE,
+          desired: true,
+          network: "online",
+          phase: "connected",
+          attempt: 1,
+          generation: 1,
+        }),
+        session: yield* SubscriptionRef.make(Option.some(session(client))),
+        prepared: yield* SubscriptionRef.make(Option.none<PreparedConnection>()),
+        connect: Effect.void,
+        disconnect: Effect.void,
+        retryNow: Effect.void,
+      } satisfies EnvironmentSupervisor.EnvironmentSupervisor["Service"]);
+      const run: EnvironmentRegistry.EnvironmentRegistry["Service"]["run"] = (_id, effect) =>
+        Effect.provideService(effect, EnvironmentSupervisor.EnvironmentSupervisor, supervisor);
+      const atoms = createBotInboxEnvironmentAtoms(
+        Atom.runtime(
+          Layer.succeed(
+            EnvironmentRegistry.EnvironmentRegistry,
+            EnvironmentRegistry.EnvironmentRegistry.of({
+              run,
+            } as unknown as EnvironmentRegistry.EnvironmentRegistry["Service"]),
+          ),
+        ),
+      );
+      const registry = yield* Effect.acquireRelease(Effect.sync(AtomRegistry.make), (value) =>
+        Effect.sync(() => value.dispose()),
+      );
+      const refresh = vi.spyOn(registry, "refresh");
+
+      const result = yield* Effect.promise(() =>
+        atoms.resolve.run(registry, {
+          environmentId,
+          input: { id: "incident-1" },
+        }),
+      );
+
+      expect(AsyncResult.isSuccess(result)).toBe(true);
+      expect(resolved).toEqual(["incident-1"]);
+      expect(refresh).toHaveBeenCalledWith(atoms.list({ environmentId, input: {} }));
+    }),
+  ),
+);

--- a/packages/client-runtime/src/state/botInbox.ts
+++ b/packages/client-runtime/src/state/botInbox.ts
@@ -1,0 +1,41 @@
+import { type EnvironmentId, WS_METHODS } from "@t3tools/contracts";
+import * as Effect from "effect/Effect";
+import { Atom, type AtomRegistry } from "effect/unstable/reactivity";
+
+import type { EnvironmentRegistry } from "../connection/registry.ts";
+import {
+  createAtomCommandScheduler,
+  createEnvironmentRpcCommand,
+  createEnvironmentRpcQueryAtomFamily,
+} from "./runtime.ts";
+
+export function createBotInboxEnvironmentAtoms<R, E>(
+  runtime: Atom.AtomRuntime<EnvironmentRegistry | R, E>,
+) {
+  const list = createEnvironmentRpcQueryAtomFamily(runtime, {
+    label: "environment-data:bot-inbox:list",
+    tag: WS_METHODS.botInboxList,
+    staleTimeMs: 5_000,
+  });
+
+  return {
+    list,
+    resolve: createEnvironmentRpcCommand(runtime, {
+      label: "environment-data:bot-inbox:resolve",
+      tag: WS_METHODS.botInboxResolve,
+      scheduler: createAtomCommandScheduler(),
+      concurrency: {
+        mode: "serial",
+        key: ({ environmentId, input }: { environmentId: EnvironmentId; input: { id: string } }) =>
+          JSON.stringify([environmentId, input.id]),
+      },
+      onSettled: (
+        target: { readonly environmentId: EnvironmentId },
+        registry: AtomRegistry.AtomRegistry,
+      ) =>
+        Effect.sync(() =>
+          registry.refresh(list({ environmentId: target.environmentId, input: {} })),
+        ),
+    }),
+  };
+}

--- a/packages/client-runtime/src/state/botInbox.ts
+++ b/packages/client-runtime/src/state/botInbox.ts
@@ -1,13 +1,9 @@
-import { type EnvironmentId, WS_METHODS } from "@t3tools/contracts";
+import { WS_METHODS } from "@t3tools/contracts";
 import * as Effect from "effect/Effect";
 import { Atom, type AtomRegistry } from "effect/unstable/reactivity";
 
 import type { EnvironmentRegistry } from "../connection/registry.ts";
-import {
-  createAtomCommandScheduler,
-  createEnvironmentRpcCommand,
-  createEnvironmentRpcQueryAtomFamily,
-} from "./runtime.ts";
+import { createEnvironmentRpcCommand, createEnvironmentRpcQueryAtomFamily } from "./runtime.ts";
 
 export function createBotInboxEnvironmentAtoms<R, E>(
   runtime: Atom.AtomRuntime<EnvironmentRegistry | R, E>,
@@ -23,16 +19,7 @@ export function createBotInboxEnvironmentAtoms<R, E>(
     resolve: createEnvironmentRpcCommand(runtime, {
       label: "environment-data:bot-inbox:resolve",
       tag: WS_METHODS.botInboxResolve,
-      scheduler: createAtomCommandScheduler(),
-      concurrency: {
-        mode: "serial",
-        key: ({ environmentId, input }: { environmentId: EnvironmentId; input: { id: string } }) =>
-          JSON.stringify([environmentId, input.id]),
-      },
-      onSettled: (
-        target: { readonly environmentId: EnvironmentId },
-        registry: AtomRegistry.AtomRegistry,
-      ) =>
+      onSettled: (target, registry: AtomRegistry.AtomRegistry) =>
         Effect.sync(() =>
           registry.refresh(list({ environmentId: target.environmentId, input: {} })),
         ),

--- a/packages/contracts/src/rpc.ts
+++ b/packages/contracts/src/rpc.ts
@@ -169,6 +169,8 @@ import {
 import { UsageReadError, UsageSummary, UsageSummaryInput } from "./usage.ts";
 import { ServerSettings, ServerSettingsError, ServerSettingsPatch } from "./settings.ts";
 import {
+  BotInboxItem,
+  BotInboxResolveInput,
   SubscriptionAuthCompleteInput,
   SubscriptionAuthError,
   SubscriptionAuthHealthTestInput,
@@ -287,6 +289,8 @@ export const WS_METHODS = {
   subscriptionAuthCancel: "subscriptionAuth.cancel",
   subscriptionAuthLogout: "subscriptionAuth.logout",
   subscriptionAuthHealthTest: "subscriptionAuth.healthTest",
+  botInboxList: "botInbox.list",
+  botInboxResolve: "botInbox.resolve",
   voiceCallGet: "voiceCall.get",
   voiceCallStart: "voiceCall.start",
   voiceCallHangup: "voiceCall.hangup",
@@ -438,6 +442,18 @@ export const WsSubscriptionAuthLogoutRpc = Rpc.make(WS_METHODS.subscriptionAuthL
 export const WsSubscriptionAuthHealthTestRpc = Rpc.make(WS_METHODS.subscriptionAuthHealthTest, {
   payload: SubscriptionAuthHealthTestInput,
   success: SubscriptionAuthStatuses,
+  error: Schema.Union([SubscriptionAuthError, EnvironmentAuthorizationError]),
+});
+
+export const WsBotInboxListRpc = Rpc.make(WS_METHODS.botInboxList, {
+  payload: Schema.Struct({}),
+  success: Schema.Array(BotInboxItem),
+  error: Schema.Union([SubscriptionAuthError, EnvironmentAuthorizationError]),
+});
+
+export const WsBotInboxResolveRpc = Rpc.make(WS_METHODS.botInboxResolve, {
+  payload: BotInboxResolveInput,
+  success: Schema.Void,
   error: Schema.Union([SubscriptionAuthError, EnvironmentAuthorizationError]),
 });
 
@@ -983,6 +999,8 @@ export const WsRpcGroup = RpcGroup.make(
   WsSubscriptionAuthCancelRpc,
   WsSubscriptionAuthLogoutRpc,
   WsSubscriptionAuthHealthTestRpc,
+  WsBotInboxListRpc,
+  WsBotInboxResolveRpc,
   WsVoiceCallGetRpc,
   WsVoiceCallStartRpc,
   WsVoiceCallHangupRpc,

--- a/packages/contracts/src/subscriptionAuth.ts
+++ b/packages/contracts/src/subscriptionAuth.ts
@@ -106,33 +106,39 @@ export const ProviderAccessStatus = Schema.Struct({
 });
 export type ProviderAccessStatus = typeof ProviderAccessStatus.Type;
 
+export const BotInboxItem = Schema.Struct({
+  id: TrimmedNonEmptyString,
+  incidentKey: TrimmedNonEmptyString,
+  kind: Schema.Literals([
+    "oauth-expired",
+    "connector-failure",
+    "routine-failure",
+    "browser-dead",
+    "silence-watchdog-failure",
+    "approval-request",
+  ]),
+  status: Schema.Literals(["open", "resolved"]),
+  botId: BotId,
+  botName: TrimmedNonEmptyString,
+  taskOrRoutine: TrimmedNonEmptyString,
+  lastFailure: TrimmedNonEmptyString,
+  nextAction: TrimmedNonEmptyString,
+  firstSeenAt: IsoDateTime,
+  lastSeenAt: IsoDateTime,
+  resolvedAt: Schema.optional(IsoDateTime),
+  occurrenceCount: Schema.Int.check(Schema.isGreaterThan(0)),
+});
+export type BotInboxItem = typeof BotInboxItem.Type;
+
+export const BotInboxResolveInput = Schema.Struct({
+  id: TrimmedNonEmptyString,
+});
+export type BotInboxResolveInput = typeof BotInboxResolveInput.Type;
+
 export const SubscriptionAuthStatuses = Schema.Struct({
   providers: Schema.Array(SubscriptionProviderStatus),
   access: Schema.Array(ProviderAccessStatus).pipe(Schema.withDecodingDefault(Effect.succeed([]))),
-  inbox: Schema.Array(
-    Schema.Struct({
-      id: TrimmedNonEmptyString,
-      incidentKey: TrimmedNonEmptyString,
-      kind: Schema.Literals([
-        "oauth-expired",
-        "connector-failure",
-        "routine-failure",
-        "browser-dead",
-        "silence-watchdog-failure",
-        "approval-request",
-      ]),
-      status: Schema.Literals(["open", "resolved"]),
-      botId: BotId,
-      botName: TrimmedNonEmptyString,
-      taskOrRoutine: TrimmedNonEmptyString,
-      lastFailure: TrimmedNonEmptyString,
-      nextAction: TrimmedNonEmptyString,
-      firstSeenAt: IsoDateTime,
-      lastSeenAt: IsoDateTime,
-      resolvedAt: Schema.optional(IsoDateTime),
-      occurrenceCount: Schema.Int.check(Schema.isGreaterThan(0)),
-    }),
-  ).pipe(Schema.withDecodingDefault(Effect.succeed([]))),
+  inbox: Schema.Array(BotInboxItem).pipe(Schema.withDecodingDefault(Effect.succeed([]))),
 });
 export type SubscriptionAuthStatuses = typeof SubscriptionAuthStatuses.Type;
 


### PR DESCRIPTION
The bot inbox was only available through the subscription-auth snapshot, so clients could not list or resolve incidents through a focused environment RPC.

This adds typed list and resolve RPCs, enforces environment scopes, resolves incidents by ID through the existing file-backed inbox, and exposes shared client atoms that refresh after a resolve.

Linear: [LEO-289](https://linear.app/opencoredev/issue/LEO-289/add-one-bot-inbox-for-action-required-events)
Linear: [LEO-294](https://linear.app/opencoredev/issue/LEO-294/own-launch-stacks-and-shared-file-integration)
Linear: [LEO-330](https://linear.app/opencoredev/issue/LEO-330/land-the-durable-bot-inbox)

## Testing

- `vp test run apps/server/src/bot-inbox/service.test.ts packages/client-runtime/src/state/botInbox.test.ts`
- `vp run typecheck` in `packages/contracts`
- `vp run typecheck` in `packages/client-runtime`

Model: GPT-5.6 Sol
Harness: Codex in T3 Code