### PR TITLE
feat(web): show per-bot usage

### DIFF
--- a/apps/web/src/components/roster/BotDetailsPanel.test.tsx
+++ b/apps/web/src/components/roster/BotDetailsPanel.test.tsx
@@ -38,6 +38,7 @@ describe("BotDetailsPanel", () => {
     expect(markup).toContain("Connect a provider");
     expect(markup).toContain(">Sandbox</div>");
     expect(markup).toContain('aria-label="Sandbox provider"');
+    expect(markup).toContain('aria-label="Bot usage"');
     expect(markup).toContain(">Voice calls</span>");
     expect(markup).toContain('aria-label="Enable voice calls for Akeru"');
     expect(markup).toContain(">Tools</div>");

--- a/apps/web/src/components/roster/BotDetailsPanel.tsx
+++ b/apps/web/src/components/roster/BotDetailsPanel.tsx
@@ -42,6 +42,7 @@ import { Tooltip, TooltipPopup, TooltipTrigger } from "../ui/tooltip";
 import { AvatarPickerDialog } from "./AvatarPickerDialog";
 import { BotAvatarView } from "./BotAvatarView";
 import { BotModelPicker } from "./BotModelPicker";
+import { BotUsageSection } from "./BotUsageSection";
 import {
   BOT_SANDBOX_OPTIONS,
   botSandboxChoice,
@@ -250,6 +251,8 @@ function BotProfileEditor({
             )}
           </div>
         </div>
+
+        <BotUsageSection environmentId={environmentId} botId={bot.id} />
 
         <div className="space-y-2">
           <div className="text-sm font-medium">Sandbox</div>

--- a/apps/web/src/components/roster/BotUsageSection.test.ts
+++ b/apps/web/src/components/roster/BotUsageSection.test.ts
@@ -1,0 +1,135 @@
+import { BotId, EnvironmentId } from "@t3tools/contracts";
+import { createElement } from "react";
+import { renderToStaticMarkup } from "react-dom/server";
+import { beforeEach, describe, expect, it, vi } from "vite-plus/test";
+
+const state = vi.hoisted(() => ({
+  query: vi.fn(),
+  summary: vi.fn(() => ({})),
+}));
+
+vi.mock("../../state/query", () => ({ useEnvironmentQuery: state.query }));
+vi.mock("../../state/botUsage", () => ({
+  botUsageEnvironment: { summary: state.summary },
+}));
+
+import { BotUsageSection, formatUsageMeasurement } from "./BotUsageSection";
+
+const render = () =>
+  renderToStaticMarkup(
+    createElement(BotUsageSection, {
+      environmentId: EnvironmentId.make("environment-1"),
+      botId: "bot-1",
+    }),
+  );
+
+const snapshot = {
+  botId: BotId.make("bot-1"),
+  consumedTokens: 12_345,
+  reservedTokens: 750,
+  measurements: {
+    input: { tokens: 1_250, unavailableEntries: 0 },
+    output: { tokens: 2_500, unavailableEntries: 0 },
+    observer: { tokens: 300, unavailableEntries: 0 },
+    reflector: { tokens: 100, unavailableEntries: 0 },
+  },
+  entries: [],
+  usageCap: { unit: "tokens", limit: 20_000 },
+  estimatedCost: { status: "available", usd: 1.25 },
+  subscriptionPool: { status: "available", used: 4_000, limit: 10_000, unit: "tokens" },
+} as const;
+
+describe("formatUsageMeasurement", () => {
+  beforeEach(() => {
+    state.query.mockReset();
+    state.summary.mockClear();
+  });
+
+  it("distinguishes exact, partial, and unavailable provider usage", () => {
+    expect(formatUsageMeasurement({ tokens: 1_250, unavailableEntries: 0 })).toBe("1,250");
+    expect(formatUsageMeasurement({ tokens: 1_250, unavailableEntries: 1 })).toBe("1,250+");
+    expect(formatUsageMeasurement({ tokens: 0, unavailableEntries: 1 })).toBe("Unavailable");
+  });
+
+  it("renders loading, empty, and failed usage states", () => {
+    state.query.mockReturnValueOnce({ data: null, error: null, isPending: true, refresh: vi.fn() });
+    expect(render()).toContain("Loading…");
+    state.query.mockReturnValueOnce({
+      data: null,
+      error: null,
+      isPending: false,
+      refresh: vi.fn(),
+    });
+    expect(render()).toContain("No usage");
+    state.query.mockReturnValueOnce({
+      data: null,
+      error: "Usage request failed.",
+      isPending: false,
+      refresh: vi.fn(),
+    });
+    expect(render()).toContain("Usage unavailable");
+  });
+
+  it("renders complete per-bot usage, cap, cost, pool, and reservations", () => {
+    state.query.mockReturnValue({
+      data: snapshot,
+      error: null,
+      isPending: false,
+      refresh: vi.fn(),
+    });
+    const markup = render();
+
+    expect(state.summary).toHaveBeenCalledWith({
+      environmentId: EnvironmentId.make("environment-1"),
+      input: { botId: BotId.make("bot-1") },
+    });
+    for (const value of [
+      "Input",
+      "1,250",
+      "Output",
+      "2,500",
+      "Observer",
+      "300",
+      "Reflector",
+      "100",
+    ]) {
+      expect(markup).toContain(value);
+    }
+    expect(markup).toContain("12,345 / 20,000");
+    expect(markup).toContain("$1.25");
+    expect(markup).toContain("4,000 / 10,000 tokens");
+    expect(markup).toContain("Reserved");
+    expect(markup).toContain("750");
+    expect(markup).not.toContain("Some provider usage is unavailable.");
+  });
+
+  it("marks partial and unavailable provider measurements without inventing values", () => {
+    state.query.mockReturnValue({
+      data: {
+        ...snapshot,
+        reservedTokens: 0,
+        usageCap: null,
+        measurements: {
+          ...snapshot.measurements,
+          input: { tokens: 0, unavailableEntries: 1 },
+          output: { tokens: 1_250, unavailableEntries: 2 },
+        },
+        estimatedCost: { status: "unavailable", usd: null },
+        subscriptionPool: { status: "unavailable", used: null, limit: null, unit: null },
+      },
+      error: null,
+      isPending: false,
+      refresh: vi.fn(),
+    });
+    const markup = render();
+
+    expect(markup).toContain("1,250+");
+    expect(markup).toContain('>Estimated cost</span><span class="text-right">Unavailable</span>');
+    expect(markup).toContain(
+      '>Subscription pool</span><span class="text-right">Unavailable</span>',
+    );
+    expect(markup).toContain("Some provider usage is unavailable.");
+    expect(markup).toContain("No cap");
+    expect(markup).not.toContain("Reserved</span>");
+  });
+});

--- a/apps/web/src/components/roster/BotUsageSection.tsx
+++ b/apps/web/src/components/roster/BotUsageSection.tsx
@@ -1,0 +1,97 @@
+import { BotId, type AkeruBotUsageSnapshot, type EnvironmentId } from "@t3tools/contracts";
+import { useMemo } from "react";
+
+import { botUsageEnvironment } from "../../state/botUsage";
+import { useEnvironmentQuery } from "../../state/query";
+
+type UsageMeasurement = AkeruBotUsageSnapshot["measurements"]["input"];
+
+export function formatUsageMeasurement(measurement: UsageMeasurement): string {
+  if (measurement.unavailableEntries === 0) return measurement.tokens.toLocaleString();
+  return measurement.tokens === 0 ? "Unavailable" : `${measurement.tokens.toLocaleString()}+`;
+}
+
+export function BotUsageSection({
+  environmentId,
+  botId,
+}: {
+  readonly environmentId: EnvironmentId | null;
+  readonly botId: string;
+}) {
+  const usageAtom = useMemo(
+    () =>
+      environmentId
+        ? botUsageEnvironment.summary({
+            environmentId,
+            input: { botId: BotId.make(botId) },
+          })
+        : null,
+    [botId, environmentId],
+  );
+  const usage = useEnvironmentQuery(usageAtom);
+  const snapshot = usage.data;
+  const hasUnavailable = snapshot
+    ? Object.values(snapshot.measurements).some((value) => value.unavailableEntries > 0)
+    : false;
+
+  return (
+    <div className="space-y-2" aria-label="Bot usage">
+      <div className="text-sm font-medium">Usage</div>
+      <div className="rounded-lg border border-border bg-muted/20 px-3 py-2.5 text-sm">
+        {usage.error ? (
+          <span className="text-muted-foreground">Usage unavailable</span>
+        ) : !snapshot ? (
+          <span className="text-muted-foreground">{usage.isPending ? "Loading…" : "No usage"}</span>
+        ) : (
+          <div className="grid grid-cols-2 gap-x-5 gap-y-2">
+            <span className="text-muted-foreground">Input</span>
+            <span className="text-right">
+              {formatUsageMeasurement(snapshot.measurements.input)}
+            </span>
+            <span className="text-muted-foreground">Output</span>
+            <span className="text-right">
+              {formatUsageMeasurement(snapshot.measurements.output)}
+            </span>
+            <span className="text-muted-foreground">Observer</span>
+            <span className="text-right">
+              {formatUsageMeasurement(snapshot.measurements.observer)}
+            </span>
+            <span className="text-muted-foreground">Reflector</span>
+            <span className="text-right">
+              {formatUsageMeasurement(snapshot.measurements.reflector)}
+            </span>
+            <span className="text-muted-foreground">Cap</span>
+            <span className="text-right">
+              {snapshot.usageCap
+                ? `${snapshot.consumedTokens.toLocaleString()} / ${snapshot.usageCap.limit.toLocaleString()}`
+                : "No cap"}
+            </span>
+            <span className="text-muted-foreground">Estimated cost</span>
+            <span className="text-right">
+              {snapshot.estimatedCost.status === "available"
+                ? `$${snapshot.estimatedCost.usd.toLocaleString()}`
+                : "Unavailable"}
+            </span>
+            <span className="text-muted-foreground">Subscription pool</span>
+            <span className="text-right">
+              {snapshot.subscriptionPool.status === "available"
+                ? `${snapshot.subscriptionPool.used.toLocaleString()} / ${snapshot.subscriptionPool.limit.toLocaleString()} ${snapshot.subscriptionPool.unit}`
+                : "Unavailable"}
+            </span>
+            {snapshot.reservedTokens > 0 ? (
+              <>
+                <span className="text-muted-foreground">Reserved</span>
+                <span className="text-right">{snapshot.reservedTokens.toLocaleString()}</span>
+              </>
+            ) : null}
+            {hasUnavailable ? (
+              <span className="col-span-2 text-xs text-muted-foreground">
+                Some provider usage is unavailable.
+              </span>
+            ) : null}
+          </div>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/apps/web/src/state/botUsage.ts
+++ b/apps/web/src/state/botUsage.ts
@@ -1,0 +1,5 @@
+import { createBotUsageEnvironmentAtoms } from "@t3tools/client-runtime/state/bot-usage";
+
+import { connectionAtomRuntime } from "../connection/runtime";
+
+export const botUsageEnvironment = createBotUsageEnvironmentAtoms(connectionAtomRuntime);


### PR DESCRIPTION
The usage RPC in #48 had no web view, so users could not inspect a bot’s token use or limits from its settings.

This adds the web query state and a usage section in the bot details panel. It shows input and output tokens, Observer and Reflector usage, the configured cap, active reservations, estimated cost, and subscription-pool data. Missing provider measurements, cost, and subscription-pool values stay explicit instead of using invented values.

Focused tests cover bot-scoped queries, loading and error states, complete measurements, partial provider data, caps, reservations, and unavailable cost and subscription-pool states.

Depends on #48.

LEO-286: https://linear.app/opencoredev/issue/LEO-286
LEO-294: https://linear.app/opencoredev/issue/LEO-294
LEO-329: https://linear.app/opencoredev/issue/LEO-329

Model: GPT-5.6 Sol
Harness: Codex in T3 Code