### PR TITLE
fix(memory): preserve storage correctness

### DIFF
--- a/apps/server/src/memory/EntityMemoryAccess.test.ts
+++ b/apps/server/src/memory/EntityMemoryAccess.test.ts
@@ -12,6 +12,7 @@ import * as Effect from "effect/Effect";
 import {
   deriveAkeruWorkspaceId,
   resolveAuthorizedMemoryPartitions,
+  resolveMemoryArchivePartitions,
   resolveRecallMemoryPartitions,
 } from "./EntityMemoryAccess.ts";
 
@@ -93,4 +94,21 @@ describe("entity memory access", () => {
     assert.equal(first, second);
     assert.notInclude(first, "/workspaces/akeru");
   });
+
+  it.effect("selects the derived workspace archive partition", () =>
+    Effect.gen(function* () {
+      const partitions = yield* resolveMemoryArchivePartitions(
+        { ...base, botId: BotId.make("bot-1"), groupId: null },
+        "workspace",
+      );
+      assert.deepEqual(partitions, [
+        {
+          tenantId: base.tenantId,
+          scope: "workspace",
+          partitionId: deriveAkeruWorkspaceId(base.workspaceRoot),
+          visibility: "shared",
+        },
+      ]);
+    }),
+  );
 });

--- a/apps/server/src/memory/EntityMemoryAccess.ts
+++ b/apps/server/src/memory/EntityMemoryAccess.ts
@@ -95,7 +95,7 @@ export function resolveRecallMemoryPartitions(
 
 export function resolveMemoryArchivePartitions(
   input: AkeruMemoryThreadAccess,
-  target: "thread" | "bot" | "project" | "all",
+  target: "thread" | "bot" | "project" | "workspace" | "all",
 ): Effect.Effect<ReadonlyArray<AuthorizedMemoryPartition>, AkeruMemoryAccessDenied> {
   return resolveAuthorizedMemoryPartitions(input).pipe(
     Effect.flatMap((partitions) => {
@@ -106,9 +106,11 @@ export function resolveMemoryArchivePartitions(
             ? partitions.filter((candidate) => candidate.scope === "thread")
             : target === "project"
               ? partitions.filter((candidate) => candidate.scope === "project")
-              : partitions.filter(
-                  (candidate) => candidate.scope === "bot-user" || candidate.scope === "bot",
-                );
+              : target === "workspace"
+                ? partitions.filter((candidate) => candidate.scope === "workspace")
+                : partitions.filter(
+                    (candidate) => candidate.scope === "bot-user" || candidate.scope === "bot",
+                  );
       return selected.length > 0
         ? Effect.succeed(selected)
         : Effect.fail(

--- a/apps/server/src/memory/Layers/EntityMemoryRepository.test.ts
+++ b/apps/server/src/memory/Layers/EntityMemoryRepository.test.ts
@@ -32,13 +32,17 @@ import {
   EntityMemoryRepository,
   type EntityMemoryRepositoryShape,
 } from "../Services/EntityMemoryRepository.ts";
+import { MemoryRevisionWriteLockLive } from "../Services/MemoryRevisionWriteLock.ts";
 import { EntityMemoryRepositoryLive } from "./EntityMemoryRepository.ts";
 import { deriveAkeruWorkspaceId, resolveMemoryArchivePartitions } from "../EntityMemoryAccess.ts";
 import { exportAkeruMemory } from "../MemoryExport.ts";
 import { applyAkeruMemoryImport, previewAkeruMemoryImport } from "../MemoryImport.ts";
 
 const repositoryLayer = Layer.mergeAll(
-  EntityMemoryRepositoryLive.pipe(Layer.provide(SqlitePersistenceMemory)),
+  EntityMemoryRepositoryLive.pipe(
+    Layer.provide(MemoryRevisionWriteLockLive),
+    Layer.provide(SqlitePersistenceMemory),
+  ),
   SqlitePersistenceMemory,
 );
 
@@ -84,6 +88,7 @@ it("preserves revision history and FTS recall after repository restart", () =>
     const directory = NodeFS.mkdtempSync(NodePath.join(NodeOS.tmpdir(), "akeru-memory-restart-"));
     const dbPath = NodePath.join(directory, "state.sqlite");
     const restartedLayer = EntityMemoryRepositoryLive.pipe(
+      Layer.provide(MemoryRevisionWriteLockLive),
       Layer.provideMerge(makeSqlitePersistenceLive(dbPath).pipe(Layer.provide(NodeServices.layer))),
     );
     const rootId = AkeruMemoryRootId.make("restart-memory-root");

--- a/apps/server/src/memory/Layers/EntityMemoryRepository.test.ts
+++ b/apps/server/src/memory/Layers/EntityMemoryRepository.test.ts
@@ -33,7 +33,7 @@ import {
   type EntityMemoryRepositoryShape,
 } from "../Services/EntityMemoryRepository.ts";
 import { EntityMemoryRepositoryLive } from "./EntityMemoryRepository.ts";
-import { resolveMemoryArchivePartitions } from "../EntityMemoryAccess.ts";
+import { deriveAkeruWorkspaceId, resolveMemoryArchivePartitions } from "../EntityMemoryAccess.ts";
 import { exportAkeruMemory } from "../MemoryExport.ts";
 import { applyAkeruMemoryImport, previewAkeruMemoryImport } from "../MemoryImport.ts";
 
@@ -232,11 +232,19 @@ it.layer(repositoryLayer)("EntityMemoryRepository", (it) => {
     Effect.gen(function* () {
       const repository = yield* EntityMemoryRepository;
       const rootId = AkeruMemoryRootId.make("delete-root");
-      yield* repository.insert({
+      const initial = makeRevision("delete-memory-1", "bot:user", {
+        rootId,
+        fact: "delete-index-old-marker",
+      });
+      yield* repository.insert({ access: botAccess, revision: initial });
+      yield* repository.revise({
         access: botAccess,
-        revision: makeRevision("delete-memory", "bot:user", {
+        expectedRevision: 1,
+        revision: makeRevision("delete-memory-2", "bot:user", {
           rootId,
-          fact: "delete-index-marker",
+          revision: 2,
+          supersedesId: initial.id,
+          fact: "delete-index-current-marker",
         }),
       });
       yield* repository.deleteRoot({ access: botAccess, rootId });
@@ -245,7 +253,7 @@ it.layer(repositoryLayer)("EntityMemoryRepository", (it) => {
       assert.isTrue(missing._tag === "Failure");
       const search = yield* repository.search({
         access: botAccess,
-        query: "delete index marker",
+        query: "delete index current marker",
         limit: 10,
       });
       assert.deepEqual(search, []);
@@ -645,7 +653,10 @@ it.layer(repositoryLayer)("EntityMemoryRepository", (it) => {
       }).pipe(Effect.exit);
       assert.equal(exit._tag, "Failure");
       if (exit._tag === "Failure") {
-        assert.match(Cause.pretty(exit.cause), /one thread, bot, or project authority domain/);
+        assert.match(
+          Cause.pretty(exit.cause),
+          /one thread, bot, project, or workspace authority domain/,
+        );
       }
     }),
   );
@@ -844,6 +855,58 @@ it.layer(repositoryLayer)("EntityMemoryRepository", (it) => {
         }),
         [],
       );
+    }),
+  );
+
+  it.effect("roundtrips workspace memory with its derived workspace identity", () =>
+    Effect.gen(function* () {
+      const repository = yield* EntityMemoryRepository;
+      const workspaceAccess = privateAccess("bot-workspace-roundtrip");
+      const workspaceId = deriveAkeruWorkspaceId(workspaceAccess.workspaceRoot);
+      const rootId = AkeruMemoryRootId.make("workspace-archive-roundtrip-root");
+      const revision = makeRevision("workspace-archive-roundtrip-revision", workspaceId, {
+        rootId,
+        partition: {
+          tenantId: workspaceAccess.tenantId,
+          scope: "workspace",
+          partitionId: workspaceId,
+        },
+        entityKind: "workspace",
+        entityId: AkeruMemoryEntityId.make(workspaceId),
+        visibility: "shared",
+        sourceThreadId: null,
+        authorBotId: workspaceAccess.botId,
+        initiatingUserId: workspaceAccess.userId,
+        affectedBotIds: [workspaceAccess.botId!],
+      });
+      yield* repository.insert({ access: workspaceAccess, revision });
+      const archive = yield* exportAkeruMemory({
+        repository,
+        access: workspaceAccess,
+        target: "workspace",
+        complete: true,
+        createdAt: "2026-08-30T23:00:00.000Z",
+        conversations: [],
+      });
+      yield* repository.deleteRoot({ access: workspaceAccess, rootId });
+      const preview = yield* previewAkeruMemoryImport({
+        repository,
+        access: workspaceAccess,
+        target: "workspace",
+        archive,
+      });
+      yield* applyAkeruMemoryImport({
+        repository,
+        access: workspaceAccess,
+        target: "workspace",
+        archive,
+        previewHash: preview.previewHash,
+      });
+
+      const restored = yield* repository.getCurrent({ access: workspaceAccess, rootId });
+      assert.equal(restored.entityKind, "workspace");
+      assert.equal(restored.entityId, AkeruMemoryEntityId.make(workspaceId));
+      assert.equal(restored.partition.partitionId, workspaceId);
     }),
   );
 });

--- a/apps/server/src/memory/Layers/EntityMemoryRepository.ts
+++ b/apps/server/src/memory/Layers/EntityMemoryRepository.ts
@@ -11,7 +11,6 @@ import {
 import * as Effect from "effect/Effect";
 import * as Layer from "effect/Layer";
 import * as Schema from "effect/Schema";
-import * as Semaphore from "effect/Semaphore";
 import * as SqlClient from "effect/unstable/sql/SqlClient";
 import * as SqlSchema from "effect/unstable/sql/SqlSchema";
 
@@ -32,6 +31,10 @@ import {
   EntityMemoryImportError,
 } from "../Services/EntityMemoryRepository.ts";
 import { encodeMemoryArchiveJson } from "../MemoryArchiveJson.ts";
+import {
+  MemoryRevisionWriteLock,
+  MemoryRevisionWriteLockLive,
+} from "../Services/MemoryRevisionWriteLock.ts";
 
 const EntityMemoryDbRow = Schema.Struct({
   id: AkeruMemoryId,
@@ -142,7 +145,7 @@ const toFtsQuery = (query: string): string | null => {
 
 const makeEntityMemoryRepository = Effect.gen(function* () {
   const sql = yield* SqlClient.SqlClient;
-  const writeLock = yield* Semaphore.make(1);
+  const writeLock = yield* MemoryRevisionWriteLock;
 
   const insertRow = SqlSchema.void({
     Request: AkeruMemoryRevision,
@@ -258,6 +261,20 @@ const makeEntityMemoryRepository = Effect.gen(function* () {
         }
         yield* insertRow(revision).pipe(
           Effect.mapError(toPersistenceSqlError("EntityMemoryRepository.insert:query")),
+          Effect.catchTag("PersistenceSqlError", (cause) =>
+            getCurrent({ access: input.access, rootId: revision.rootId }).pipe(
+              Effect.flatMap((current) =>
+                Effect.fail(
+                  new EntityMemoryConflictError({
+                    rootId: revision.rootId,
+                    expectedRevision: 0,
+                    actualRevision: current.revision,
+                  }),
+                ),
+              ),
+              Effect.catchTag("EntityMemoryNotFoundError", () => Effect.fail(cause)),
+            ),
+          ),
         );
         return revision;
       }),
@@ -566,7 +583,7 @@ const makeEntityMemoryRepository = Effect.gen(function* () {
       botUserPartition.visibility === "private";
     if (input.partitions.length !== 1 && !isBotAuthorityPair) {
       return yield* new AkeruMemoryAccessDenied({
-        reason: "Import one thread, bot, or project authority domain at a time.",
+        reason: "Import one thread, bot, project, or workspace authority domain at a time.",
       });
     }
     const authorBotId = input.access.respondingBotId ?? input.access.botId;
@@ -597,30 +614,35 @@ const makeEntityMemoryRepository = Effect.gen(function* () {
               entityKind: "project" as const,
               entityId: AkeruMemoryEntityId.make(input.access.projectId),
             }
-          : selected.scope === "bot-user" || selected.scope === "user"
+          : selected.scope === "workspace"
             ? {
-                entityKind: "user" as const,
-                entityId: AkeruMemoryEntityId.make(input.access.userId),
+                entityKind: "workspace" as const,
+                entityId: AkeruMemoryEntityId.make(selected.partitionId),
               }
-            : selected.scope === "bot"
+            : selected.scope === "bot-user" || selected.scope === "user"
               ? {
-                  entityKind: "bot" as const,
-                  entityId: AkeruMemoryEntityId.make(input.access.botId!),
+                  entityKind: "user" as const,
+                  entityId: AkeruMemoryEntityId.make(input.access.userId),
                 }
-              : selected.scope === "thread" && input.access.groupId !== null
+              : selected.scope === "bot"
                 ? {
-                    entityKind: "group" as const,
-                    entityId: AkeruMemoryEntityId.make(input.access.groupId),
+                    entityKind: "bot" as const,
+                    entityId: AkeruMemoryEntityId.make(input.access.botId!),
                   }
-                : selected.scope === "thread" && input.access.botId !== null
+                : selected.scope === "thread" && input.access.groupId !== null
                   ? {
-                      entityKind: "bot" as const,
-                      entityId: AkeruMemoryEntityId.make(input.access.botId),
+                      entityKind: "group" as const,
+                      entityId: AkeruMemoryEntityId.make(input.access.groupId),
                     }
-                  : {
-                      entityKind: "project" as const,
-                      entityId: AkeruMemoryEntityId.make(input.access.projectId),
-                    };
+                  : selected.scope === "thread" && input.access.botId !== null
+                    ? {
+                        entityKind: "bot" as const,
+                        entityId: AkeruMemoryEntityId.make(input.access.botId),
+                      }
+                    : {
+                        entityKind: "project" as const,
+                        entityId: AkeruMemoryEntityId.make(input.access.projectId),
+                      };
       normalized.push({
         ...revision,
         partition: {
@@ -961,4 +983,4 @@ const makeEntityMemoryRepository = Effect.gen(function* () {
 export const EntityMemoryRepositoryLive = Layer.effect(
   EntityMemoryRepository,
   makeEntityMemoryRepository,
-);
+).pipe(Layer.provide(MemoryRevisionWriteLockLive));

--- a/apps/server/src/memory/Layers/EntityMemoryRepository.ts
+++ b/apps/server/src/memory/Layers/EntityMemoryRepository.ts
@@ -31,10 +31,7 @@ import {
   EntityMemoryImportError,
 } from "../Services/EntityMemoryRepository.ts";
 import { encodeMemoryArchiveJson } from "../MemoryArchiveJson.ts";
-import {
-  MemoryRevisionWriteLock,
-  MemoryRevisionWriteLockLive,
-} from "../Services/MemoryRevisionWriteLock.ts";
+import { MemoryRevisionWriteLock } from "../Services/MemoryRevisionWriteLock.ts";
 
 const EntityMemoryDbRow = Schema.Struct({
   id: AkeruMemoryId,
@@ -983,4 +980,4 @@ const makeEntityMemoryRepository = Effect.gen(function* () {
 export const EntityMemoryRepositoryLive = Layer.effect(
   EntityMemoryRepository,
   makeEntityMemoryRepository,
-).pipe(Layer.provide(MemoryRevisionWriteLockLive));
+);

--- a/apps/server/src/memory/Layers/MemoryCandidateRepository.test.ts
+++ b/apps/server/src/memory/Layers/MemoryCandidateRepository.test.ts
@@ -23,6 +23,7 @@ import {
 import * as Effect from "effect/Effect";
 import * as Cause from "effect/Cause";
 import * as Layer from "effect/Layer";
+import * as Semaphore from "effect/Semaphore";
 import * as SqlClient from "effect/unstable/sql/SqlClient";
 
 import {
@@ -31,12 +32,20 @@ import {
 } from "../../persistence/Layers/Sqlite.ts";
 import { EntityMemoryRepository } from "../Services/EntityMemoryRepository.ts";
 import { MemoryCandidateRepository } from "../Services/MemoryCandidateRepository.ts";
+import {
+  MemoryRevisionWriteLock,
+  MemoryRevisionWriteLockLive,
+} from "../Services/MemoryRevisionWriteLock.ts";
 import { EntityMemoryRepositoryLive } from "./EntityMemoryRepository.ts";
 import { MemoryCandidateRepositoryLive } from "./MemoryCandidateRepository.ts";
 
+const repositoriesLive = Layer.mergeAll(
+  EntityMemoryRepositoryLive,
+  MemoryCandidateRepositoryLive,
+).pipe(Layer.provide(MemoryRevisionWriteLockLive));
+
 const layer = Layer.mergeAll(
-  EntityMemoryRepositoryLive.pipe(Layer.provide(SqlitePersistenceMemory)),
-  MemoryCandidateRepositoryLive.pipe(Layer.provide(SqlitePersistenceMemory)),
+  repositoriesLive.pipe(Layer.provide(SqlitePersistenceMemory)),
   SqlitePersistenceMemory,
 );
 
@@ -78,8 +87,7 @@ it("preserves candidates and decision receipts after repository restart", () =>
     const dbPath = NodePath.join(directory, "state.sqlite");
     const persistence = makeSqlitePersistenceLive(dbPath).pipe(Layer.provide(NodeServices.layer));
     const restartedLayer = Layer.mergeAll(
-      EntityMemoryRepositoryLive.pipe(Layer.provide(persistence)),
-      MemoryCandidateRepositoryLive.pipe(Layer.provide(persistence)),
+      repositoriesLive.pipe(Layer.provide(persistence)),
       persistence,
     );
     const candidateId = AkeruMemoryCandidateId.make("candidate-restart");
@@ -127,6 +135,27 @@ it("preserves candidates and decision receipts after repository restart", () =>
     }).pipe(Effect.provide(restartedLayer));
     NodeFS.rmSync(directory, { recursive: true, force: true });
   }));
+
+it("shares one revision write lock between both repositories", () => {
+  let constructions = 0;
+  const countedLock = Layer.effect(
+    MemoryRevisionWriteLock,
+    Effect.gen(function* () {
+      constructions++;
+      return yield* Semaphore.make(1);
+    }),
+  );
+  const countedRepositories = Layer.mergeAll(
+    EntityMemoryRepositoryLive,
+    MemoryCandidateRepositoryLive,
+  ).pipe(Layer.provide(countedLock), Layer.provide(SqlitePersistenceMemory));
+
+  return Effect.gen(function* () {
+    yield* EntityMemoryRepository;
+    yield* MemoryCandidateRepository;
+    assert.equal(constructions, 1);
+  }).pipe(Effect.provide(countedRepositories));
+});
 
 const approvedRevision = (id: string): AkeruMemoryRevision => ({
   id: AkeruMemoryId.make(`${id}-revision`),

--- a/apps/server/src/memory/Layers/MemoryCandidateRepository.test.ts
+++ b/apps/server/src/memory/Layers/MemoryCandidateRepository.test.ts
@@ -21,6 +21,7 @@ import {
   type AkeruMemoryRevision,
 } from "@t3tools/contracts";
 import * as Effect from "effect/Effect";
+import * as Cause from "effect/Cause";
 import * as Layer from "effect/Layer";
 import * as SqlClient from "effect/unstable/sql/SqlClient";
 
@@ -210,6 +211,41 @@ it.layer(layer)("MemoryCandidateRepository", (it) => {
         })
         .pipe(Effect.exit);
       assert.isTrue(replay._tag === "Failure");
+    }),
+  );
+
+  it.effect("coordinates candidate approval with direct revision writers", () =>
+    Effect.gen(function* () {
+      const candidates = yield* MemoryCandidateRepository;
+      const memory = yield* EntityMemoryRepository;
+      const candidateId = AkeruMemoryCandidateId.make("candidate-concurrent-head");
+      const approved = approvedRevision("candidate-concurrent-head");
+      const direct = { ...approved, id: AkeruMemoryId.make("direct-concurrent-head") };
+      yield* candidates.create({ access, candidate: candidate(candidateId) });
+
+      const exits = yield* Effect.all(
+        [
+          Effect.exit(
+            candidates.approve({
+              access,
+              candidateId,
+              revision: approved,
+              receiptId: "receipt-concurrent-head",
+              decidedAt: approved.updatedAt,
+            }),
+          ),
+          Effect.exit(memory.insert({ access, revision: direct })),
+        ],
+        { concurrency: "unbounded" },
+      );
+      const failures = exits.filter((exit) => exit._tag === "Failure");
+      assert.equal(failures.length, 1);
+      const error = Cause.squash(failures[0]!.cause as Cause.Cause<unknown>);
+      assert.include(
+        ["EntityMemoryConflictError", "MemoryCandidateConflictError"],
+        (error as { readonly _tag?: string })._tag,
+      );
+      assert.equal((yield* memory.listHistory({ access, rootId: approved.rootId })).length, 1);
     }),
   );
 

--- a/apps/server/src/memory/Layers/MemoryCandidateRepository.ts
+++ b/apps/server/src/memory/Layers/MemoryCandidateRepository.ts
@@ -9,7 +9,6 @@ import {
 import * as Effect from "effect/Effect";
 import * as Layer from "effect/Layer";
 import * as Schema from "effect/Schema";
-import * as Semaphore from "effect/Semaphore";
 import * as SqlClient from "effect/unstable/sql/SqlClient";
 
 import { toPersistenceDecodeError, toPersistenceSqlError } from "../../persistence/Errors.ts";
@@ -23,6 +22,10 @@ import {
   MemoryCandidateRepository,
   type MemoryCandidateRepositoryShape,
 } from "../Services/MemoryCandidateRepository.ts";
+import {
+  MemoryRevisionWriteLock,
+  MemoryRevisionWriteLockLive,
+} from "../Services/MemoryRevisionWriteLock.ts";
 
 const CandidateRow = Schema.Struct({
   candidateId: Schema.String,
@@ -126,7 +129,7 @@ const expectedEntityId = (scope: AkeruMemoryTargetScope, access: AkeruMemoryThre
 
 const makeMemoryCandidateRepository = Effect.gen(function* () {
   const sql = yield* SqlClient.SqlClient;
-  const writeLock = yield* Semaphore.make(1);
+  const writeLock = yield* MemoryRevisionWriteLock;
 
   const getPending = Effect.fn("MemoryCandidateRepository.getPending")(function* (
     access: AkeruMemoryThreadAccess,
@@ -237,22 +240,28 @@ const makeMemoryCandidateRepository = Effect.gen(function* () {
             reason: "The approved memory revision is not valid for this authenticated turn.",
           });
         }
-        if (nextRevision) {
-          const currentRows = yield* sql<{
-            readonly id: string;
-            readonly revision: number;
-            readonly scope: string;
-            readonly partitionId: string;
-            readonly visibility: string;
-            readonly deletionState: string;
-          }>`
+        const currentRows = yield* sql<{
+          readonly id: string;
+          readonly revision: number;
+          readonly scope: string;
+          readonly partitionId: string;
+          readonly visibility: string;
+          readonly deletionState: string;
+        }>`
           SELECT memory_id AS id, revision, scope, partition_id AS partitionId,
             visibility, deletion_state AS deletionState
           FROM akeru_memory_revisions
           WHERE tenant_id = ${input.access.tenantId} AND root_id = ${revision.rootId}
             AND superseded_by_id IS NULL LIMIT 1
         `.pipe(Effect.mapError(toPersistenceSqlError("MemoryCandidateRepository.approve:current")));
-          const current = currentRows[0];
+        const current = currentRows[0];
+        if (initialRevision && current) {
+          return yield* new MemoryCandidateConflictError({
+            candidateId: candidate.candidateId,
+            detail: "a current revision already exists for this memory root",
+          });
+        }
+        if (nextRevision) {
           const currentAuthorized =
             current &&
             partitions.some(
@@ -421,4 +430,4 @@ const makeMemoryCandidateRepository = Effect.gen(function* () {
 export const MemoryCandidateRepositoryLive = Layer.effect(
   MemoryCandidateRepository,
   makeMemoryCandidateRepository,
-);
+).pipe(Layer.provide(MemoryRevisionWriteLockLive));

--- a/apps/server/src/memory/Layers/MemoryCandidateRepository.ts
+++ b/apps/server/src/memory/Layers/MemoryCandidateRepository.ts
@@ -22,10 +22,7 @@ import {
   MemoryCandidateRepository,
   type MemoryCandidateRepositoryShape,
 } from "../Services/MemoryCandidateRepository.ts";
-import {
-  MemoryRevisionWriteLock,
-  MemoryRevisionWriteLockLive,
-} from "../Services/MemoryRevisionWriteLock.ts";
+import { MemoryRevisionWriteLock } from "../Services/MemoryRevisionWriteLock.ts";
 
 const CandidateRow = Schema.Struct({
   candidateId: Schema.String,
@@ -430,4 +427,4 @@ const makeMemoryCandidateRepository = Effect.gen(function* () {
 export const MemoryCandidateRepositoryLive = Layer.effect(
   MemoryCandidateRepository,
   makeMemoryCandidateRepository,
-).pipe(Layer.provide(MemoryRevisionWriteLockLive));
+);

--- a/apps/server/src/memory/MemoryImport.ts
+++ b/apps/server/src/memory/MemoryImport.ts
@@ -46,7 +46,7 @@ const prepare = Effect.fn("MemoryImport.prepare")(function* (input: {
     input.target === "all"
       ? yield* new EntityMemoryImportError({
           detail:
-            "All-memory archives span separate authority domains. Import a thread, bot, or project archive instead.",
+            "All-memory archives span separate authority domains. Import a thread, bot, project, or workspace archive instead.",
         })
       : input.target;
   if (input.archive.files.some((file) => checksum(file.content) !== file.sha256)) {

--- a/apps/server/src/memory/Services/MemoryRevisionWriteLock.ts
+++ b/apps/server/src/memory/Services/MemoryRevisionWriteLock.ts
@@ -1,0 +1,10 @@
+import * as Context from "effect/Context";
+import * as Layer from "effect/Layer";
+import * as Semaphore from "effect/Semaphore";
+
+export class MemoryRevisionWriteLock extends Context.Service<
+  MemoryRevisionWriteLock,
+  Semaphore.Semaphore
+>()("akeru-bot/memory/Services/MemoryRevisionWriteLock") {}
+
+export const MemoryRevisionWriteLockLive = Layer.effect(MemoryRevisionWriteLock, Semaphore.make(1));

--- a/packages/contracts/src/akeruMemory.test.ts
+++ b/packages/contracts/src/akeruMemory.test.ts
@@ -8,6 +8,7 @@ import {
   AKERU_MEMORY_PACKET_MAX_FACTS,
   AkeruMemoryCandidate,
   AkeruMemoryCandidateDecision,
+  AkeruMemoryExportInput,
   AkeruMemoryDecisionReceipt,
   AkeruMemoryPacket,
   AkeruMemoryMutateInput,
@@ -89,6 +90,17 @@ describe("Akeru memory contracts", () => {
 
       assert.equal(candidate.status, "pending");
       assert.equal(decision.decision, "approve");
+    }),
+  );
+
+  it.effect("accepts workspace memory archives", () =>
+    Effect.gen(function* () {
+      const input = yield* Schema.decodeUnknownEffect(AkeruMemoryExportInput)({
+        threadId: "thread-1",
+        complete: true,
+        target: "workspace",
+      });
+      assert.equal(input.target, "workspace");
     }),
   );
 

--- a/packages/contracts/src/akeruMemory.ts
+++ b/packages/contracts/src/akeruMemory.ts
@@ -198,7 +198,13 @@ export const AkeruMemoryArchiveV1 = Schema.Struct({
 });
 export type AkeruMemoryArchiveV1 = typeof AkeruMemoryArchiveV1.Type;
 
-export const AkeruMemoryArchiveTarget = Schema.Literals(["thread", "bot", "project", "all"]);
+export const AkeruMemoryArchiveTarget = Schema.Literals([
+  "thread",
+  "bot",
+  "project",
+  "workspace",
+  "all",
+]);
 export type AkeruMemoryArchiveTarget = typeof AkeruMemoryArchiveTarget.Type;
 
 export const AkeruMemoryArchiveRevision = Schema.Struct({


### PR DESCRIPTION
## What changed

- Added workspace archive selection and import normalization that keeps the derived workspace identity.
- Serialized entity and candidate revision writers with one shared lock and return domain conflicts for competing current heads.
- Covered permanent deletion after revision history and FTS updates.

## Why

Workspace archives could not round-trip as workspace memory. Entity and candidate writers used separate locks, so concurrent writes could expose SQLite current-head constraint errors instead of memory conflicts. Revised roots also needed deletion coverage for every history and FTS row.

Linear: [LEO-285](https://linear.app/opencoredev/issue/LEO-285), [LEO-296](https://linear.app/opencoredev/issue/LEO-296), [LEO-297](https://linear.app/opencoredev/issue/LEO-297), [LEO-294](https://linear.app/opencoredev/issue/LEO-294), [LEO-329](https://linear.app/opencoredev/issue/LEO-329)

Tests: 39 focused tests passed across the contracts memory, memory access, entity repository, and candidate repository suites. Contracts and server typechecks passed.

## Checklist

- [x] This PR is small and focused
- [x] I explained what changed and why
- [x] I linked the accepted plugin or provider proposal in **Why**, or this PR does not add one
- [x] I included before/after screenshots for any UI changes
- [x] I included a video for animation/interaction changes

Model: GPT-5.6 Sol
Harness: Codex in T3 Code