### PR TITLE
feat(mobile): resolve bot inbox incidents

### DIFF
--- a/apps/mobile/src/features/settings/SettingsProviderHealthRouteScreen.tsx
+++ b/apps/mobile/src/features/settings/SettingsProviderHealthRouteScreen.tsx
@@ -1,16 +1,17 @@
 import { useNavigation, type StaticScreenProps } from "@react-navigation/native";
 import { useAtomValue } from "@effect/atom-react";
-import type { EnvironmentId, SubscriptionAuthStatuses } from "@t3tools/contracts";
+import type { BotInboxItem, EnvironmentId } from "@t3tools/contracts";
 import { Platform, Pressable, RefreshControl, ScrollView, View } from "react-native";
 import { useSafeAreaInsets } from "react-native-safe-area-context";
 
 import { AndroidScreenHeader } from "../../components/AndroidScreenHeader";
 import { AppText as Text } from "../../components/AppText";
 import { NativeStackScreenOptions } from "../../native/StackHeader";
+import { botInboxEnvironment } from "../../state/botInbox";
 import { useEnvironmentQuery } from "../../state/query";
 import { serverEnvironment } from "../../state/server";
 import { useAtomCommand } from "../../state/use-atom-command";
-import { settingsInboxView } from "./botInbox.logic";
+import { canResolveInboxItem, settingsInboxView } from "./botInbox.logic";
 import { SettingsSection } from "./components/SettingsSection";
 
 export type SettingsProviderHealthParams = {
@@ -27,7 +28,14 @@ function Field(props: { readonly label: string; readonly value: string }) {
   );
 }
 
-function BotInbox({ items }: { readonly items: SubscriptionAuthStatuses["inbox"] }) {
+function BotInbox({
+  environmentId,
+  items,
+}: {
+  readonly environmentId: EnvironmentId;
+  readonly items: ReadonlyArray<BotInboxItem>;
+}) {
+  const resolveIncident = useAtomCommand(botInboxEnvironment.resolve);
   return (
     <SettingsSection title="Error inbox" card>
       {items.length === 0 ? (
@@ -42,6 +50,17 @@ function BotInbox({ items }: { readonly items: SubscriptionAuthStatuses["inbox"]
             <Field label="Task or routine" value={item.taskOrRoutine} />
             <Field label="Last failure" value={item.lastFailure} />
             <Field label="Next action" value={item.nextAction} />
+            {canResolveInboxItem(item) ? (
+              <Pressable
+                accessibilityRole="button"
+                className="self-start rounded-[12px] bg-subtle px-3 py-2"
+                onPress={() => {
+                  void resolveIncident({ environmentId, input: { id: item.id } });
+                }}
+              >
+                <Text className="text-sm font-t3-medium text-foreground">Resolve</Text>
+              </Pressable>
+            ) : null}
           </View>
         ))
       )}
@@ -102,7 +121,7 @@ export function SettingsProviderHealthRouteScreen({
   const query = useEnvironmentQuery(
     route.params.target === "local-execution"
       ? null
-      : serverEnvironment.subscriptionAuth({
+      : botInboxEnvironment.list({
           environmentId: route.params.environmentId,
           input: {},
         }),
@@ -115,7 +134,7 @@ export function SettingsProviderHealthRouteScreen({
     route.params.target === "local-execution" ? (
       <LocalExecution environmentId={route.params.environmentId} />
     ) : inboxView?.kind === "ready" ? (
-      <BotInbox items={inboxView.items} />
+      <BotInbox environmentId={route.params.environmentId} items={inboxView.items} />
     ) : null;
 
   return (
@@ -140,7 +159,7 @@ export function SettingsProviderHealthRouteScreen({
           <Text className="py-16 text-center text-sm text-danger">{inboxView.message}</Text>
         ) : inboxView?.kind === "loading" ? (
           <Text className="py-16 text-center text-sm text-foreground-muted">
-            Loading provider health…
+            Loading bot inbox…
           </Text>
         ) : (
           section

--- a/apps/mobile/src/features/settings/botInbox.logic.test.ts
+++ b/apps/mobile/src/features/settings/botInbox.logic.test.ts
@@ -2,7 +2,7 @@ import { BotId } from "@t3tools/contracts";
 import type { BotInboxItem } from "@t3tools/client-runtime/bot-inbox";
 import { describe, expect, it } from "vite-plus/test";
 
-import { settingsInboxView } from "./botInbox.logic";
+import { canResolveInboxItem, settingsInboxView } from "./botInbox.logic";
 
 function incident(overrides: Partial<BotInboxItem> = {}): BotInboxItem {
   return {
@@ -27,7 +27,7 @@ describe("settingsInboxView", () => {
     expect(
       settingsInboxView({
         error: "Environment disconnected",
-        data: { inbox: [incident()] },
+        data: [incident()],
       }),
     ).toEqual({ kind: "error", message: "Environment disconnected" });
   });
@@ -39,13 +39,11 @@ describe("settingsInboxView", () => {
   it("drops resolved items and sorts the newest open incident first", () => {
     const view = settingsInboxView({
       error: null,
-      data: {
-        inbox: [
-          incident({ id: "older" }),
-          incident({ id: "resolved", status: "resolved" }),
-          incident({ id: "newer", lastSeenAt: "2026-08-30T11:00:00.000Z" }),
-        ],
-      },
+      data: [
+        incident({ id: "older" }),
+        incident({ id: "resolved", status: "resolved" }),
+        incident({ id: "newer", lastSeenAt: "2026-08-30T11:00:00.000Z" }),
+      ],
     });
 
     expect(view).toEqual({
@@ -61,8 +59,15 @@ describe("settingsInboxView", () => {
     expect(
       settingsInboxView({
         error: null,
-        data: { inbox: [incident({ status: "resolved" })] },
+        data: [incident({ status: "resolved" })],
       }),
     ).toEqual({ kind: "ready", items: [] });
+  });
+});
+
+describe("canResolveInboxItem", () => {
+  it("keeps connector incidents open until their dependency recovers", () => {
+    expect(canResolveInboxItem(incident())).toBe(false);
+    expect(canResolveInboxItem(incident({ kind: "approval-request" }))).toBe(true);
   });
 });

--- a/apps/mobile/src/features/settings/botInbox.logic.ts
+++ b/apps/mobile/src/features/settings/botInbox.logic.ts
@@ -2,13 +2,17 @@ import { selectOpenBotInboxItems, type BotInboxItem } from "@t3tools/client-runt
 
 export type SettingsInboxQuery = {
   readonly error: string | null;
-  readonly data: { readonly inbox: ReadonlyArray<BotInboxItem> } | null;
+  readonly data: ReadonlyArray<BotInboxItem> | null;
 };
 
 export type SettingsInboxView =
   | { readonly kind: "error"; readonly message: string }
   | { readonly kind: "loading" }
   | { readonly kind: "ready"; readonly items: ReadonlyArray<BotInboxItem> };
+
+export function canResolveInboxItem(item: BotInboxItem): boolean {
+  return item.kind === "approval-request";
+}
 
 export function settingsInboxView(query: SettingsInboxQuery): SettingsInboxView {
   if (query.error !== null) {
@@ -17,5 +21,5 @@ export function settingsInboxView(query: SettingsInboxQuery): SettingsInboxView 
   if (query.data === null) {
     return { kind: "loading" };
   }
-  return { kind: "ready", items: selectOpenBotInboxItems(query.data.inbox) };
+  return { kind: "ready", items: selectOpenBotInboxItems(query.data) };
 }

--- a/apps/mobile/src/state/botInbox.ts
+++ b/apps/mobile/src/state/botInbox.ts
@@ -1,0 +1,5 @@
+import { createBotInboxEnvironmentAtoms } from "@t3tools/client-runtime/state/bot-inbox";
+
+import { connectionAtomRuntime } from "../connection/runtime";
+
+export const botInboxEnvironment = createBotInboxEnvironmentAtoms(connectionAtomRuntime);


### PR DESCRIPTION
## What changed

- Read incidents through the focused bot inbox query.
- Resolve approval requests from the provider health screen.
- Keep connector incidents open until the dependency recovers.

## Why

Mobile read inbox data through the broader subscription-auth snapshot and offered no action for approval requests. Connector incidents need recovery from the failed dependency, so the screen does not offer a manual Resolve action for them.

Builds on #31.

Linear: [LEO-289](https://linear.app/opencoredev/issue/LEO-289/add-one-bot-inbox-for-action-required-events)
Linear: [LEO-294](https://linear.app/opencoredev/issue/LEO-294/own-launch-stacks-and-shared-file-integration)
Linear: [LEO-330](https://linear.app/opencoredev/issue/LEO-330/land-the-durable-bot-inbox)

## Testing

- `vp test run apps/mobile/src/features/settings/botInbox.logic.test.ts`
- `vp run typecheck` in `apps/mobile`
- `git diff --check origin/main...HEAD`

## UI changes

Screenshots and video were not captured because browser and computer control were not authorized for this run.

## Checklist

- [x] This PR is small and focused
- [x] I explained what changed and why
- [x] This PR does not add a plugin or provider
- [ ] I included before/after screenshots for UI changes
- [ ] I included a video for interaction changes

Model: GPT-5.6 Sol
Harness: Codex in T3 Code