### PR TITLE
feat(bots): reply before tools with status beats

### DIFF
--- a/apps/server/src/orchestration/Layers/ProviderCommandReactor.test.ts
+++ b/apps/server/src/orchestration/Layers/ProviderCommandReactor.test.ts
@@ -640,6 +640,7 @@ describe("ProviderCommandReactor", () => {
         model: "gpt-5-codex",
       },
       mode: "default",
+      botConversation: false,
     });
     expect(harness.startSession.mock.calls[0]?.[0]).toEqual(ThreadId.make("thread-1"));
     expect(harness.startSession.mock.calls[0]?.[1]).toMatchObject({
@@ -703,6 +704,7 @@ describe("ProviderCommandReactor", () => {
         model: "claude-fable-5",
       },
       mode: "default",
+      botConversation: true,
     });
     expect(harness.startSession.mock.calls[0]?.[1]).toMatchObject({
       provider: ProviderDriverKind.make("claudeAgent"),

--- a/apps/server/src/orchestration/Layers/ProviderCommandReactor.ts
+++ b/apps/server/src/orchestration/Layers/ProviderCommandReactor.ts
@@ -538,6 +538,7 @@ const make = Effect.gen(function* () {
       engine,
       fallback,
       mode: thread.interactionMode,
+      botConversation: thread.botId != null || thread.groupId != null,
     });
     return { ...selection, configured: engine !== null };
   });

--- a/apps/server/src/orchestration/Layers/ProviderRuntimeIngestion.test.ts
+++ b/apps/server/src/orchestration/Layers/ProviderRuntimeIngestion.test.ts
@@ -1343,6 +1343,61 @@ describe("ProviderRuntimeIngestion", () => {
     expect(message?.streaming).toBe(false);
   });
 
+  it("persists separate assistant notes while one turn remains active", async () => {
+    const harness = await createHarness();
+    const now = "2026-01-01T00:00:00.000Z";
+    const threadId = asThreadId("thread-1");
+    const turnId = asTurnId("turn-status-beats");
+
+    harness.emit({
+      type: "turn.started",
+      eventId: asEventId("evt-status-turn-started"),
+      provider: ProviderDriverKind.make("codex"),
+      createdAt: now,
+      threadId,
+      turnId,
+    });
+    for (const [itemId, text] of [
+      ["reply-before-tools", "I'll check that now."],
+      ["status-after-tool", "I found the relevant setting."],
+    ] as const) {
+      harness.emit({
+        type: "content.delta",
+        eventId: asEventId(`evt-${itemId}-delta`),
+        provider: ProviderDriverKind.make("codex"),
+        createdAt: now,
+        threadId,
+        turnId,
+        itemId: asItemId(itemId),
+        payload: { streamKind: "assistant_text", delta: text },
+      });
+      harness.emit({
+        type: "item.completed",
+        eventId: asEventId(`evt-${itemId}-completed`),
+        provider: ProviderDriverKind.make("codex"),
+        createdAt: now,
+        threadId,
+        turnId,
+        itemId: asItemId(itemId),
+        payload: { itemType: "assistant_message", status: "completed" },
+      });
+    }
+
+    const thread = await waitForThread(harness.readModel, (entry) =>
+      ["assistant:reply-before-tools", "assistant:status-after-tool"].every((id) =>
+        entry.messages.some(
+          (message: ProviderRuntimeTestMessage) => message.id === id && !message.streaming,
+        ),
+      ),
+    );
+    expect(
+      thread.messages
+        .filter((message: ProviderRuntimeTestMessage) => message.turnId === turnId)
+        .map((message: ProviderRuntimeTestMessage) => message.text),
+    ).toEqual(["I'll check that now.", "I found the relevant setting."]);
+    expect(thread.session?.activeTurnId).toBe(turnId);
+  });
+
   it("uses assistant item completion detail when no assistant deltas were streamed", async () => {
     const harness = await createHarness();
     const now = "2026-01-01T00:00:00.000Z";

--- a/apps/server/src/provider/AkeruAgentInstructions.ts
+++ b/apps/server/src/provider/AkeruAgentInstructions.ts
@@ -8,3 +8,13 @@ export const AKERU_AGENT_INSTRUCTIONS = [
   "When asked about available tools, describe only tools present in the current turn.",
   "Do not claim that a tool ran unless its result is present in this turn.",
 ].join("\n");
+
+export const AKERU_BOT_TURN_INSTRUCTIONS = [
+  "Before you use a tool for a visible user request, first answer with one short plain-language sentence that acknowledges the request and says what you will do next.",
+  "During longer tool work, add one short plain-language status note after meaningful progress or a change in direction and before the next tool call. Do not narrate every tool call.",
+  "Treat a hidden system reminder or automatic continuation as ongoing work, not a new user request. Skip the opening reply and continue with only useful status notes.",
+].join("\n");
+
+export const AKERU_BOT_INSTRUCTIONS = [AKERU_AGENT_INSTRUCTIONS, AKERU_BOT_TURN_INSTRUCTIONS].join(
+  "\n",
+);

--- a/apps/server/src/provider/AkeruMastraHarness.test.ts
+++ b/apps/server/src/provider/AkeruMastraHarness.test.ts
@@ -7,10 +7,11 @@ import {
 } from "@t3tools/contracts";
 import { assert, describe, it } from "vite-plus/test";
 
-import { AKERU_AGENT_INSTRUCTIONS } from "./AkeruAgentInstructions.ts";
+import { AKERU_AGENT_INSTRUCTIONS, AKERU_BOT_INSTRUCTIONS } from "./AkeruAgentInstructions.ts";
 import {
   criticalAkeruAction,
   mastraModelId,
+  resolveAkeruInstructions,
   resolveAkeruMastraModel,
   resolveAkeruTools,
 } from "./AkeruMastraHarness.ts";
@@ -42,6 +43,18 @@ describe("AkeruMastraHarness", () => {
     assert.include(AKERU_AGENT_INSTRUCTIONS, "enabled plugin tools");
     assert.include(AKERU_AGENT_INSTRUCTIONS, "Do not assume");
     assert.notInclude(AKERU_AGENT_INSTRUCTIONS, "coding agent");
+  });
+
+  it("adds reply and status rules only to bot conversations", () => {
+    const regular = new RequestContext();
+    regular.setRaw("controller", { state: { botConversation: false } });
+    const bot = new RequestContext();
+    bot.setRaw("controller", { state: { botConversation: true } });
+
+    assert.equal(resolveAkeruInstructions(regular), AKERU_AGENT_INSTRUCTIONS);
+    assert.equal(resolveAkeruInstructions(bot), AKERU_BOT_INSTRUCTIONS);
+    assert.include(resolveAkeruInstructions(bot), "Before you use a tool");
+    assert.include(resolveAkeruInstructions(bot), "automatic continuation");
   });
 
   it("selects implemented runtime tools without dropping approval-aware plugins", async () => {

--- a/apps/server/src/provider/AkeruMastraHarness.ts
+++ b/apps/server/src/provider/AkeruMastraHarness.ts
@@ -21,7 +21,7 @@ import {
 import * as Exit from "effect/Exit";
 import * as Schema from "effect/Schema";
 
-import { AKERU_AGENT_INSTRUCTIONS } from "./AkeruAgentInstructions.ts";
+import { AKERU_AGENT_INSTRUCTIONS, AKERU_BOT_INSTRUCTIONS } from "./AkeruAgentInstructions.ts";
 import { akeruKimiProvider, type AkeruKimiAccess } from "./AkeruKimiProvider.ts";
 import { createAkeruMastraTools } from "./AkeruMastraTools.ts";
 import type { AkeruToolRuntime } from "./AkeruToolRuntime.ts";
@@ -69,6 +69,7 @@ const productFeedbackTool = createTool({
 export interface AkeruMastraState {
   readonly projectPath?: string;
   readonly yolo?: boolean;
+  readonly botConversation?: boolean;
 }
 
 export type AkeruMastraSession = Session<AkeruMastraState>;
@@ -147,6 +148,16 @@ export function resolveAkeruMastraModel(
     return akeruKimiProvider(trimmed.slice("kimi-for-coding/".length), getKimiAccess);
   }
   throw new Error(`Mastra has no subscription transport for model '${modelId}'.`);
+}
+
+export function resolveAkeruInstructions(requestContext: RequestContext): string {
+  const state = controllerContext(requestContext)?.state;
+  return typeof state === "object" &&
+    state !== null &&
+    "botConversation" in state &&
+    state.botConversation === true
+    ? AKERU_BOT_INSTRUCTIONS
+    : AKERU_AGENT_INSTRUCTIONS;
 }
 
 export async function resolveAkeruTools(
@@ -343,7 +354,7 @@ export async function createAkeruMastraHarness(
   const agent = createCodingAgent({
     id: "akeru-agent",
     name: "Akeru",
-    instructions: AKERU_AGENT_INSTRUCTIONS,
+    instructions: ({ requestContext }) => resolveAkeruInstructions(requestContext),
     model: ({ requestContext }) =>
       resolveAkeruMastraModel(
         controllerModelId(requestContext),

--- a/apps/server/src/provider/Layers/AgentController.test.ts
+++ b/apps/server/src/provider/Layers/AgentController.test.ts
@@ -17,6 +17,7 @@ import {
   ProviderDriverKind,
   ProviderInstanceId,
   ProjectId,
+  RuntimeItemId,
   ThreadId,
   TurnId,
   type ProviderRuntimeEvent,
@@ -199,9 +200,9 @@ function makeMastraHarness() {
   };
 }
 
-function assistantMessage(text: string): MastraDBMessage {
+function assistantMessage(text: string, id = "assistant-message"): MastraDBMessage {
   return {
-    id: "assistant-message",
+    id,
     role: "assistant",
     createdAt: new Date("2026-01-01T00:00:00.000Z"),
     content: {
@@ -264,6 +265,7 @@ function resolveCodex(controller: AgentController["Service"]) {
     engine: { provider: "codex", model: "gpt-5.6-sol" },
     fallback: codexSelection,
     mode: "default",
+    botConversation: true,
   });
 }
 
@@ -702,6 +704,68 @@ describe("AgentControllerLive", () => {
     );
   });
 
+  it.effect("keeps replies and status beats as separate completed messages", () => {
+    const bridge = makeBridge();
+    const mastra = makeMastraHarness();
+    return provideController(
+      Effect.gen(function* () {
+        const controller = yield* AgentController;
+        yield* resolveCodex(controller);
+        yield* controller.startSession(codexThreadId, {
+          threadId: codexThreadId,
+          provider: ProviderDriverKind.make("codex"),
+          providerInstanceId: codexInstanceId,
+          cwd: process.cwd(),
+          modelSelection: codexSelection,
+          runtimeMode: "full-access",
+        });
+
+        const events: ProviderRuntimeEvent[] = [];
+        const eventsFiber = yield* controller.streamEvents.pipe(
+          Stream.runForEach((event) => Effect.sync(() => events.push(event))),
+          Effect.forkChild({ startImmediately: true }),
+        );
+        yield* Effect.yieldNow;
+        yield* controller.sendTurn({ threadId: codexThreadId, input: "Check the project." });
+        mastra.emit({
+          type: "message_update",
+          message: assistantMessage("I'll check first.", "opening"),
+        } as AgentControllerEvent);
+        mastra.emit({
+          type: "tool_start",
+          toolCallId: "view-1",
+          toolName: "view",
+          args: { path: "package.json" },
+        } as AgentControllerEvent);
+        mastra.emit({
+          type: "tool_end",
+          toolCallId: "view-1",
+          result: "{}",
+          isError: false,
+        } as AgentControllerEvent);
+        mastra.emit({
+          type: "message_end",
+          message: assistantMessage("I found the configuration.", "status"),
+        } as AgentControllerEvent);
+        mastra.emit({ type: "agent_end", reason: "complete" } as AgentControllerEvent);
+        mastra.finishSend();
+        yield* Effect.yieldNow;
+        yield* Fiber.interrupt(eventsFiber);
+
+        assert.deepEqual(
+          events.filter((event) => event.type === "item.completed").map((event) => event.itemId),
+          [
+            RuntimeItemId.make("mastra-answer-opening"),
+            RuntimeItemId.make("view-1"),
+            RuntimeItemId.make("mastra-answer-status"),
+          ],
+        );
+      }),
+      bridge.service,
+      mastra.factory,
+    );
+  });
+
   it.effect("keeps product feedback approval-gated in full-access mode", () => {
     const bridge = makeBridge();
     const mastra = makeMastraHarness();
@@ -1116,7 +1180,6 @@ describe("AgentControllerLive", () => {
         threadId: codexThreadId,
         provider: ProviderDriverKind.make("codex"),
         providerInstanceId: codexInstanceId,
-        cwd: process.cwd(),
         modelSelection: codexSelection,
         runtimeMode: "full-access",
         botSandbox: "upstash",
@@ -1266,6 +1329,7 @@ describe("AgentControllerLive", () => {
           engine: { provider: "claudeAgent", model: "claude-fable-5" },
           fallback: codexSelection,
           mode: "plan",
+          botConversation: true,
         });
         yield* controller.startSession(claudeThreadId, {
           threadId: claudeThreadId,
@@ -1301,6 +1365,7 @@ describe("AgentControllerLive", () => {
           engine: { provider: "kimi", model: "k3-256k" },
           fallback: codexSelection,
           mode: "default",
+          botConversation: true,
         });
         const session = yield* controller.startSession(kimiThreadId, {
           threadId: kimiThreadId,
@@ -1340,12 +1405,14 @@ describe("AgentControllerLive", () => {
           engine: { provider: "claudeAgent", model: "claude-fable-5" },
           fallback: codexSelection,
           mode: "default",
+          botConversation: false,
         });
         yield* controller.resolveEngine({
           threadId: codexThreadId,
           engine: { provider: "codex", model: "gpt-5.6-sol" },
           fallback: codexSelection,
           mode: "default",
+          botConversation: false,
         });
         yield* controller.stopSession({ threadId: codexThreadId });
 

--- a/apps/server/src/provider/Layers/AgentController.ts
+++ b/apps/server/src/provider/Layers/AgentController.ts
@@ -61,6 +61,7 @@ import {
   type AkeruMastraHarnessOptions,
   type AkeruMastraSession,
 } from "../AkeruMastraHarness.ts";
+import { AKERU_BOT_TURN_INSTRUCTIONS } from "../AkeruAgentInstructions.ts";
 import {
   createAkeruToolRuntime,
   isMemoryToolId,
@@ -88,14 +89,19 @@ interface ResolvedEngine {
   readonly providerInstanceId: ProviderInstanceId;
   readonly mastraModelId: string;
   readonly mode: "default" | "plan";
+  readonly botConversation: boolean;
+}
+
+interface ActiveAssistantMessage {
+  readonly itemId: RuntimeItemId;
+  length: number;
+  started: boolean;
+  completed: boolean;
 }
 
 interface ActiveTurn {
   readonly turnId: TurnId;
-  readonly assistantItemId: RuntimeItemId;
-  assistantLength: number;
-  assistantStarted: boolean;
-  assistantCompleted: boolean;
+  readonly assistantMessages: Map<string, ActiveAssistantMessage>;
   waiting: boolean;
   finished: boolean;
 }
@@ -395,6 +401,23 @@ const make = (options?: AgentControllerLiveOptions) =>
       });
     };
 
+    const completeAssistantMessages = (
+      threadId: ThreadId,
+      active: ActiveSession,
+      turn: ActiveTurn,
+    ) => {
+      for (const message of turn.assistantMessages.values()) {
+        if (!message.started || message.completed) continue;
+        message.completed = true;
+        publish({
+          ...baseEvent(threadId, active, turn.turnId),
+          itemId: message.itemId,
+          type: "item.completed",
+          payload: { itemType: "assistant_message", status: "completed" },
+        });
+      }
+    };
+
     const finishTurn = (
       threadId: ThreadId,
       active: ActiveSession,
@@ -404,15 +427,7 @@ const make = (options?: AgentControllerLiveOptions) =>
       const turn = active.activeTurn;
       if (!turn || turn.finished) return;
       turn.finished = true;
-      if (turn.assistantStarted && !turn.assistantCompleted) {
-        turn.assistantCompleted = true;
-        publish({
-          ...baseEvent(threadId, active, turn.turnId),
-          itemId: turn.assistantItemId,
-          type: "item.completed",
-          payload: { itemType: "assistant_message", status: "completed" },
-        });
-      }
+      completeAssistantMessages(threadId, active, turn);
       publish({
         ...baseEvent(threadId, active, turn.turnId),
         type: "turn.completed",
@@ -437,30 +452,42 @@ const make = (options?: AgentControllerLiveOptions) =>
       const turn = active.activeTurn;
       if (!turn) return;
       const text = messageText(message);
-      if (!turn.assistantStarted && text.length > 0) {
-        turn.assistantStarted = true;
+      const messageKey = String(message.id);
+      let activeMessage = turn.assistantMessages.get(messageKey);
+      if (!activeMessage) {
+        activeMessage = {
+          itemId: RuntimeItemId.make(`mastra-answer-${messageKey}`),
+          length: 0,
+          started: false,
+          completed: false,
+        };
+        turn.assistantMessages.set(messageKey, activeMessage);
+      }
+      if (activeMessage.completed) return;
+      if (!activeMessage.started && text.length > 0) {
+        activeMessage.started = true;
         publish({
           ...baseEvent(threadId, active, turn.turnId),
-          itemId: turn.assistantItemId,
+          itemId: activeMessage.itemId,
           type: "item.started",
           payload: { itemType: "assistant_message", status: "inProgress" },
         });
       }
-      if (text.length > turn.assistantLength) {
-        const delta = text.slice(turn.assistantLength);
-        turn.assistantLength = text.length;
+      if (text.length > activeMessage.length) {
+        const delta = text.slice(activeMessage.length);
+        activeMessage.length = text.length;
         publish({
           ...baseEvent(threadId, active, turn.turnId),
-          itemId: turn.assistantItemId,
+          itemId: activeMessage.itemId,
           type: "content.delta",
           payload: { streamKind: "assistant_text", delta },
         });
       }
-      if (complete && turn.assistantStarted && !turn.assistantCompleted) {
-        turn.assistantCompleted = true;
+      if (complete && activeMessage.started && !activeMessage.completed) {
+        activeMessage.completed = true;
         publish({
           ...baseEvent(threadId, active, turn.turnId),
-          itemId: turn.assistantItemId,
+          itemId: activeMessage.itemId,
           type: "item.completed",
           payload: { itemType: "assistant_message", status: "completed" },
         });
@@ -482,6 +509,7 @@ const make = (options?: AgentControllerLiveOptions) =>
           return;
         case "tool_start": {
           if (!turn) return;
+          completeAssistantMessages(threadId, active, turn);
           active.toolNames.set(event.toolCallId, event.toolName);
           publish({
             ...baseEvent(threadId, active, turn.turnId),
@@ -528,6 +556,7 @@ const make = (options?: AgentControllerLiveOptions) =>
         }
         case "tool_approval_required":
           if (!turn) return;
+          completeAssistantMessages(threadId, active, turn);
           active.toolNames.set(event.toolCallId, event.toolName);
           active.approvalRequests.set(event.toolCallId, {
             name: event.toolName,
@@ -570,6 +599,7 @@ const make = (options?: AgentControllerLiveOptions) =>
           return;
         case "tool_suspended":
           if (!turn) return;
+          completeAssistantMessages(threadId, active, turn);
           active.toolNames.set(event.toolCallId, event.toolName);
           turn.waiting = true;
           publishSessionState(threadId, active, "waiting");
@@ -675,6 +705,7 @@ const make = (options?: AgentControllerLiveOptions) =>
             providerInstanceId: modelSelection.instanceId,
             mastraModelId: mastraModelId(inspected.routing.driverKind, modelSelection.model),
             mode: input.mode,
+            botConversation: input.botConversation,
           };
           resolvedByThread.set(String(input.threadId), resolved);
           const active = sessions.get(String(input.threadId));
@@ -836,6 +867,7 @@ const make = (options?: AgentControllerLiveOptions) =>
         session.state.set({
           ...(input.cwd ? { projectPath: input.cwd } : {}),
           yolo: false,
+          botConversation: resolved.botConversation,
         }),
       );
       yield* runMastra("model.switch", () =>
@@ -913,7 +945,15 @@ const make = (options?: AgentControllerLiveOptions) =>
               detail: `Mastra session for thread '${input.threadId}' is not running.`,
             });
           }
-          return yield* legacyProviderBridge.sendTurn(input);
+          const resolved = resolvedByThread.get(key);
+          return yield* legacyProviderBridge.sendTurn(
+            resolved?.botConversation === true && String(resolved.provider) !== "claudeAgent"
+              ? {
+                  ...input,
+                  input: [AKERU_BOT_TURN_INSTRUCTIONS, input.input].filter(Boolean).join("\n\n"),
+                }
+              : input,
+          );
         }
         if (active.activeTurn) {
           return yield* new AgentControllerRuntimeError({
@@ -958,10 +998,7 @@ const make = (options?: AgentControllerLiveOptions) =>
         const turnId = TurnId.make(`mastra-turn-${NodeCrypto.randomUUID()}`);
         active.activeTurn = {
           turnId,
-          assistantItemId: RuntimeItemId.make(`mastra-answer-${turnId}`),
-          assistantLength: 0,
-          assistantStarted: false,
-          assistantCompleted: false,
+          assistantMessages: new Map(),
           waiting: false,
           finished: false,
         };

--- a/apps/server/src/provider/Layers/ClaudeAdapter.test.ts
+++ b/apps/server/src/provider/Layers/ClaudeAdapter.test.ts
@@ -413,19 +413,43 @@ describe("ClaudeAdapterLive", () => {
           type: "preset",
           preset: "claude_code",
         });
-        assert.include(
+        const appendedInstructions =
           typeof createInput?.options.systemPrompt === "object" &&
-            "append" in createInput.options.systemPrompt
+          "append" in createInput.options.systemPrompt
             ? (createInput.options.systemPrompt.append ?? "")
-            : "",
-          "general-purpose assistant",
-        );
+            : "";
+        assert.include(appendedInstructions, "general-purpose assistant");
+        assert.notInclude(appendedInstructions, "Before you use a tool");
       }).pipe(
         Effect.provideService(Random.Random, makeDeterministicRandomService()),
         Effect.provide(harness.layer),
       );
     },
   );
+
+  it.effect("adds reply-first instructions to bot Claude sessions", () => {
+    const harness = makeHarness();
+    return Effect.gen(function* () {
+      const adapter = yield* ClaudeAdapter;
+      yield* adapter.startSession({
+        threadId: THREAD_ID,
+        provider: ProviderDriverKind.make("claudeAgent"),
+        runtimeMode: "full-access",
+        botId: "bot-1" as never,
+      });
+
+      const systemPrompt = harness.getLastCreateQueryInput()?.options.systemPrompt;
+      const appendedInstructions =
+        typeof systemPrompt === "object" && "append" in systemPrompt
+          ? (systemPrompt.append ?? "")
+          : "";
+      assert.include(appendedInstructions, "Before you use a tool");
+      assert.include(appendedInstructions, "automatic continuation");
+    }).pipe(
+      Effect.provideService(Random.Random, makeDeterministicRandomService()),
+      Effect.provide(harness.layer),
+    );
+  });
 
   it.effect("passes the configured auto-compaction window to Claude", () => {
     const harness = makeHarness({ claudeConfig: { autoCompactWindow: "300000" } });

--- a/apps/server/src/provider/Layers/ClaudeAdapter.ts
+++ b/apps/server/src/provider/Layers/ClaudeAdapter.ts
@@ -78,7 +78,7 @@ import * as Stream from "effect/Stream";
 
 import { resolveAttachmentPath } from "../../attachmentStore.ts";
 import { ServerConfig } from "../../config.ts";
-import { AKERU_AGENT_INSTRUCTIONS } from "../AkeruAgentInstructions.ts";
+import { AKERU_AGENT_INSTRUCTIONS, AKERU_BOT_INSTRUCTIONS } from "../AkeruAgentInstructions.ts";
 import * as McpProviderSession from "../../mcp/McpProviderSession.ts";
 import { toClaudeMcpServers } from "../McpServerConfig.ts";
 import { resolveClaudeSdkExecutablePath } from "../Drivers/ClaudeExecutable.ts";
@@ -4320,7 +4320,7 @@ export const makeClaudeAdapter = Effect.fn("makeClaudeAdapter")(function* (
         systemPrompt: {
           type: "preset",
           preset: "claude_code",
-          append: AKERU_AGENT_INSTRUCTIONS,
+          append: input.botId ? AKERU_BOT_INSTRUCTIONS : AKERU_AGENT_INSTRUCTIONS,
         },
         settingSources: [...CLAUDE_SETTING_SOURCES],
         // `ultracode` is a Claude Code setting, not an API effort level. It is

--- a/apps/server/src/provider/Services/AgentController.ts
+++ b/apps/server/src/provider/Services/AgentController.ts
@@ -50,6 +50,7 @@ export interface AgentControllerShape {
     readonly engine: BotEngine | null;
     readonly fallback: ModelSelection;
     readonly mode: ProviderInteractionMode;
+    readonly botConversation: boolean;
   }) => Effect.Effect<AgentControllerEngineSelection, AgentControllerError>;
 
   /** Read routing metadata without changing the thread's active runtime session. */

--- a/apps/web/src/components/roster/BotRosterSidebar.tsx
+++ b/apps/web/src/components/roster/BotRosterSidebar.tsx
@@ -185,7 +185,6 @@ const BotStripTile = memo(function BotStripTile({
 function useLatestBotMessage(
   botId: string,
   fallback: RosterLastMessage | null,
-  working: boolean,
 ): RosterLastMessage | null {
   const rememberedPath = useRosterStore((state) => state.chatPathByBotId[botId]);
   const environmentId = usePrimaryEnvironmentId();
@@ -200,10 +199,7 @@ function useLatestBotMessage(
       : null;
   }, [botId, environmentId, rememberedPath, threadShells]);
   const messages = useThreadMessages(threadRef);
-  const visibleMessages = useMemo(
-    () => visibleBotChatMessages(messages, working),
-    [messages, working],
-  );
+  const visibleMessages = useMemo(() => visibleBotChatMessages(messages), [messages]);
   return useMemo(
     () => resolveLatestRosterMessage(fallback, visibleMessages),
     [fallback, visibleMessages],
@@ -223,7 +219,7 @@ const BotRosterRow = memo(function BotRosterRow({
 }) {
   const timestampFormat = useClientSettings((s) => s.timestampFormat);
   const presence = useBotPresence(bot.id);
-  const latestMessage = useLatestBotMessage(bot.id, lastMessage, presence === "working");
+  const latestMessage = useLatestBotMessage(bot.id, lastMessage);
   const { listeners, setNodeRef, transform, transition, isDragging } = useSortable({ id: bot.id });
   return (
     <li

--- a/apps/web/src/components/roster/BotThreadLanding.tsx
+++ b/apps/web/src/components/roster/BotThreadLanding.tsx
@@ -108,7 +108,7 @@ export function BotThreadLanding({ botId }: { readonly botId: string }) {
 
   if (!bot || bot.archivedAt !== null) return null;
   const working = runtime.sending || presence === "working";
-  const messages = visibleBotChatMessages(runtime.messages, working);
+  const messages = visibleBotChatMessages(runtime.messages);
   const inboxItems = selectOpenBotInboxItems(inboxQuery.data?.inbox ?? [], new Set([bot.id]));
 
   return (

--- a/apps/web/src/components/roster/GroupThreadLanding.tsx
+++ b/apps/web/src/components/roster/GroupThreadLanding.tsx
@@ -44,7 +44,7 @@ export function GroupThreadLanding({ groupId }: { readonly groupId: string }) {
   const boss = members.find((bot) => bot.id === group.bossBotId) ?? members[0];
   if (!boss) return null;
   const working = runtime.sending || presence === "working";
-  const messages = visibleBotChatMessages(runtime.messages, working);
+  const messages = visibleBotChatMessages(runtime.messages);
   const activeBot = members.find((bot) => bot.id === runtime.respondingBotId) ?? boss;
   const inboxItems = selectOpenBotInboxItems(
     inboxQuery.data?.inbox ?? [],

--- a/apps/web/src/components/roster/botConversationPresentation.test.ts
+++ b/apps/web/src/components/roster/botConversationPresentation.test.ts
@@ -31,17 +31,21 @@ describe("bot conversation presentation", () => {
     expect(visibleBotChatMessages(messages).map((entry) => entry.id)).toEqual(["user", "answer"]);
   });
 
-  it("shows only the last settled assistant record from one turn", () => {
+  it("shows each settled assistant note from one turn", () => {
     const messages = [
       message("user", "user", false),
       message("intermediate", "assistant", false, "turn-1"),
       message("final", "assistant", false, "turn-1"),
     ];
 
-    expect(visibleBotChatMessages(messages).map((entry) => entry.id)).toEqual(["user", "final"]);
+    expect(visibleBotChatMessages(messages).map((entry) => entry.id)).toEqual([
+      "user",
+      "intermediate",
+      "final",
+    ]);
   });
 
-  it("hides assistant records from the active turn behind the working status", () => {
+  it("shows completed status beats while the turn remains active", () => {
     const messages = [
       message("first-user", "user", false),
       message("first-answer", "assistant", false, "turn-1"),
@@ -49,10 +53,11 @@ describe("bot conversation presentation", () => {
       message("active-intermediate", "assistant", false, "turn-2"),
     ];
 
-    expect(visibleBotChatMessages(messages, true).map((entry) => entry.id)).toEqual([
+    expect(visibleBotChatMessages(messages).map((entry) => entry.id)).toEqual([
       "first-user",
       "first-answer",
       "active-user",
+      "active-intermediate",
     ]);
   });
 });

--- a/apps/web/src/components/roster/botConversationPresentation.ts
+++ b/apps/web/src/components/roster/botConversationPresentation.ts
@@ -1,36 +1,13 @@
 import type { OrchestrationMessage } from "@t3tools/contracts";
 
 /**
- * Bot chat shows each user message and one final assistant answer per turn.
- * Provider progress and intermediate assistant records stay behind the working
- * status so one provider turn cannot appear as several bot replies.
+ * Bot chat shows user messages and every completed assistant note. A turn can
+ * answer before tools, add status beats during work, and finish with a result.
  */
 export function visibleBotChatMessages(
   messages: ReadonlyArray<OrchestrationMessage>,
-  working = false,
 ): ReadonlyArray<OrchestrationMessage> {
-  const latestAssistantIndexByResponse = new Map<string, number>();
-  let precedingUserId = "before-first-user";
-  let lastUserIndex = -1;
-
-  messages.forEach((message, index) => {
-    if (message.role === "user") {
-      precedingUserId = message.id;
-      lastUserIndex = index;
-      return;
-    }
-    if (message.role !== "assistant" || message.streaming) return;
-    latestAssistantIndexByResponse.set(message.turnId ?? precedingUserId, index);
-  });
-
-  precedingUserId = "before-first-user";
-  return messages.filter((message, index) => {
-    if (message.role === "user") {
-      precedingUserId = message.id;
-      return true;
-    }
-    if (message.role !== "assistant" || message.streaming) return false;
-    if (working && index > lastUserIndex) return false;
-    return latestAssistantIndexByResponse.get(message.turnId ?? precedingUserId) === index;
-  });
+  return messages.filter(
+    (message) => message.role === "user" || (message.role === "assistant" && !message.streaming),
+  );
 }

--- a/docs/internals/voice.md
+++ b/docs/internals/voice.md
@@ -12,7 +12,8 @@ How an Akeru Bot talks in chat. These rules feed bot system prompts and review o
 
 ## Working
 
-- Say what you are about to do in one line before a long task, then go quiet until there is a result.
+- Say what you are about to do in one line before a long task.
+- During longer work, add one short update after meaningful progress or a change in direction. Do not narrate each tool.
 - Report a result with what changed and where it lives. A link or a path beats a paragraph.
 - Ask one question when blocked. Include your best-guess default so a "yes" unblocks you.
 

--- a/docs/user/bots.md
+++ b/docs/user/bots.md
@@ -16,6 +16,8 @@ Settings controls whether bots share their workspace and browser. **Separate** i
 
 Use the panel button to collapse or reopen the editor. The default shortcut is **Mod+Alt+B**, and you can change `Right Panel: Toggle` in the keybinding settings. On a narrow screen, the same button opens a sheet.
 
+When a request needs tools, the bot first replies in plain language. During longer work, it adds short status notes after meaningful progress. When work resumes automatically, it continues without a repeated opening note.
+
 Bot replies support headings, links, tables, task lists, code blocks, math, and Mermaid diagrams.
 
 On web and desktop, a bot can link to an app setting with a chip such as `[Error inbox](grokbot://app/v1/settings?id=bot-inbox)`. The chip opens the matching Settings section and shows the destination on hover.


### PR DESCRIPTION
Bots buffered pre-tool text, and bot conversations hid completed assistant notes until the turn ended. Long tool runs could look silent even when the provider had already replied.

This ports the intended behavior from #7 onto current `main`. Bot and group turns receive reply-first and status-note instructions. Mastra keeps each assistant note as a separate item, completes the current note before tools or input requests, and ignores hidden signal messages. Web and desktop show settled notes while work remains active. The current pooled workspace path remains intact, including remote sandboxes without a local `cwd`.

Supersedes #7.

[LEO-281](https://linear.app/opencoredev/issue/LEO-281/reply-first-then-work-with-status-beats)

Tests:

- `vp test run packages/contracts/src/provider.test.ts apps/server/src/provider/AkeruMastraHarness.test.ts apps/server/src/provider/Layers/AgentController.test.ts apps/server/src/provider/Layers/ClaudeAdapter.test.ts apps/server/src/orchestration/Layers/ProviderCommandReactor.test.ts apps/server/src/orchestration/Layers/ProviderRuntimeIngestion.test.ts apps/web/src/components/roster/botConversationPresentation.test.ts` (244 passed)
- `vp run --filter @t3tools/contracts --filter @t3tools/web typecheck`
- `vp run --filter akeru-bot typecheck`
- Targeted `vp fmt --check`
- `git diff --check`

No screenshot or video is included because this changes message sequencing and visibility without changing styling or motion.

Model: GPT-5.6 Sol
Harness: Codex in T3 Code
