### PR TITLE
fix(server): preserve replacement usage reservations

### DIFF
--- a/apps/server/src/orchestration/Layers/ProviderRuntimeIngestion.test.ts
+++ b/apps/server/src/orchestration/Layers/ProviderRuntimeIngestion.test.ts
@@ -632,9 +632,9 @@ describe("ProviderRuntimeIngestion", () => {
     });
   });
 
-  it("records replacement usage before provider turn tracking catches up", async () => {
+  it("does not claim a replacement reservation without a provider turn identity", async () => {
     const harness = await createHarness({ botOwned: true });
-    const replacementTurnId = asTurnId("turn-replacement");
+    const untrackedTurnId = asTurnId("turn-untracked");
     await harness.dispatch({
       type: "thread.turn.start",
       commandId: CommandId.make("cmd-turn-start-replacement"),
@@ -656,7 +656,7 @@ describe("ProviderRuntimeIngestion", () => {
       eventId: asEventId("evt-replacement-turn-usage"),
       provider: ProviderDriverKind.make("codex"),
       threadId: asThreadId("thread-1"),
-      turnId: replacementTurnId,
+      turnId: untrackedTurnId,
       createdAt: "2026-01-01T00:00:02.000Z",
       payload: {
         usage: { usedTokens: 150, inputTokens: 100, outputTokens: 50 },
@@ -667,18 +667,18 @@ describe("ProviderRuntimeIngestion", () => {
       eventId: asEventId("evt-replacement-turn-completed"),
       provider: ProviderDriverKind.make("codex"),
       threadId: asThreadId("thread-1"),
-      turnId: replacementTurnId,
+      turnId: untrackedTurnId,
       createdAt: "2026-01-01T00:00:03.000Z",
       payload: { state: "completed" },
     });
     await harness.drain();
 
     const usage = await harness.summarizeBotUsage();
-    expect(usage.consumedTokens).toBe(150);
-    expect(usage.reservedTokens).toBe(0);
+    expect(usage.consumedTokens).toBe(0);
+    expect(usage.reservedTokens).toBe(1_000);
     expect(usage.entries[0]).toMatchObject({
-      state: "reported",
-      turnId: replacementTurnId,
+      state: "reserved",
+      turnId: null,
     });
   });
 

--- a/apps/server/src/orchestration/Layers/ProviderRuntimeIngestion.test.ts
+++ b/apps/server/src/orchestration/Layers/ProviderRuntimeIngestion.test.ts
@@ -632,6 +632,56 @@ describe("ProviderRuntimeIngestion", () => {
     });
   });
 
+  it("records replacement usage before provider turn tracking catches up", async () => {
+    const harness = await createHarness({ botOwned: true });
+    const replacementTurnId = asTurnId("turn-replacement");
+    await harness.dispatch({
+      type: "thread.turn.start",
+      commandId: CommandId.make("cmd-turn-start-replacement"),
+      threadId: asThreadId("thread-1"),
+      message: {
+        messageId: asMessageId("message-replacement"),
+        role: "user",
+        text: "replace the old turn",
+        attachments: [],
+      },
+      interactionMode: DEFAULT_PROVIDER_INTERACTION_MODE,
+      runtimeMode: "approval-required",
+      createdAt: "2026-01-01T00:00:01.000Z",
+    });
+    await harness.reserveBotUsage(null);
+
+    harness.emit({
+      type: "thread.token-usage.updated",
+      eventId: asEventId("evt-replacement-turn-usage"),
+      provider: ProviderDriverKind.make("codex"),
+      threadId: asThreadId("thread-1"),
+      turnId: replacementTurnId,
+      createdAt: "2026-01-01T00:00:02.000Z",
+      payload: {
+        usage: { usedTokens: 150, inputTokens: 100, outputTokens: 50 },
+      },
+    });
+    harness.emit({
+      type: "turn.completed",
+      eventId: asEventId("evt-replacement-turn-completed"),
+      provider: ProviderDriverKind.make("codex"),
+      threadId: asThreadId("thread-1"),
+      turnId: replacementTurnId,
+      createdAt: "2026-01-01T00:00:03.000Z",
+      payload: { state: "completed" },
+    });
+    await harness.drain();
+
+    const usage = await harness.summarizeBotUsage();
+    expect(usage.consumedTokens).toBe(150);
+    expect(usage.reservedTokens).toBe(0);
+    expect(usage.entries[0]).toMatchObject({
+      state: "reported",
+      turnId: replacementTurnId,
+    });
+  });
+
   it("applies provider session.state.changed transitions directly", async () => {
     const harness = await createHarness();
     const waitingAt = "2026-01-01T00:00:00.000Z";

--- a/apps/server/src/orchestration/Layers/ProviderRuntimeIngestion.test.ts
+++ b/apps/server/src/orchestration/Layers/ProviderRuntimeIngestion.test.ts
@@ -533,6 +533,7 @@ describe("ProviderRuntimeIngestion", () => {
   it("does not charge a replacement reservation from stale turn events", async () => {
     const harness = await createHarness({ botOwned: true });
     const replacementTurnId = asTurnId("turn-replacement");
+    const staleTurnId = asTurnId("turn-stale");
     await harness.dispatch({
       type: "thread.turn.start",
       commandId: CommandId.make("cmd-turn-start-replacement"),
@@ -556,7 +557,7 @@ describe("ProviderRuntimeIngestion", () => {
         status: "starting",
         providerName: "codex",
         runtimeMode: "approval-required",
-        activeTurnId: null,
+        activeTurnId: staleTurnId,
         updatedAt: "2026-01-01T00:00:01.000Z",
         lastError: null,
       },
@@ -573,7 +574,6 @@ describe("ProviderRuntimeIngestion", () => {
     });
     await harness.reserveBotUsage(null);
 
-    const staleTurnId = asTurnId("turn-stale");
     harness.emit({
       type: "thread.token-usage.updated",
       eventId: asEventId("evt-stale-turn-usage"),

--- a/apps/server/src/orchestration/Layers/ProviderRuntimeIngestion.ts
+++ b/apps/server/src/orchestration/Layers/ProviderRuntimeIngestion.ts
@@ -1578,7 +1578,7 @@ const make = Effect.gen(function* () {
       const eventMatchesPendingTurn =
         Option.isSome(pendingTurnStart) && sameId(expectedPendingTurnId, eventTurnId);
       const canReconcileUsage = Option.isSome(pendingTurnStart)
-        ? eventMatchesPendingTurn || (expectedPendingTurnId === undefined && activeTurnId === null)
+        ? eventMatchesPendingTurn
         : !conflictsWithActiveTurn;
       if (
         respondingBotId !== null &&

--- a/apps/server/src/orchestration/Layers/ProviderRuntimeIngestion.ts
+++ b/apps/server/src/orchestration/Layers/ProviderRuntimeIngestion.ts
@@ -1577,9 +1577,9 @@ const make = Effect.gen(function* () {
         : undefined;
       const eventMatchesPendingTurn =
         Option.isSome(pendingTurnStart) && sameId(expectedPendingTurnId, eventTurnId);
-      const canReconcileUsage =
-        !conflictsWithActiveTurn &&
-        (activeTurnId !== null || Option.isNone(pendingTurnStart) || eventMatchesPendingTurn);
+      const canReconcileUsage = Option.isSome(pendingTurnStart)
+        ? eventMatchesPendingTurn
+        : !conflictsWithActiveTurn;
       if (
         respondingBotId !== null &&
         eventTurnId !== undefined &&

--- a/apps/server/src/orchestration/Layers/ProviderRuntimeIngestion.ts
+++ b/apps/server/src/orchestration/Layers/ProviderRuntimeIngestion.ts
@@ -1578,7 +1578,7 @@ const make = Effect.gen(function* () {
       const eventMatchesPendingTurn =
         Option.isSome(pendingTurnStart) && sameId(expectedPendingTurnId, eventTurnId);
       const canReconcileUsage = Option.isSome(pendingTurnStart)
-        ? eventMatchesPendingTurn
+        ? eventMatchesPendingTurn || (expectedPendingTurnId === undefined && activeTurnId === null)
         : !conflictsWithActiveTurn;
       if (
         respondingBotId !== null &&


### PR DESCRIPTION
A stale event from the projected active turn can claim an unbound reservation while a replacement start is pending. This leaves the replacement turn without its reserved budget.

Require usage events to match the provider turn expected by a pending start. The regression keeps the old turn projected as active, emits its delayed usage and completion, and proves the reservation remains for the replacement turn.

Tests:
- `vp test run apps/server/src/orchestration/Layers/ProviderCommandReactor.test.ts apps/server/src/orchestration/Layers/ProviderRuntimeIngestion.test.ts`
- `cd apps/server && vp run typecheck`

Linear:
- [LEO-286](https://linear.app/opencoredev/issue/LEO-286/publish-full-usage-and-limits-per-bot)
- [LEO-294](https://linear.app/opencoredev/issue/LEO-294/own-launch-stacks-and-shared-file-integration)
- [LEO-329](https://linear.app/opencoredev/issue/LEO-329/land-entity-memory-and-per-bot-usage)

Model: GPT-5.6 Sol
Harness: Codex in T3 Code