### PR TITLE
feat(app): ask before local agent commands

### DIFF
--- a/apps/mobile/src/features/threads/new-task-flow-provider.tsx
+++ b/apps/mobile/src/features/threads/new-task-flow-provider.tsx
@@ -11,8 +11,8 @@ import type {
 } from "@t3tools/contracts";
 import {
   CommandId,
+  DEFAULT_LOCAL_EXECUTION_MODE,
   DEFAULT_PROVIDER_INTERACTION_MODE,
-  DEFAULT_RUNTIME_MODE,
   MessageId,
   T3_PROJECT_FILE_NAME,
   ThreadId,
@@ -400,7 +400,10 @@ export function NewTaskFlowProvider(props: React.PropsWithChildren) {
     draftStartFromOrigin ??
     selectedEnvironmentServerConfig?.settings.newWorktreesStartFromOrigin ??
     true;
-  const runtimeMode = selectedProjectDraft.runtimeMode ?? DEFAULT_RUNTIME_MODE;
+  const runtimeMode =
+    selectedProjectDraft.runtimeMode ??
+    selectedEnvironmentServerConfig?.settings.localExecutionMode ??
+    DEFAULT_LOCAL_EXECUTION_MODE;
   const interactionMode = planModeEnabled
     ? (selectedProjectDraft.interactionMode ?? DEFAULT_PROVIDER_INTERACTION_MODE)
     : DEFAULT_PROVIDER_INTERACTION_MODE;
@@ -865,7 +868,10 @@ export function NewTaskFlowProvider(props: React.PropsWithChildren) {
         text,
         attachments: draft.attachments,
         modelSelection: draftModelSelection,
-        runtimeMode: draft.runtimeMode ?? DEFAULT_RUNTIME_MODE,
+        runtimeMode:
+          draft.runtimeMode ??
+          selectedEnvironmentServerConfig?.settings.localExecutionMode ??
+          DEFAULT_LOCAL_EXECUTION_MODE,
         interactionMode: resolvePendingTaskInteractionMode({
           preferenceLoaded: planModePreferenceLoaded,
           planModeEnabled,

--- a/apps/mobile/src/state/use-thread-outbox-drain.ts
+++ b/apps/mobile/src/state/use-thread-outbox-drain.ts
@@ -6,8 +6,8 @@ import type {
 import type { AtomCommandResult } from "@t3tools/client-runtime/state/runtime";
 import {
   CommandId,
+  DEFAULT_LOCAL_EXECUTION_MODE,
   DEFAULT_PROVIDER_INTERACTION_MODE,
-  DEFAULT_RUNTIME_MODE,
   type MessageId,
 } from "@t3tools/contracts";
 import { buildTemporaryWorktreeBranchName } from "@t3tools/shared/git";
@@ -268,7 +268,7 @@ export function useThreadOutboxDrain(): void {
           text: queuedMessage.text.trim(),
           attachments: queuedMessage.attachments,
           modelSelection,
-          runtimeMode: queuedMessage.runtimeMode ?? DEFAULT_RUNTIME_MODE,
+          runtimeMode: queuedMessage.runtimeMode ?? DEFAULT_LOCAL_EXECUTION_MODE,
           interactionMode: queuedMessage.interactionMode ?? DEFAULT_PROVIDER_INTERACTION_MODE,
           workspaceMode: creation.workspaceMode,
           branch: creation.branch,

--- a/apps/server/src/orchestration/Layers/BotPersistence.test.ts
+++ b/apps/server/src/orchestration/Layers/BotPersistence.test.ts
@@ -518,11 +518,11 @@ it.layer(TestLayer)("bot persistence", (it) => {
       const engine = yield* OrchestrationEngineService;
       const snapshots = yield* ProjectionSnapshotQuery;
 
-      for (const sandbox of [null, "akeru-cloud"] as const) {
+      for (const sandbox of [null, "local", "akeru-cloud"] as const) {
         yield* engine.dispatch({
           type: "bot.create",
-          commandId: CommandId.make(`cmd-bot-default-${sandbox ?? "local"}`),
-          botId: BotId.make(`bot-default-${sandbox ?? "local"}`),
+          commandId: CommandId.make(`cmd-bot-default-${sandbox ?? "null"}`),
+          botId: BotId.make(`bot-default-${sandbox ?? "null"}`),
           name: "Akeru",
           title: "Akeru",
           avatar: { kind: "dither", seed: "akeru" },
@@ -535,6 +535,10 @@ it.layer(TestLayer)("bot persistence", (it) => {
       }
 
       const bots = (yield* snapshots.getShellSnapshot()).bots;
+      assert.equal(
+        bots.find((bot) => bot.id === BotId.make("bot-default-null"))?.runtimeMode,
+        "approval-required",
+      );
       assert.equal(
         bots.find((bot) => bot.id === BotId.make("bot-default-local"))?.runtimeMode,
         "approval-required",

--- a/apps/server/src/orchestration/Layers/BotPersistence.test.ts
+++ b/apps/server/src/orchestration/Layers/BotPersistence.test.ts
@@ -512,4 +512,37 @@ it.layer(TestLayer)("bot persistence", (it) => {
       assert.equal(rebuiltHistoricalThread?.groupId, null);
     }),
   );
+
+  it.effect("defaults omitted bot runtime modes by sandbox", () =>
+    Effect.gen(function* () {
+      const engine = yield* OrchestrationEngineService;
+      const snapshots = yield* ProjectionSnapshotQuery;
+
+      for (const sandbox of [null, "akeru-cloud"] as const) {
+        yield* engine.dispatch({
+          type: "bot.create",
+          commandId: CommandId.make(`cmd-bot-default-${sandbox ?? "local"}`),
+          botId: BotId.make(`bot-default-${sandbox ?? "local"}`),
+          name: "Akeru",
+          title: "Akeru",
+          avatar: { kind: "dither", seed: "akeru" },
+          engine: null,
+          sandbox,
+          usageCap: null,
+          groupId: null,
+          createdAt: "2026-01-01T00:00:00.000Z",
+        });
+      }
+
+      const bots = (yield* snapshots.getShellSnapshot()).bots;
+      assert.equal(
+        bots.find((bot) => bot.id === BotId.make("bot-default-local"))?.runtimeMode,
+        "approval-required",
+      );
+      assert.equal(
+        bots.find((bot) => bot.id === BotId.make("bot-default-akeru-cloud"))?.runtimeMode,
+        "full-access",
+      );
+    }),
+  );
 });

--- a/apps/server/src/orchestration/decider.ts
+++ b/apps/server/src/orchestration/decider.ts
@@ -413,7 +413,9 @@ export const decideOrchestrationCommand = Effect.fn("decideOrchestrationCommand"
           sandbox: command.sandbox,
           runtimeMode:
             command.runtimeMode ??
-            (command.sandbox === null ? DEFAULT_LOCAL_EXECUTION_MODE : DEFAULT_RUNTIME_MODE),
+            (command.sandbox === null || command.sandbox === "local"
+              ? DEFAULT_LOCAL_EXECUTION_MODE
+              : DEFAULT_RUNTIME_MODE),
           usageCap: command.usageCap,
           voiceEnabled: command.voiceEnabled ?? false,
           groupId: command.groupId,

--- a/apps/server/src/orchestration/decider.ts
+++ b/apps/server/src/orchestration/decider.ts
@@ -1,5 +1,7 @@
 import {
   BotId,
+  DEFAULT_LOCAL_EXECUTION_MODE,
+  DEFAULT_RUNTIME_MODE,
   EventId,
   GroupId,
   ProviderInstanceId,
@@ -409,7 +411,9 @@ export const decideOrchestrationCommand = Effect.fn("decideOrchestrationCommand"
           avatar: command.avatar,
           engine: command.engine,
           sandbox: command.sandbox,
-          runtimeMode: command.runtimeMode,
+          runtimeMode:
+            command.runtimeMode ??
+            (command.sandbox === null ? DEFAULT_LOCAL_EXECUTION_MODE : DEFAULT_RUNTIME_MODE),
           usageCap: command.usageCap,
           voiceEnabled: command.voiceEnabled ?? false,
           groupId: command.groupId,

--- a/apps/web/src/components/roster/BotRosterSidebar.tsx
+++ b/apps/web/src/components/roster/BotRosterSidebar.tsx
@@ -42,6 +42,7 @@ import { visibleBotChatMessages } from "./botConversationPresentation";
 import { useBotPresence } from "./botPresence";
 import { findLatestBotThreadTarget } from "./botThreadRuntime.logic";
 import { NewBotDialog } from "./NewBotDialog";
+import { DEFAULT_BOT_RUNTIME_MODE } from "./botSandbox";
 import {
   buildGroupedRosterSections,
   buildRosterStrip,
@@ -455,7 +456,7 @@ export default function BotRosterSidebar() {
         avatar,
         engine: null,
         sandbox: null,
-        runtimeMode: "full-access",
+        runtimeMode: DEFAULT_BOT_RUNTIME_MODE,
         usageCap: null,
         groupId: null,
       },

--- a/apps/web/src/components/roster/botSandbox.test.ts
+++ b/apps/web/src/components/roster/botSandbox.test.ts
@@ -1,12 +1,30 @@
 import { describe, expect, it } from "vite-plus/test";
 
-import { BOT_SANDBOX_OPTIONS, botSandboxChoice, botSandboxLabel } from "./botSandbox";
+import {
+  BOT_SANDBOX_OPTIONS,
+  DEFAULT_BOT_RUNTIME_MODE,
+  botSandboxChoice,
+  botSandboxLabel,
+  resolveBotRuntimeMode,
+} from "./botSandbox";
 
 describe("botSandbox", () => {
   it("treats a missing bot sandbox as local", () => {
     expect(botSandboxChoice(null)).toBe("local");
     expect(botSandboxChoice("local")).toBe("local");
     expect(botSandboxChoice("vercel")).toBe("vercel");
+  });
+
+  it("asks before local tools unless full access is enabled", () => {
+    expect(DEFAULT_BOT_RUNTIME_MODE).toBe("approval-required");
+    expect(resolveBotRuntimeMode(null, "approval-required")).toBe("approval-required");
+    expect(resolveBotRuntimeMode("local", "full-access")).toBe("full-access");
+  });
+
+  it("runs cloud sandbox tools without a local approval prompt", () => {
+    for (const sandbox of ["vercel", "akeru-cloud", "upstash"] as const) {
+      expect(resolveBotRuntimeMode(sandbox, "approval-required")).toBe("full-access");
+    }
   });
 
   it("lists the first sandbox providers", () => {

--- a/apps/web/src/components/roster/botSandbox.ts
+++ b/apps/web/src/components/roster/botSandbox.ts
@@ -1,4 +1,12 @@
+import {
+  DEFAULT_LOCAL_EXECUTION_MODE,
+  type LocalExecutionMode,
+  type RuntimeMode,
+} from "@t3tools/contracts";
+
 import type { Bot } from "./types";
+
+export const DEFAULT_BOT_RUNTIME_MODE: RuntimeMode = DEFAULT_LOCAL_EXECUTION_MODE;
 
 export const BOT_SANDBOX_OPTIONS = [
   { value: "local", label: "Local" },
@@ -15,4 +23,11 @@ export function botSandboxChoice(sandbox: Bot["sandbox"]): BotSandboxChoice {
 
 export function botSandboxLabel(sandbox: BotSandboxChoice): string {
   return BOT_SANDBOX_OPTIONS.find((option) => option.value === sandbox)?.label ?? "Local";
+}
+
+export function resolveBotRuntimeMode(
+  sandbox: Bot["sandbox"],
+  localExecutionMode: LocalExecutionMode,
+): RuntimeMode {
+  return botSandboxChoice(sandbox) === "local" ? localExecutionMode : "full-access";
 }

--- a/apps/web/src/components/roster/useBotThreadRuntime.ts
+++ b/apps/web/src/components/roster/useBotThreadRuntime.ts
@@ -181,10 +181,7 @@ export function useBotThreadRuntime(botId: string, effectiveModelSelection: Mode
                 effectiveModelSelection ??
                 activeProject.defaultModelSelection ??
                 appDefaultModelSelection,
-              runtimeMode: resolveBotRuntimeMode(
-                bot?.sandbox ?? null,
-                settings.localExecutionMode,
-              ),
+              runtimeMode: resolveBotRuntimeMode(bot?.sandbox ?? null, settings.localExecutionMode),
               interactionMode: DEFAULT_INTERACTION_MODE,
               branch: null,
               worktreePath: null,

--- a/apps/web/src/components/roster/useBotThreadRuntime.ts
+++ b/apps/web/src/components/roster/useBotThreadRuntime.ts
@@ -3,7 +3,6 @@ import { scopeThreadRef } from "@t3tools/client-runtime/environment";
 import { squashAtomCommandFailure } from "@t3tools/client-runtime/state/runtime";
 import {
   BotId,
-  DEFAULT_RUNTIME_MODE,
   EnvironmentId,
   ThreadId,
   type ModelSelection,
@@ -29,6 +28,7 @@ import { primaryServerProvidersAtom } from "../../state/server";
 import { threadEnvironment } from "../../state/threads";
 import { useAtomCommand } from "../../state/use-atom-command";
 import { sortScopedProjectsForSidebar } from "../Sidebar.logic";
+import { resolveBotRuntimeMode } from "./botSandbox";
 import {
   acceptBotTurnSubmission,
   buildBotTurnStartInput,
@@ -139,6 +139,9 @@ export function useBotThreadRuntime(botId: string, effectiveModelSelection: Mode
     () => resolveAppModelSelectionState(settings, providers),
     [providers, settings],
   );
+  const setRuntimeMode = useAtomCommand(threadEnvironment.setRuntimeMode, {
+    reportFailure: false,
+  });
   const startTurn = useAtomCommand(threadEnvironment.startTurn, { reportFailure: false });
   const appendVoiceTranscript = useAtomCommand(threadEnvironment.appendVoiceTranscript, {
     reportFailure: false,
@@ -178,7 +181,10 @@ export function useBotThreadRuntime(botId: string, effectiveModelSelection: Mode
                 effectiveModelSelection ??
                 activeProject.defaultModelSelection ??
                 appDefaultModelSelection,
-              runtimeMode: bot?.runtimeMode ?? DEFAULT_RUNTIME_MODE,
+              runtimeMode: resolveBotRuntimeMode(
+                bot?.sandbox ?? null,
+                settings.localExecutionMode,
+              ),
               interactionMode: DEFAULT_INTERACTION_MODE,
               branch: null,
               worktreePath: null,
@@ -203,6 +209,7 @@ export function useBotThreadRuntime(botId: string, effectiveModelSelection: Mode
       botReady,
       createThread,
       effectiveModelSelection,
+      settings.localExecutionMode,
     ],
   );
 
@@ -243,7 +250,7 @@ export function useBotThreadRuntime(botId: string, effectiveModelSelection: Mode
       const createdAt = new Date().toISOString();
       const modelSelection: ModelSelection =
         effectiveModelSelection ?? activeProject.defaultModelSelection ?? appDefaultModelSelection;
-      const runtimeMode = bot?.runtimeMode ?? DEFAULT_RUNTIME_MODE;
+      const runtimeMode = resolveBotRuntimeMode(bot?.sandbox ?? null, settings.localExecutionMode);
       const title = threadTitle(prompt, files);
       const messageId = newMessageId();
       let accepted = false;
@@ -263,6 +270,16 @@ export function useBotThreadRuntime(botId: string, effectiveModelSelection: Mode
         if (!currentThreadRef) {
           setError("Could not send the message.");
           return false;
+        }
+        if (rememberedThread && rememberedThread.runtimeMode !== runtimeMode) {
+          const modeResult = await setRuntimeMode({
+            environmentId: currentThreadRef.environmentId,
+            input: { threadId: currentThreadRef.threadId, runtimeMode },
+          });
+          if (modeResult._tag === "Failure") {
+            setError(errorMessage(modeResult));
+            return false;
+          }
         }
         const startResult = await startTurn({
           environmentId: currentThreadRef.environmentId,
@@ -324,6 +341,9 @@ export function useBotThreadRuntime(botId: string, effectiveModelSelection: Mode
       botReady,
       ensureTranscriptThread,
       rememberedThread?.latestTurn,
+      rememberedThread?.runtimeMode,
+      settings.localExecutionMode,
+      setRuntimeMode,
       startTurn,
     ],
   );

--- a/apps/web/src/components/roster/useGroupThreadRuntime.ts
+++ b/apps/web/src/components/roster/useGroupThreadRuntime.ts
@@ -3,7 +3,6 @@ import { scopeThreadRef } from "@t3tools/client-runtime/environment";
 import { squashAtomCommandFailure } from "@t3tools/client-runtime/state/runtime";
 import {
   BotId,
-  DEFAULT_RUNTIME_MODE,
   EnvironmentId,
   GroupId,
   ProviderInstanceId,
@@ -30,6 +29,7 @@ import { threadEnvironment } from "../../state/threads";
 import { useAtomCommand } from "../../state/use-atom-command";
 import { DEFAULT_INTERACTION_MODE } from "../../types";
 import { sortScopedProjectsForSidebar } from "../Sidebar.logic";
+import { resolveBotRuntimeMode } from "./botSandbox";
 import { buildGroupTurnStartInput, findLatestGroupThreadTarget } from "./botThreadRuntime.logic";
 import { useRosterStore } from "./rosterStore";
 
@@ -129,6 +129,9 @@ export function useGroupThreadRuntime(groupId: string) {
     () => resolveAppModelSelectionState(settings, providers),
     [providers, settings],
   );
+  const setRuntimeMode = useAtomCommand(threadEnvironment.setRuntimeMode, {
+    reportFailure: false,
+  });
   const startTurn = useAtomCommand(threadEnvironment.startTurn, { reportFailure: false });
   const groupReady = serverGroups.some((candidate) => candidate.id === groupId);
   const sendInFlightRef = useRef(false);
@@ -173,6 +176,7 @@ export function useGroupThreadRuntime(groupId: string) {
       const createdAt = new Date().toISOString();
       const currentThreadRef = retainedThreadRef.current.threadRef;
       const threadId = currentThreadRef?.threadId ?? newThreadId();
+      const runtimeMode = resolveBotRuntimeMode(respondingBot.sandbox, settings.localExecutionMode);
 
       try {
         const attachments = await Promise.all(
@@ -185,6 +189,16 @@ export function useGroupThreadRuntime(groupId: string) {
           })),
         );
         const environmentId = currentThreadRef?.environmentId ?? activeProject.environmentId;
+        if (currentThreadRef && rememberedThread?.runtimeMode !== runtimeMode) {
+          const modeResult = await setRuntimeMode({
+            environmentId,
+            input: { threadId, runtimeMode },
+          });
+          if (modeResult._tag === "Failure") {
+            setError(errorMessage(modeResult));
+            return false;
+          }
+        }
         const result = await startTurn({
           environmentId,
           input: buildGroupTurnStartInput({
@@ -200,7 +214,7 @@ export function useGroupThreadRuntime(groupId: string) {
               attachments,
             },
             modelSelection,
-            runtimeMode: respondingBot.runtimeMode ?? DEFAULT_RUNTIME_MODE,
+            runtimeMode,
             interactionMode: DEFAULT_INTERACTION_MODE,
             createdAt,
             createThread: currentThreadRef === null,
@@ -220,7 +234,18 @@ export function useGroupThreadRuntime(groupId: string) {
         setSending(false);
       }
     },
-    [activeProject, appDefaultModelSelection, bots, group, groupId, groupReady, startTurn],
+    [
+      activeProject,
+      appDefaultModelSelection,
+      bots,
+      group,
+      groupId,
+      groupReady,
+      rememberedThread?.runtimeMode,
+      settings.localExecutionMode,
+      setRuntimeMode,
+      startTurn,
+    ],
   );
 
   return {

--- a/apps/web/src/components/roster/useServerRoster.ts
+++ b/apps/web/src/components/roster/useServerRoster.ts
@@ -10,6 +10,7 @@ import {
 } from "../../state/bots";
 import { usePrimaryEnvironmentId } from "../../state/environments";
 import { useAtomCommand } from "../../state/use-atom-command";
+import { DEFAULT_BOT_RUNTIME_MODE } from "./botSandbox";
 import { useRosterStore } from "./rosterStore";
 import type { BotAvatar } from "./types";
 
@@ -38,7 +39,7 @@ export function useServerRosterSync(): void {
           avatar: { kind: "blob", shape: "circle", color: "#5B7FD4" },
           engine: null,
           sandbox: null,
-          runtimeMode: "full-access",
+          runtimeMode: DEFAULT_BOT_RUNTIME_MODE,
           usageCap: null,
           groupId: null,
         },

--- a/apps/web/src/components/settings/SettingsPanels.tsx
+++ b/apps/web/src/components/settings/SettingsPanels.tsx
@@ -535,6 +535,9 @@ export function useSettingsRestore(onRestored?: () => void) {
         ? ["Sandbox and browser sharing"]
         : []),
       ...(isBackgroundActivityDirty ? ["Background activity"] : []),
+      ...(settings.localExecutionMode !== DEFAULT_UNIFIED_SETTINGS.localExecutionMode
+        ? ["Local execution"]
+        : []),
       ...(settings.defaultThreadEnvMode !== DEFAULT_UNIFIED_SETTINGS.defaultThreadEnvMode
         ? ["New thread mode"]
         : []),
@@ -575,6 +578,7 @@ export function useSettingsRestore(onRestored?: () => void) {
       settings.confirmThreadArchive,
       settings.confirmThreadDelete,
       settings.addProjectBaseDirectory,
+      settings.localExecutionMode,
       settings.defaultThreadEnvMode,
       settings.newWorktreesStartFromOrigin,
       settings.diffIgnoreWhitespace,
@@ -687,6 +691,7 @@ export function useSettingsRestore(onRestored?: () => void) {
       backgroundActivityProfile: DEFAULT_UNIFIED_SETTINGS.backgroundActivityProfile,
       automaticGitFetchInterval: DEFAULT_UNIFIED_SETTINGS.automaticGitFetchInterval,
       providerHealthRefreshInterval: DEFAULT_UNIFIED_SETTINGS.providerHealthRefreshInterval,
+      localExecutionMode: DEFAULT_UNIFIED_SETTINGS.localExecutionMode,
       defaultThreadEnvMode: DEFAULT_UNIFIED_SETTINGS.defaultThreadEnvMode,
       newWorktreesStartFromOrigin: DEFAULT_UNIFIED_SETTINGS.newWorktreesStartFromOrigin,
       addProjectBaseDirectory: DEFAULT_UNIFIED_SETTINGS.addProjectBaseDirectory,
@@ -2354,8 +2359,48 @@ export function GeneralSettingsPanel() {
         />
 
         <SettingsRow
+          {...searchableSetting("local-execution")}
+          description="Ask before local file changes and shell commands. Full access skips these prompts. Sensitive actions still ask."
+          resetAction={
+            settings.localExecutionMode !== DEFAULT_UNIFIED_SETTINGS.localExecutionMode ? (
+              <SettingResetButton
+                label="local execution"
+                onClick={() =>
+                  updateSettings({
+                    localExecutionMode: DEFAULT_UNIFIED_SETTINGS.localExecutionMode,
+                  })
+                }
+              />
+            ) : null
+          }
+          control={
+            <Select
+              value={settings.localExecutionMode}
+              onValueChange={(value) => {
+                if (value === "approval-required" || value === "full-access") {
+                  updateSettings({ localExecutionMode: value });
+                }
+              }}
+            >
+              <SelectTrigger className="w-full sm:w-40" aria-label="Local execution">
+                <SelectValue>
+                  {settings.localExecutionMode === "full-access" ? "Full access" : "Ask first"}
+                </SelectValue>
+              </SelectTrigger>
+              <SelectPopup align="end" alignItemWithTrigger={false}>
+                <SelectItem hideIndicator value="approval-required">
+                  Ask first
+                </SelectItem>
+                <SelectItem hideIndicator value="full-access">
+                  Full access
+                </SelectItem>
+              </SelectPopup>
+            </Select>
+          }
+        />
+
+        <SettingsRow
           {...searchableSetting("new-threads")}
-          id="local-execution"
           description="Pick the default workspace mode for newly created draft threads."
           resetAction={
             settings.defaultThreadEnvMode !== DEFAULT_UNIFIED_SETTINGS.defaultThreadEnvMode ||

--- a/apps/web/src/components/settings/settingsSearch.test.ts
+++ b/apps/web/src/components/settings/settingsSearch.test.ts
@@ -46,6 +46,10 @@ describe("searchSettings", () => {
   it("matches normalized title substrings", () => {
     expect(searchSettings("  WORD   WRAP  ", ITEMS).map((item) => item.id)).toEqual(["word-wrap"]);
     expect(searchSettings("glass").map((item) => item.id)).toEqual(["setting-glass-opacity"]);
+    expect(searchSettings("local execution")[0]).toMatchObject({
+      id: "local-execution",
+      to: "/settings/general",
+    });
     expect(searchSettings("xyzzy")).toEqual([]);
   });
 

--- a/apps/web/src/components/settings/settingsSearch.ts
+++ b/apps/web/src/components/settings/settingsSearch.ts
@@ -154,6 +154,11 @@ export const SETTINGS_SEARCH_ITEMS = [
     to: "/settings/general",
   },
   {
+    id: "local-execution",
+    title: "Local execution",
+    to: "/settings/general",
+  },
+  {
     id: "voice-enabled",
     title: "Voice",
     to: "/settings/voice",

--- a/apps/web/src/components/sidebar/SidebarChrome.test.ts
+++ b/apps/web/src/components/sidebar/SidebarChrome.test.ts
@@ -56,6 +56,58 @@ describe("sidebar footer", () => {
     expect(source).toContain("Sign in for remote access");
   });
 
+  it("creates manual and first-run bots with approval required", () => {
+    const rosterSource = NodeFS.readFileSync(
+      new URL("../roster/BotRosterSidebar.tsx", import.meta.url),
+      "utf8",
+    );
+    const syncSource = NodeFS.readFileSync(
+      new URL("../roster/useServerRoster.ts", import.meta.url),
+      "utf8",
+    );
+
+    expect(rosterSource).toContain("runtimeMode: DEFAULT_BOT_RUNTIME_MODE");
+    expect(syncSource).toContain("runtimeMode: DEFAULT_BOT_RUNTIME_MODE");
+    expect(rosterSource).not.toContain('runtimeMode: "full-access"');
+    expect(syncSource).not.toContain('runtimeMode: "full-access"');
+  });
+
+  it("updates existing bot and group threads before starting the next turn", () => {
+    const botSource = NodeFS.readFileSync(
+      new URL("../roster/useBotThreadRuntime.ts", import.meta.url),
+      "utf8",
+    );
+    const groupSource = NodeFS.readFileSync(
+      new URL("../roster/useGroupThreadRuntime.ts", import.meta.url),
+      "utf8",
+    );
+
+    for (const source of [botSource, groupSource]) {
+      const modeUpdate = source.indexOf("const modeResult = await setRuntimeMode");
+      expect(modeUpdate).toBeGreaterThan(-1);
+      expect(modeUpdate).toBeLessThan(source.indexOf("await startTurn", modeUpdate));
+    }
+  });
+
+  it("mints fresh web and mobile threads from the local execution setting", () => {
+    const webSource = NodeFS.readFileSync(
+      new URL("../../hooks/useHandleNewThread.ts", import.meta.url),
+      "utf8",
+    );
+    const mobileSource = NodeFS.readFileSync(
+      new URL(
+        "../../../../mobile/src/features/threads/new-task-flow-provider.tsx",
+        import.meta.url,
+      ),
+      "utf8",
+    );
+
+    expect(webSource).toContain(
+      "runtimeMode: carryRuntimeMode ?? primaryServerSettings.localExecutionMode",
+    );
+    expect(mobileSource).toContain("selectedEnvironmentServerConfig?.settings.localExecutionMode");
+  });
+
   it("keeps the roster scrollable from touch gestures that start on a bot row", () => {
     const source = NodeFS.readFileSync(
       new URL("../roster/BotRosterSidebar.tsx", import.meta.url),

--- a/apps/web/src/composerDraftStore.test.ts
+++ b/apps/web/src/composerDraftStore.test.ts
@@ -806,7 +806,7 @@ describe("composerDraftStore project draft thread mapping", () => {
       branch: "feature/test",
       worktreePath: "/tmp/worktree-test",
       envMode: "worktree",
-      runtimeMode: "full-access",
+      runtimeMode: "approval-required",
       interactionMode: "default",
       createdAt: "2026-01-01T00:00:00.000Z",
     });
@@ -817,7 +817,7 @@ describe("composerDraftStore project draft thread mapping", () => {
       branch: "feature/test",
       worktreePath: "/tmp/worktree-test",
       envMode: "worktree",
-      runtimeMode: "full-access",
+      runtimeMode: "approval-required",
       interactionMode: "default",
       createdAt: "2026-01-01T00:00:00.000Z",
     });

--- a/apps/web/src/composerDraftStore.ts
+++ b/apps/web/src/composerDraftStore.ts
@@ -1,4 +1,5 @@
 import {
+  DEFAULT_LOCAL_EXECUTION_MODE,
   DEFAULT_MODEL,
   DEFAULT_MODEL_BY_PROVIDER,
   defaultInstanceIdForDriver,
@@ -33,7 +34,7 @@ import { createModelSelection, normalizeModelSlug } from "@t3tools/shared/model"
 import { useMemo } from "react";
 import { getLocalStorageItem } from "./hooks/useLocalStorage";
 import { resolveAppModelSelection, resolveAppModelSelectionForInstance } from "./modelSelection";
-import { DEFAULT_INTERACTION_MODE, DEFAULT_RUNTIME_MODE, type ChatImageAttachment } from "./types";
+import { DEFAULT_INTERACTION_MODE, type ChatImageAttachment } from "./types";
 import {
   type TerminalContextDraft,
   ensureInlineTerminalContextPlaceholders,
@@ -1406,7 +1407,8 @@ function createDraftThreadState(
     projectId: projectRef.projectId,
     logicalProjectKey,
     createdAt: options?.createdAt ?? existingThread?.createdAt ?? new Date().toISOString(),
-    runtimeMode: options?.runtimeMode ?? existingThread?.runtimeMode ?? DEFAULT_RUNTIME_MODE,
+    runtimeMode:
+      options?.runtimeMode ?? existingThread?.runtimeMode ?? DEFAULT_LOCAL_EXECUTION_MODE,
     interactionMode:
       options?.interactionMode ?? existingThread?.interactionMode ?? DEFAULT_INTERACTION_MODE,
     branch: nextBranch,
@@ -1579,7 +1581,7 @@ function normalizePersistedDraftThreads(
             : new Date().toISOString(),
         runtimeMode: isRuntimeMode(candidateDraftThread.runtimeMode)
           ? candidateDraftThread.runtimeMode
-          : DEFAULT_RUNTIME_MODE,
+          : DEFAULT_LOCAL_EXECUTION_MODE,
         interactionMode:
           candidateDraftThread.interactionMode === "plan" ||
           candidateDraftThread.interactionMode === "default"
@@ -1629,7 +1631,7 @@ function normalizePersistedDraftThreads(
           projectId: projectRef.projectId,
           logicalProjectKey,
           createdAt: new Date().toISOString(),
-          runtimeMode: DEFAULT_RUNTIME_MODE,
+          runtimeMode: DEFAULT_LOCAL_EXECUTION_MODE,
           interactionMode: DEFAULT_INTERACTION_MODE,
           branch: null,
           worktreePath: null,

--- a/apps/web/src/hooks/useHandleNewThread.ts
+++ b/apps/web/src/hooks/useHandleNewThread.ts
@@ -4,12 +4,7 @@ import {
   scopeProjectRef,
   scopeThreadRef,
 } from "@t3tools/client-runtime/environment";
-import {
-  DEFAULT_RUNTIME_MODE,
-  type RuntimeMode,
-  type ScopedProjectRef,
-  type ThreadId,
-} from "@t3tools/contracts";
+import { type RuntimeMode, type ScopedProjectRef, type ThreadId } from "@t3tools/contracts";
 import { useParams, useRouter } from "@tanstack/react-router";
 import { useCallback, useMemo } from "react";
 import {
@@ -280,7 +275,7 @@ export function useNewThreadHandler() {
           if (workspaceContext) {
             setDraftThreadContext(emptyStoredDraftThread.draftId, {
               ...workspaceContext,
-              ...(carryRuntimeMode ? { runtimeMode: carryRuntimeMode } : {}),
+              runtimeMode: carryRuntimeMode ?? primaryServerSettings.localExecutionMode,
               ...(carryInteractionMode ? { interactionMode: carryInteractionMode } : {}),
             });
             if (carryModelSelection) {
@@ -303,7 +298,7 @@ export function useNewThreadHandler() {
             {
               threadId: emptyStoredDraftThread.threadId,
               ...workspaceContext,
-              ...(carryRuntimeMode ? { runtimeMode: carryRuntimeMode } : {}),
+              runtimeMode: carryRuntimeMode ?? primaryServerSettings.localExecutionMode,
               ...(carryInteractionMode ? { interactionMode: carryInteractionMode } : {}),
             },
           );
@@ -415,7 +410,7 @@ export function useNewThreadHandler() {
               envMode: initialEnvMode,
               newWorktreesStartFromOrigin: primaryServerSettings.newWorktreesStartFromOrigin,
             }),
-          runtimeMode: carryRuntimeMode ?? DEFAULT_RUNTIME_MODE,
+          runtimeMode: carryRuntimeMode ?? primaryServerSettings.localExecutionMode,
           ...(carryInteractionMode ? { interactionMode: carryInteractionMode } : {}),
         });
         applyStickyState(draftId);

--- a/docs/user/bots.md
+++ b/docs/user/bots.md
@@ -14,6 +14,8 @@ Akeru Bot stores the profile in the connected environment. Other clients connect
 
 Settings controls whether bots share their workspace and browser. **Separate** is the default and gives each bot its own workspace identity and browser profile. **Shared** lets bots share files and cookies. Bots use a local workspace. Remote sandbox options stay unavailable.
 
+Local bots ask before file changes and shell commands by default. Select **Settings > General > Local execution > Full access** to skip those local prompts. Actions that send, pay, delete, change production, or use secrets still ask. Bots that run in a cloud sandbox do not show the local computer prompt.
+
 Use the panel button to collapse or reopen the editor. The default shortcut is **Mod+Alt+B**, and you can change `Right Panel: Toggle` in the keybinding settings. On a narrow screen, the same button opens a sheet.
 
 Bot replies support headings, links, tables, task lists, code blocks, math, and Mermaid diagrams.

--- a/docs/user/permission-modes.md
+++ b/docs/user/permission-modes.md
@@ -4,8 +4,8 @@ A permission mode controls how much the agent does on its own and when it stops 
 
 The mode is set per thread, from the mode control in the message composer. Changing it in one
 thread does not change any other thread. A thread created from inside another thread keeps that
-thread's mode; otherwise new threads start in **Full access** unless you pick something else
-before sending.
+thread's mode. Otherwise, new threads use **Settings > General > Local execution** and ask before
+local file changes and shell commands by default.
 
 ## The Modes
 
@@ -20,8 +20,9 @@ on the provider: Codex delegates routine approvals to an AI reviewer, Claude use
 permission mode, and providers without an equivalent (such as OpenCode) fall back to asking, like
 Supervised.
 
-**Full access**: allow commands and edits without prompts. The default. The agent runs
-unattended until it finishes or asks a question of its own.
+**Full access**: allow commands and edits without local prompts. The agent runs unattended until
+it finishes or asks a question of its own. Actions that send, pay, delete, change production, or
+use secrets still ask.
 
 Approvals appear inline in the conversation. Approve or reject one and the agent continues from
 there. The Codex runtime still asks before every MCP tool call and actions that send, pay, delete,

--- a/packages/contracts/src/orchestration.test.ts
+++ b/packages/contracts/src/orchestration.test.ts
@@ -268,7 +268,7 @@ it.effect("decodes thread.turn.start defaults for provider and runtime mode", ()
   }),
 );
 
-it.effect("decodes bot.create to approval required when an old client omits runtimeMode", () =>
+it.effect("leaves an omitted bot.create runtime mode for the server", () =>
   Effect.gen(function* () {
     const parsed = yield* decodeOrchestrationCommand({
       type: "bot.create",
@@ -285,7 +285,7 @@ it.effect("decodes bot.create to approval required when an old client omits runt
     });
 
     if (parsed.type !== "bot.create") assert.fail(`Expected bot.create, received ${parsed.type}.`);
-    assert.strictEqual(parsed.runtimeMode, DEFAULT_LOCAL_EXECUTION_MODE);
+    assert.strictEqual(parsed.runtimeMode, undefined);
   }),
 );
 

--- a/packages/contracts/src/orchestration.test.ts
+++ b/packages/contracts/src/orchestration.test.ts
@@ -5,6 +5,7 @@ import * as Schema from "effect/Schema";
 import { MessageId } from "./baseSchemas.ts";
 import {
   BotAvatar,
+  DEFAULT_LOCAL_EXECUTION_MODE,
   DEFAULT_PROVIDER_INTERACTION_MODE,
   DEFAULT_RUNTIME_MODE,
   ClientOrchestrationCommand,
@@ -262,8 +263,29 @@ it.effect("decodes thread.turn.start defaults for provider and runtime mode", ()
       createdAt: "2026-01-01T00:00:00.000Z",
     });
     assert.strictEqual(parsed.modelSelection, undefined);
-    assert.strictEqual(parsed.runtimeMode, DEFAULT_RUNTIME_MODE);
+    assert.strictEqual(parsed.runtimeMode, DEFAULT_LOCAL_EXECUTION_MODE);
     assert.strictEqual(parsed.interactionMode, DEFAULT_PROVIDER_INTERACTION_MODE);
+  }),
+);
+
+it.effect("decodes bot.create to approval required when an old client omits runtimeMode", () =>
+  Effect.gen(function* () {
+    const parsed = yield* decodeOrchestrationCommand({
+      type: "bot.create",
+      commandId: "cmd-bot-default-runtime",
+      botId: "bot-default-runtime",
+      name: "Akeru",
+      title: "Akeru",
+      avatar: { kind: "dither", seed: "akeru" },
+      engine: null,
+      sandbox: null,
+      usageCap: null,
+      groupId: null,
+      createdAt: "2026-01-01T00:00:00.000Z",
+    });
+
+    if (parsed.type !== "bot.create") assert.fail(`Expected bot.create, received ${parsed.type}.`);
+    assert.strictEqual(parsed.runtimeMode, DEFAULT_LOCAL_EXECUTION_MODE);
   }),
 );
 

--- a/packages/contracts/src/orchestration.ts
+++ b/packages/contracts/src/orchestration.ts
@@ -127,7 +127,11 @@ export const RuntimeMode = Schema.Literals([
   "full-access",
 ]);
 export type RuntimeMode = typeof RuntimeMode.Type;
+// Event decoders keep the historical full-access fallback for old persisted data.
 export const DEFAULT_RUNTIME_MODE: RuntimeMode = "full-access";
+export const LocalExecutionMode = Schema.Literals(["approval-required", "full-access"]);
+export type LocalExecutionMode = typeof LocalExecutionMode.Type;
+export const DEFAULT_LOCAL_EXECUTION_MODE: LocalExecutionMode = "approval-required";
 export const ProviderInteractionMode = Schema.Literals(["default", "plan"]);
 export type ProviderInteractionMode = typeof ProviderInteractionMode.Type;
 export const DEFAULT_PROVIDER_INTERACTION_MODE: ProviderInteractionMode = "default";
@@ -840,7 +844,9 @@ const BotCreateCommand = Schema.Struct({
   avatar: BotAvatar,
   engine: Schema.NullOr(BotEngine),
   sandbox: Schema.NullOr(BotSandbox),
-  runtimeMode: RuntimeMode.pipe(Schema.withDecodingDefault(Effect.succeed(DEFAULT_RUNTIME_MODE))),
+  runtimeMode: RuntimeMode.pipe(
+    Schema.withDecodingDefault(Effect.succeed(DEFAULT_LOCAL_EXECUTION_MODE)),
+  ),
   usageCap: Schema.NullOr(BotUsageCap).pipe(Schema.withDecodingDefault(Effect.succeed(null))),
   voiceEnabled: Schema.optional(Schema.Boolean),
   groupId: Schema.NullOr(GroupId),
@@ -1174,7 +1180,9 @@ export const ThreadTurnStartCommand = Schema.Struct({
   }),
   modelSelection: Schema.optional(ModelSelection),
   titleSeed: Schema.optional(TrimmedNonEmptyString),
-  runtimeMode: RuntimeMode.pipe(Schema.withDecodingDefault(Effect.succeed(DEFAULT_RUNTIME_MODE))),
+  runtimeMode: RuntimeMode.pipe(
+    Schema.withDecodingDefault(Effect.succeed(DEFAULT_LOCAL_EXECUTION_MODE)),
+  ),
   interactionMode: ProviderInteractionMode.pipe(
     Schema.withDecodingDefault(Effect.succeed(DEFAULT_PROVIDER_INTERACTION_MODE)),
   ),

--- a/packages/contracts/src/orchestration.ts
+++ b/packages/contracts/src/orchestration.ts
@@ -844,9 +844,7 @@ const BotCreateCommand = Schema.Struct({
   avatar: BotAvatar,
   engine: Schema.NullOr(BotEngine),
   sandbox: Schema.NullOr(BotSandbox),
-  runtimeMode: RuntimeMode.pipe(
-    Schema.withDecodingDefault(Effect.succeed(DEFAULT_LOCAL_EXECUTION_MODE)),
-  ),
+  runtimeMode: Schema.optional(RuntimeMode),
   usageCap: Schema.NullOr(BotUsageCap).pipe(Schema.withDecodingDefault(Effect.succeed(null))),
   voiceEnabled: Schema.optional(Schema.Boolean),
   groupId: Schema.NullOr(GroupId),

--- a/packages/contracts/src/settings.test.ts
+++ b/packages/contracts/src/settings.test.ts
@@ -96,6 +96,20 @@ describe("ClaudeSettings auto-compaction", () => {
   });
 });
 
+describe("ServerSettings local execution", () => {
+  it("asks before local execution by default and accepts an explicit full-access opt-in", () => {
+    expect(decodeServerSettings({}).localExecutionMode).toBe("approval-required");
+    expect(
+      decodeServerSettingsPatch({ localExecutionMode: "full-access" }).localExecutionMode,
+    ).toBe("full-access");
+  });
+
+  it("rejects other runtime modes", () => {
+    expect(() => decodeServerSettingsPatch({ localExecutionMode: "auto" })).toThrow();
+    expect(() => decodeServerSettingsPatch({ localExecutionMode: "auto-accept-edits" })).toThrow();
+  });
+});
+
 describe("ClientSettings word wrap", () => {
   it("defaults word wrap on", () => {
     expect(decodeClientSettings({}).wordWrap).toBe(true);

--- a/packages/contracts/src/settings.ts
+++ b/packages/contracts/src/settings.ts
@@ -12,6 +12,8 @@ import {
 import {
   BotSandboxBrowserSharing,
   DEFAULT_BOT_SANDBOX_BROWSER_SHARING,
+  DEFAULT_LOCAL_EXECUTION_MODE,
+  LocalExecutionMode,
   ModelSelection,
 } from "./orchestration.ts";
 import {
@@ -683,6 +685,9 @@ export const ServerSettings = Schema.Struct({
    * between a desktop window and a phone attached to the same server.
    */
   enableAgentBrowserAccess: Schema.Boolean.pipe(Schema.withDecodingDefault(Effect.succeed(true))),
+  localExecutionMode: LocalExecutionMode.pipe(
+    Schema.withDecodingDefault(Effect.succeed(DEFAULT_LOCAL_EXECUTION_MODE)),
+  ),
   voice: VoiceSettings,
   backgroundActivity: BackgroundActivitySettings,
   // Legacy flat fields retained for old settings files and old clients. New
@@ -907,6 +912,7 @@ export const ServerSettingsPatch = Schema.Struct({
   productFeedbackEndpoint: Schema.optionalKey(ProductFeedbackEndpoint),
   botSandboxBrowserSharing: Schema.optionalKey(BotSandboxBrowserSharing),
   enableAgentBrowserAccess: Schema.optionalKey(Schema.Boolean),
+  localExecutionMode: Schema.optionalKey(LocalExecutionMode),
   voice: Schema.optionalKey(
     Schema.Struct({
       enabled: Schema.optionalKey(Schema.Boolean),


### PR DESCRIPTION
Local file and shell tools defaulted to full access unless each thread changed its runtime mode. New local work should ask first, while users can still opt into unattended execution.

## What changed

- Added a server setting that defaults local execution to `approval-required` and allows an explicit `full-access` opt-in.
- Applied the setting to new web and mobile threads and to local bot and group turns.
- Updated existing bot and group threads before their next local turn when the setting changed.
- Kept remote sandbox bots on full access because the local-computer prompt does not apply there.
- Updated the user documentation and Settings search entry.

## Testing

- `vp test run packages/contracts/src/settings.test.ts packages/contracts/src/orchestration.test.ts packages/contracts/src/botConfig.test.ts apps/web/src/components/roster/botSandbox.test.ts apps/web/src/composerDraftStore.test.ts apps/web/src/components/settings/settingsSearch.test.ts apps/web/src/components/sidebar/SidebarChrome.test.ts` (221 tests passed)
- `vp run --filter @t3tools/contracts typecheck`
- `vp run --filter @t3tools/web typecheck`
- `vp run --filter @t3tools/mobile typecheck`

## Notes

No screenshot was captured because browser and computer control were not authorized for this run.

Linear: LEO-276

Model: gpt-5.6-sol
Harness: Codex in T3 Code
