### PR TITLE
fix(plugins): align directory with connector lifecycle

### DIFF
--- a/apps/web/src/components/plugins/PluginDetails.tsx
+++ b/apps/web/src/components/plugins/PluginDetails.tsx
@@ -1,4 +1,4 @@
-import type { McpServer } from "@t3tools/contracts";
+import type { McpServer, ProviderAccessStatus } from "@t3tools/contracts";
 import { ArrowUpRightIcon, ChevronLeftIcon } from "lucide-react";
 import type { PluginDirectoryDefinition, PluginSkill } from "../../../../../plugins";
 import { Button } from "../ui/button";
@@ -14,6 +14,7 @@ import {
 interface PluginDetailsContentProps {
   readonly plugin: PluginDirectoryDefinition;
   readonly server: McpServer | undefined;
+  readonly accessStatus?: ProviderAccessStatus;
   readonly activeDependentBotNames: readonly string[];
   readonly pending: boolean;
   readonly onToggle: (enabled: boolean) => void;
@@ -32,6 +33,7 @@ function transportLabel(plugin: PluginDirectoryDefinition): string {
 export function PluginDetailsContent({
   plugin,
   server,
+  accessStatus,
   activeDependentBotNames,
   pending,
   onToggle,
@@ -116,7 +118,13 @@ export function PluginDetailsContent({
               ["Execution", pluginExecutionLabel(plugin)],
               ["Transport", transportLabel(plugin)],
               ["Status", server ? (server.enabled ? "Enabled" : "Disabled") : "Not installed"],
-              ["Health", "Not checked"],
+              [
+                "Health",
+                accessStatus
+                  ? `${accessStatus.health.charAt(0).toUpperCase()}${accessStatus.health.slice(1).replaceAll("-", " ")}`
+                  : "Not checked",
+              ],
+              ...(accessStatus?.repairAction ? [["Repair", accessStatus.repairAction]] : []),
               ["Platforms", plugin.platforms.join(", ")],
               ["License", plugin.license],
             ].map(([label, value]) => (
@@ -232,6 +240,7 @@ export function PluginDetailsContent({
 export function PluginDetails({
   plugin,
   server,
+  accessStatus,
   activeDependentBotNames,
   pending,
   onBack,
@@ -254,6 +263,7 @@ export function PluginDetails({
       <PluginDetailsContent
         plugin={plugin}
         server={server}
+        {...(accessStatus ? { accessStatus } : {})}
         activeDependentBotNames={activeDependentBotNames}
         pending={pending}
         onToggle={onToggle}

--- a/apps/web/src/components/plugins/PluginsDialog.test.tsx
+++ b/apps/web/src/components/plugins/PluginsDialog.test.tsx
@@ -104,7 +104,7 @@ describe("Plugins dialog content", () => {
       />,
     );
     expect(markup).toContain("Disable Firecrawl");
-    expect(markup).toContain("Add Executor");
+    expect(markup).toContain("Connect Executor");
     expect(markup).toContain("Connect Pending Vendor");
     expect(markup).toContain(pendingPlugin.description.replaceAll("'", "&#x27;"));
     expect(markup).toContain("Approval pending");
@@ -156,15 +156,54 @@ describe("Plugins dialog content", () => {
     );
     expect(markup).toContain("By Useful Software Co.");
     expect(markup).toContain("Authentication");
-    expect(markup).toContain("Local");
-    expect(markup).toContain("Local command");
+    expect(markup).toContain("OAuth");
+    expect(markup).toContain("Hosted");
+    expect(markup).toContain("Remote URL");
     expect(markup).toContain("Not checked");
-    expect(markup).toContain("macos, windows, linux");
+    expect(markup).toContain("web, desktop, mobile");
     expect(markup).toContain("Submit a payment.");
     expect(markup).toContain("account-wide");
     expect(markup).toContain("Documentation");
     expect(markup).toContain("Source");
     expect(markup).not.toContain("Connected");
+  });
+
+  it("shows persisted connector health without exposing credential data", () => {
+    const markup = renderToStaticMarkup(
+      <PluginDetailsContent
+        plugin={executor}
+        server={undefined}
+        accessStatus={{
+          id: "mcp-builtin-executor",
+          label: "Executor",
+          accessMethod: "mcp",
+          health: "recovered",
+          apiAccess: "not-applicable",
+          nextAction: "Disable or remove Executor when it is no longer needed.",
+          repairAction: "Reconnect",
+          serverId: "builtin-executor",
+          pluginId: "executor",
+          lastSuccessfulRequestAt: "2026-08-31T20:00:00.000Z",
+          lastFailedRequest: {
+            at: "2026-08-31T19:00:00.000Z",
+            message: "The MCP tool request failed.",
+          },
+          dependentBots: [],
+          dependentRoutines: [],
+        }}
+        activeDependentBotNames={[]}
+        pending={false}
+        onToggle={noop}
+        onRemove={noop}
+        onViewDocumentation={noop}
+        onViewSource={noop}
+        onOpenSkill={noop}
+      />,
+    );
+    expect(markup).toContain("Recovered");
+    expect(markup).toContain("Reconnect");
+    expect(markup).not.toContain("token");
+    expect(markup).not.toContain("secret-access");
   });
 
   it("blocks approval-pending connection and names the blocker in details", () => {
@@ -185,6 +224,28 @@ describe("Plugins dialog content", () => {
     expect(markup).toContain("disabled");
     expect(markup).toContain("Approval pending");
     expect(markup).toContain("The vendor must approve Akeru as an OAuth client.");
+  });
+
+  it("keeps disable available after an installed plugin becomes pending", () => {
+    const pendingServer = { ...firecrawlServer, id: pluginMcpServerId(pendingPlugin) };
+    const markup = renderToStaticMarkup(
+      <PluginDetailsContent
+        plugin={pendingPlugin}
+        server={pendingServer}
+        activeDependentBotNames={[]}
+        pending={false}
+        onToggle={noop}
+        onRemove={noop}
+        onViewDocumentation={noop}
+        onViewSource={noop}
+        onOpenSkill={noop}
+      />,
+    );
+    expect(markup).toContain('aria-label="Disable Pending Vendor"');
+    expect(planPluginToggle(firecrawl, [firecrawlServer], false)).toEqual({
+      action: "disable",
+      mcpServerId: pluginMcpServerId(firecrawl),
+    });
   });
 
   it("shows key setup without storing a credential in the registry", () => {

--- a/apps/web/src/components/plugins/PluginsDialog.tsx
+++ b/apps/web/src/components/plugins/PluginsDialog.tsx
@@ -3,7 +3,12 @@ import {
   isAtomCommandInterrupted,
   squashAtomCommandFailure,
 } from "@t3tools/client-runtime/state/runtime";
-import { McpServerId, type EnvironmentId, type McpServer } from "@t3tools/contracts";
+import {
+  McpServerId,
+  type EnvironmentId,
+  type McpServer,
+  type ProviderAccessStatus,
+} from "@t3tools/contracts";
 import { SearchIcon } from "lucide-react";
 import { useState } from "react";
 import {
@@ -18,6 +23,8 @@ import { closePlugins, usePluginsDialogStore } from "../../pluginsDialogStore";
 import { environmentBotsAtom } from "../../state/bots";
 import { usePrimaryEnvironmentId } from "../../state/environments";
 import { environmentMcpServersAtom, mcpServerEnvironment } from "../../state/mcpServers";
+import { useEnvironmentQuery } from "../../state/query";
+import { serverEnvironment } from "../../state/server";
 import { useAtomCommand } from "../../state/use-atom-command";
 import { Button } from "../ui/button";
 import {
@@ -129,6 +136,9 @@ export function validateMcpServerDraft(draft: McpServerDraft): string | null {
 function PluginsDialogForEnvironment({ environmentId }: { readonly environmentId: EnvironmentId }) {
   const servers = useAtomValue(environmentMcpServersAtom(environmentId));
   const bots = useAtomValue(environmentBotsAtom(environmentId));
+  const subscriptionAuth = useEnvironmentQuery(
+    serverEnvironment.subscriptionAuth({ environmentId, input: {} }),
+  );
   const createServer = useAtomCommand(mcpServerEnvironment.create, { reportFailure: false });
   const updateServer = useAtomCommand(mcpServerEnvironment.update, { reportFailure: false });
   const deleteServer = useAtomCommand(mcpServerEnvironment.delete, { reportFailure: false });
@@ -152,6 +162,9 @@ function PluginsDialogForEnvironment({ environmentId }: { readonly environmentId
   const validationError = validateMcpServerDraft(draft);
   const selectedPluginServer = selectedPlugin
     ? findPluginServer(selectedPlugin, servers)
+    : undefined;
+  const selectedPluginAccess: ProviderAccessStatus | undefined = selectedPlugin
+    ? subscriptionAuth.data?.access.find((status) => status.pluginId === selectedPlugin.id)
     : undefined;
 
   const reportFailure = (
@@ -186,8 +199,13 @@ function PluginsDialogForEnvironment({ environmentId }: { readonly environmentId
   };
 
   const togglePlugin = async (plugin: PluginDirectoryDefinition, enabled: boolean) => {
-    if (!isInstallablePlugin(plugin)) return;
-    const plan = planPluginToggle(plugin, servers, enabled);
+    let plan;
+    if (enabled) {
+      if (!isInstallablePlugin(plugin)) return;
+      plan = planPluginToggle(plugin, servers, true);
+    } else {
+      plan = { action: "disable" as const, mcpServerId: pluginMcpServerId(plugin) };
+    }
     setPendingServerId(plan.mcpServerId);
     if (plan.action === "refresh-and-enable") {
       const updateResult = await updateServer({
@@ -288,6 +306,7 @@ function PluginsDialogForEnvironment({ environmentId }: { readonly environmentId
         <PluginDetails
           plugin={selectedPlugin}
           server={selectedPluginServer}
+          {...(selectedPluginAccess ? { accessStatus: selectedPluginAccess } : {})}
           activeDependentBotNames={pluginActiveDependentBotNames(selectedPluginServer, bots)}
           pending={pendingServerId === pluginMcpServerId(selectedPlugin)}
           onBack={() => setSelectedPlugin(null)}

--- a/apps/web/src/components/plugins/pluginPresentation.test.ts
+++ b/apps/web/src/components/plugins/pluginPresentation.test.ts
@@ -87,7 +87,7 @@ describe("plugin presentation", () => {
         ...catalog.filter((plugin) => ["Work", "Web"].includes(plugin.primaryCategory)),
         { ...pendingPlugin, primaryCategory: "Marketing", category: "Marketing" },
       ]),
-    ).toEqual(["All", "Featured", "Installed", "Work", "Web", "Marketing"]);
+    ).toEqual(["All", "Featured", "Installed", "Work", "Web", "Marketing", "Support"]);
     expect(
       buildPluginSections({ plugins: catalog, query: "", filter: "All" }).flatMap((section) =>
         section.plugins.map((plugin) => plugin.id),
@@ -111,6 +111,17 @@ describe("plugin presentation", () => {
         (plugin) => plugin.id,
       ),
     ).toEqual(["context", "apify", "exa", "firecrawl", "parallel-search", "tavily"]);
+    expect(
+      buildPluginSections({ plugins: catalog, query: "", filter: "Sales" })[0]?.plugins,
+    ).toEqual(expect.arrayContaining([expect.objectContaining({ id: "hubspot" })]));
+    expect(
+      buildPluginSections({ plugins: catalog, query: "", filter: "Support" })[0]?.plugins,
+    ).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({ id: "customer-io" }),
+        expect.objectContaining({ id: "linear" }),
+      ]),
+    );
   });
 
   it("groups the unfiltered directory into populated category sections", () => {

--- a/apps/web/src/components/plugins/pluginPresentation.ts
+++ b/apps/web/src/components/plugins/pluginPresentation.ts
@@ -7,16 +7,23 @@ import {
 
 export type PluginFilter = "All" | "Featured" | "Installed" | PluginCategory;
 
+function pluginMatchesCategory(
+  plugin: PluginDirectoryDefinition,
+  category: PluginCategory,
+): boolean {
+  return (
+    plugin.category === category ||
+    plugin.tags.some((tag) => tag.toLocaleLowerCase() === category.toLocaleLowerCase())
+  );
+}
+
 export function buildPluginFilters(
   plugins: readonly PluginDirectoryDefinition[],
 ): readonly PluginFilter[] {
-  const categories = new Set(plugins.map((plugin) => plugin.category));
-  return [
-    "All",
-    "Featured",
-    "Installed",
-    ...PLUGIN_CATEGORIES.filter((category) => categories.has(category)),
-  ];
+  const categories = PLUGIN_CATEGORIES.filter((category) =>
+    plugins.some((plugin) => pluginMatchesCategory(plugin, category)),
+  );
+  return ["All", "Featured", "Installed", ...categories];
 }
 
 export interface PluginSection {
@@ -69,7 +76,7 @@ export function buildPluginSections(input: {
       if (input.filter === "All") return true;
       if (input.filter === "Featured") return plugin.featured === true;
       if (input.filter === "Installed") return input.installedPluginIds?.has(plugin.id) ?? false;
-      return plugin.category === input.filter;
+      return pluginMatchesCategory(plugin, input.filter);
     });
   if (input.query.trim()) return [{ title: "Search results", plugins }];
   if (input.filter !== "All") return [{ title: input.filter, plugins }];

--- a/plugins/catalog.test.ts
+++ b/plugins/catalog.test.ts
@@ -64,13 +64,7 @@ const EXPECTED_DIRECTORY_IDS = [
   "zernio",
 ] as const;
 
-const EXPECTED_INSTALLABLE_IDS = [
-  "context",
-  "exa",
-  "executor",
-  "firecrawl",
-  "parallel-search",
-] as const;
+const EXPECTED_INSTALLABLE_IDS = ["context", "exa", "firecrawl", "parallel-search"] as const;
 
 function manifest(id: string) {
   return parsePluginManifestJson(
@@ -167,7 +161,7 @@ describe("plugin catalog loader", () => {
     ]);
   });
 
-  it("loads the complete directory with only the five verified recipes installable", () => {
+  it("loads the complete directory with only verified recipes installable", () => {
     const directory = loadDirectoryCatalog();
     const catalog = loadCatalog();
     expect(directory.map((plugin) => plugin.id).toSorted()).toEqual(EXPECTED_DIRECTORY_IDS);
@@ -207,11 +201,6 @@ describe("plugin catalog loader", () => {
       url: "https://mcp.exa.ai/mcp",
       authentication: "optional-oauth",
     });
-    expect(byId.get("executor")).toMatchObject({
-      kind: "mcp-stdio",
-      command: "bunx",
-      args: ["-y", "executor", "mcp"],
-    });
     expect(byId.get("firecrawl")).toMatchObject({
       kind: "mcp-url",
       url: "https://mcp.firecrawl.dev/v2/mcp-oauth",
@@ -228,13 +217,13 @@ describe("plugin catalog loader", () => {
     const pending = loadDirectoryCatalog().filter(
       (plugin) => !EXPECTED_INSTALLABLE_IDS.some((id) => id === plugin.id),
     );
-    expect(pending).toHaveLength(46);
+    expect(pending).toHaveLength(47);
     expect(pending.filter((plugin) => plugin.catalogStatus === "approval-pending")).toHaveLength(
       16,
     );
     expect(
       pending.filter((plugin) => plugin.catalogStatus === "verification-pending"),
-    ).toHaveLength(30);
+    ).toHaveLength(31);
     for (const plugin of pending) {
       expect(["approval-pending", "verification-pending"]).toContain(plugin.catalogStatus);
       expect(plugin.connection).toMatchObject({
@@ -274,7 +263,15 @@ describe("plugin catalog loader", () => {
     expect(byId.get("typefully")).toMatchObject({
       authentication: "oauth",
       requiredCredentials: [],
+      documentationUrl: "https://typefully.com/ai-agents",
       transport: { type: "url", url: "https://mcp.typefully.com/mcp" },
+      connection: { type: "verification-pending" },
+      catalogStatus: "verification-pending",
+    });
+    expect(byId.get("executor")).toMatchObject({
+      authentication: "oauth",
+      requiredCredentials: [],
+      transport: { type: "url", url: "https://executor.sh/mcp" },
       connection: { type: "verification-pending" },
       catalogStatus: "verification-pending",
     });

--- a/plugins/entries/executor/plugin.json
+++ b/plugins/entries/executor/plugin.json
@@ -2,27 +2,30 @@
   "schemaVersion": 1,
   "id": "executor",
   "name": "Executor",
-  "description": "Use the integrations configured in your local Executor account.",
+  "description": "Use the integrations configured in your Executor account.",
   "primaryCategory": "Work",
-  "tags": ["integrations", "automation", "local"],
-  "capabilities": ["use configured integrations", "run local integration tools"],
+  "tags": ["integrations", "automation", "hosted"],
+  "capabilities": ["use configured integrations", "run integration tools"],
   "publisher": { "name": "Useful Software Co.", "url": "https://executor.sh" },
   "maintainer": { "name": "Useful Software Co.", "url": "https://executor.sh" },
   "documentationUrl": "https://executor.sh/docs",
-  "sourceUrl": "https://github.com/UsefulSoftwareCo/executor",
-  "license": "MIT",
+  "sourceUrl": "https://executor.sh/docs",
+  "license": "Proprietary",
   "logo": {
     "provenance": {
       "sourceUrl": "https://executor.sh/favicon-192.png",
       "license": "Executor brand asset"
     }
   },
-  "platforms": ["macos", "windows", "linux"],
-  "transport": { "type": "stdio", "command": "bunx", "args": ["-y", "executor", "mcp"] },
-  "connection": { "type": "local" },
-  "authentication": "none",
+  "platforms": ["web", "desktop", "mobile"],
+  "transport": { "type": "url", "url": "https://executor.sh/mcp" },
+  "connection": {
+    "type": "verification-pending",
+    "blocker": "Hosted OAuth is documented, but the full add, use, disable, reconnect, and remove lifecycle still needs current verification."
+  },
+  "authentication": "oauth",
   "requiredCredentials": [],
-  "setup": ["Sign in to Executor locally, then start its MCP command."],
+  "setup": ["Wait for the hosted Executor connection lifecycle to pass."],
   "permissions": [
     {
       "id": "read-integrations",
@@ -70,5 +73,5 @@
     "refunds",
     "account-wide"
   ],
-  "catalogStatus": "available"
+  "catalogStatus": "verification-pending"
 }

--- a/plugins/lifecycle-matrix.test.ts
+++ b/plugins/lifecycle-matrix.test.ts
@@ -12,7 +12,7 @@ const EXPECTED_IDS =
   "ahrefs apify apollo asana atlassian attio canva cloudflare coda context customer-io datadog docusign dropbox exa executor figma firecrawl framer github help-scout hubspot intercom lemon-squeezy linear mobbin monday netlify notion paddle paper parallel-search paypal pipedrive posthog railway render salesforce semrush sentry sequenzy shopify slack stripe superside tavily typefully vercel webflow zendesk zernio".split(
     " ",
   );
-const INSTALLABLE_IDS = ["context", "exa", "executor", "firecrawl", "parallel-search"];
+const INSTALLABLE_IDS = ["context", "exa", "firecrawl", "parallel-search"];
 
 describe("milestone 13 plugin lifecycle matrix", () => {
   it("keeps verified plugins installable and every unverified plugin blocked", () => {
@@ -35,13 +35,13 @@ describe("milestone 13 plugin lifecycle matrix", () => {
     ]);
 
     const pending = directory.filter((plugin) => !INSTALLABLE_IDS.includes(plugin.id));
-    expect(pending).toHaveLength(46);
+    expect(pending).toHaveLength(47);
     expect(pending.filter((plugin) => plugin.catalogStatus === "approval-pending")).toHaveLength(
       16,
     );
     expect(
       pending.filter((plugin) => plugin.catalogStatus === "verification-pending"),
-    ).toHaveLength(30);
+    ).toHaveLength(31);
     for (const plugin of pending) {
       expect(["approval-pending", "verification-pending"]).toContain(plugin.catalogStatus);
       expect(plugin.connection).toMatchObject({
@@ -54,6 +54,12 @@ describe("milestone 13 plugin lifecycle matrix", () => {
     expect(byId.get("typefully")).toMatchObject({
       authentication: "oauth",
       requiredCredentials: [],
+      documentationUrl: "https://typefully.com/ai-agents",
+      connection: { type: "verification-pending" },
+    });
+    expect(byId.get("executor")).toMatchObject({
+      transport: { type: "url", url: "https://executor.sh/mcp" },
+      authentication: "oauth",
       connection: { type: "verification-pending" },
     });
     expect(byId.get("github")).toMatchObject({


### PR DESCRIPTION
## Problem

The plugin directory treated category tags as invisible, showed stale connector health, and blocked disable after an installed plugin moved back to pending verification. Executor was also listed as a verified local integration even though its current hosted OAuth lifecycle has not passed.

## Fix

- Include tag-matched plugins in directory category filters.
- Show persisted connector health and repair guidance in plugin details.
- Keep disable available for installed plugins that are no longer installable.
- Mark Executor's hosted OAuth connection as verification pending.

## Verification

- `vp test run plugins/catalog.test.ts plugins/lifecycle-matrix.test.ts apps/web/src/components/plugins/PluginsDialog.test.tsx apps/web/src/components/plugins/pluginPresentation.test.ts apps/web/src/components/plugins/pluginRegistry.test.ts` (34 passed)
- `bun run plugins:check`
- `vp run --filter @t3tools/web typecheck`
- Targeted `vp lint`
- Targeted `vp fmt --check`
- `git diff --check origin/main...HEAD`

## Screenshots

![Plugin directory](https://github.com/user-attachments/assets/db102476-3b11-41f1-8e52-52d67c24cf62)

![Plugin details](https://github.com/user-attachments/assets/4c869201-a25a-4b9d-862f-9702c1c0251b)

Model: GPT-5.6 Sol
Harness: Codex harness in T3 Code
