### PR TITLE
feat(web): resolve bot inbox incidents

### DIFF
--- a/apps/web/src/components/settings/InboxPanel.test.ts
+++ b/apps/web/src/components/settings/InboxPanel.test.ts
@@ -2,9 +2,9 @@ import { BotId } from "@t3tools/contracts";
 import type { BotInboxItem } from "@t3tools/client-runtime/bot-inbox";
 import { describe, expect, it } from "vite-plus/test";
 
-import { inboxRepairDestination } from "./InboxPanel";
+import { inboxRepairDestination, inboxRowAction } from "./InboxPanel";
 
-function incident(incidentKey: string): BotInboxItem {
+function incident(incidentKey: string, overrides: Partial<BotInboxItem> = {}): BotInboxItem {
   return {
     id: "incident-1",
     incidentKey,
@@ -18,6 +18,7 @@ function incident(incidentKey: string): BotInboxItem {
     firstSeenAt: "2026-08-30T10:00:00.000Z",
     lastSeenAt: "2026-08-30T10:00:00.000Z",
     occurrenceCount: 1,
+    ...overrides,
   };
 }
 
@@ -35,5 +36,12 @@ describe("inbox repair destinations", () => {
 
   it("does not add a dead action for approval requests", () => {
     expect(inboxRepairDestination(incident("approval:req-1"))).toBeNull();
+  });
+});
+
+describe("inbox row actions", () => {
+  it("resolves approval and user-action items in Settings", () => {
+    expect(inboxRowAction(incident("approval:req-1"))).toBe("resolve");
+    expect(inboxRowAction(incident("user-action:bot-1:request_box_help:login"))).toBe("resolve");
   });
 });

--- a/apps/web/src/components/settings/InboxPanel.tsx
+++ b/apps/web/src/components/settings/InboxPanel.tsx
@@ -4,13 +4,15 @@ import { selectOpenBotInboxItems, type BotInboxItem } from "@t3tools/client-runt
 import { openPlugins } from "../../pluginsDialogStore";
 import { openSettings } from "../../settingsDialogStore";
 import { useSettingsEnvironmentId } from "../../settingsDialogStore";
+import { botInboxEnvironment } from "../../state/botInbox";
 import { useEnvironmentQuery } from "../../state/query";
-import { serverEnvironment } from "../../state/server";
+import { useAtomCommand } from "../../state/use-atom-command";
 import { Badge } from "../ui/badge";
 import { Button } from "../ui/button";
 import { SettingsPageContainer, SettingsRow, SettingsSection } from "./settingsLayout";
 
 export type InboxRepairDestination = "providers" | "plugins";
+export type InboxRowAction = InboxRepairDestination | "resolve";
 
 export function inboxRepairDestination(item: BotInboxItem): InboxRepairDestination | null {
   if (item.incidentKey.startsWith("access:mcp-")) return "plugins";
@@ -20,14 +22,17 @@ export function inboxRepairDestination(item: BotInboxItem): InboxRepairDestinati
   return null;
 }
 
+export function inboxRowAction(item: BotInboxItem): InboxRowAction {
+  return inboxRepairDestination(item) ?? "resolve";
+}
+
 export function InboxPanel() {
   const environmentId = useSettingsEnvironmentId();
   const inboxQuery = useEnvironmentQuery(
-    environmentId === null
-      ? null
-      : serverEnvironment.subscriptionAuth({ environmentId, input: {} }),
+    environmentId === null ? null : botInboxEnvironment.list({ environmentId, input: {} }),
   );
-  const openItems = selectOpenBotInboxItems(inboxQuery.data?.inbox ?? []);
+  const resolveIncident = useAtomCommand(botInboxEnvironment.resolve);
+  const openItems = selectOpenBotInboxItems(inboxQuery.data ?? []);
 
   return (
     <SettingsPageContainer>
@@ -48,7 +53,14 @@ export function InboxPanel() {
           />
         ) : (
           openItems.map((item) => (
-            <InboxIncidentRow key={item.id} item={item} environmentId={environmentId} />
+            <InboxIncidentRow
+              key={item.id}
+              item={item}
+              environmentId={environmentId}
+              onResolve={() =>
+                environmentId && void resolveIncident({ environmentId, input: { id: item.id } })
+              }
+            />
           ))
         )}
       </SettingsSection>
@@ -59,17 +71,19 @@ export function InboxPanel() {
 function InboxIncidentRow({
   item,
   environmentId,
+  onResolve,
 }: {
   readonly item: BotInboxItem;
   readonly environmentId: ReturnType<typeof useSettingsEnvironmentId>;
+  readonly onResolve: () => void;
 }) {
-  const destination = inboxRepairDestination(item);
+  const action = inboxRowAction(item);
   const openRepair = () => {
-    if (destination === "plugins") {
+    if (action === "plugins") {
       openPlugins();
       return;
     }
-    if (destination === "providers") openSettings("providers", null, environmentId);
+    if (action === "providers") openSettings("providers", null, environmentId);
   };
 
   return (
@@ -83,14 +97,14 @@ function InboxIncidentRow({
       description={item.lastFailure}
       status={item.nextAction}
       control={
-        destination ? (
-          <Button size="xs" variant="outline" onClick={openRepair}>
-            {destination === "plugins" ? "Open Plugins" : "Open Providers"}
+        action === "resolve" ? (
+          <Button size="xs" variant="outline" onClick={onResolve}>
+            Resolve
           </Button>
         ) : (
-          <Badge variant="error">
-            {item.occurrenceCount > 1 ? `${item.occurrenceCount} events` : "Action needed"}
-          </Badge>
+          <Button size="xs" variant="outline" onClick={openRepair}>
+            {action === "plugins" ? "Open Plugins" : "Open Providers"}
+          </Button>
         )
       }
     />

--- a/apps/web/src/components/settings/InboxPanel.tsx
+++ b/apps/web/src/components/settings/InboxPanel.tsx
@@ -1,11 +1,12 @@
 import { CircleAlertIcon } from "lucide-react";
+import { useState } from "react";
 
 import { selectOpenBotInboxItems, type BotInboxItem } from "@t3tools/client-runtime/bot-inbox";
 import { openPlugins } from "../../pluginsDialogStore";
 import { openSettings } from "../../settingsDialogStore";
 import { useSettingsEnvironmentId } from "../../settingsDialogStore";
 import { botInboxEnvironment } from "../../state/botInbox";
-import { useEnvironmentQuery } from "../../state/query";
+import { formatEnvironmentQueryError, useEnvironmentQuery } from "../../state/query";
 import { useAtomCommand } from "../../state/use-atom-command";
 import { Badge } from "../ui/badge";
 import { Button } from "../ui/button";
@@ -57,8 +58,18 @@ export function InboxPanel() {
               key={item.id}
               item={item}
               environmentId={environmentId}
-              onResolve={() =>
-                environmentId && void resolveIncident({ environmentId, input: { id: item.id } })
+              onResolve={
+                environmentId === null
+                  ? null
+                  : async () => {
+                      const result = await resolveIncident({
+                        environmentId,
+                        input: { id: item.id },
+                      });
+                      return result._tag === "Failure"
+                        ? formatEnvironmentQueryError(result.cause)
+                        : null;
+                    }
               }
             />
           ))
@@ -75,15 +86,27 @@ function InboxIncidentRow({
 }: {
   readonly item: BotInboxItem;
   readonly environmentId: ReturnType<typeof useSettingsEnvironmentId>;
-  readonly onResolve: () => void;
+  readonly onResolve: (() => Promise<string | null>) | null;
 }) {
   const action = inboxRowAction(item);
+  const [isResolving, setIsResolving] = useState(false);
+  const [resolveError, setResolveError] = useState<string | null>(null);
   const openRepair = () => {
     if (action === "plugins") {
       openPlugins();
       return;
     }
     if (action === "providers") openSettings("providers", null, environmentId);
+  };
+  const handleResolve = async () => {
+    if (onResolve === null || isResolving) return;
+    setIsResolving(true);
+    setResolveError(null);
+    try {
+      setResolveError(await onResolve());
+    } finally {
+      setIsResolving(false);
+    }
   };
 
   return (
@@ -95,11 +118,16 @@ function InboxIncidentRow({
         </span>
       }
       description={item.lastFailure}
-      status={item.nextAction}
+      status={resolveError ?? item.nextAction}
       control={
         action === "resolve" ? (
-          <Button size="xs" variant="outline" onClick={onResolve}>
-            Resolve
+          <Button
+            size="xs"
+            variant="outline"
+            disabled={isResolving || onResolve === null}
+            onClick={() => void handleResolve()}
+          >
+            {isResolving ? "Resolving..." : "Resolve"}
           </Button>
         ) : (
           <Button size="xs" variant="outline" onClick={openRepair}>

--- a/apps/web/src/state/botInbox.ts
+++ b/apps/web/src/state/botInbox.ts
@@ -1,0 +1,5 @@
+import { createBotInboxEnvironmentAtoms } from "@t3tools/client-runtime/state/bot-inbox";
+
+import { connectionAtomRuntime } from "../connection/runtime";
+
+export const botInboxEnvironment = createBotInboxEnvironmentAtoms(connectionAtomRuntime);


### PR DESCRIPTION
Settings showed bot inbox incidents but could not resolve approval and user-action rows. It also read the inbox through the broader subscription-auth snapshot.

This uses the focused inbox list atom, adds Resolve actions for rows without a repair destination, and relies on the shared command to refresh the list after completion.

Depends on #31.

Linear: [LEO-289](https://linear.app/opencoredev/issue/LEO-289/add-one-bot-inbox-for-action-required-events)
Linear: [LEO-294](https://linear.app/opencoredev/issue/LEO-294/own-launch-stacks-and-shared-file-integration)
Linear: [LEO-330](https://linear.app/opencoredev/issue/LEO-330/land-the-durable-bot-inbox)

## Testing

- `vp test run apps/web/src/components/settings/InboxPanel.test.ts`
- `vp run typecheck` in `apps/web`

Model: GPT-5.6 Sol
Harness: Codex in T3 Code