### PR TITLE
fix(server): redact screenshot tool results

### DIFF
--- a/apps/server/src/provider/AkeruToolRuntime.test.ts
+++ b/apps/server/src/provider/AkeruToolRuntime.test.ts
@@ -3,11 +3,22 @@ import * as NodeFS from "node:fs";
 import * as NodeOS from "node:os";
 import * as NodePath from "node:path";
 
-import { LocalFilesystem, LocalSandbox, Workspace } from "@mastra/core/workspace";
+import {
+  createWorkspaceTools,
+  LocalFilesystem,
+  LocalSandbox,
+  Workspace,
+} from "@mastra/core/workspace";
+import { PNG } from "pngjs";
 import { afterEach, describe, expect, it, vi } from "vite-plus/test";
 import { BotId } from "@t3tools/contracts";
 
 import { createAkeruToolRuntime } from "./AkeruToolRuntime.ts";
+
+vi.mock("@mastra/core/workspace", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("@mastra/core/workspace")>();
+  return { ...actual, createWorkspaceTools: vi.fn(actual.createWorkspaceTools) };
+});
 
 const directories = new Set<string>();
 
@@ -40,6 +51,41 @@ describe("AkeruToolRuntime", () => {
       "Read",
       "AwaitShell",
     ]);
+  });
+
+  it("redacts screenshot frames before returning tool results", async () => {
+    const png = new PNG({ width: 1, height: 1 });
+    png.data.set([255, 255, 255, 255]);
+    const bot = workspace("screenshot");
+    Object.defineProperty(bot.sandbox, "computer", { value: {} });
+    vi.mocked(createWorkspaceTools).mockResolvedValueOnce({
+      mastra_workspace_computer_screenshot: {
+        execute: async () => ({
+          __workspaceMedia: true,
+          text: "Screenshot captured.",
+          mediaType: "image/png",
+          data: PNG.sync.write(png).toString("base64"),
+        }),
+      },
+    });
+    const runtime = createAkeruToolRuntime();
+    runtime.registerSession("thread-screenshot", {
+      runtimeMode: "full-access",
+      workspaceType: "cloud",
+      workspace: bot,
+    });
+
+    const result = (await runtime.execute({
+      threadId: "thread-screenshot",
+      toolId: "Screenshot",
+      toolCallId: "tool-screenshot",
+      input: {},
+      approvalMode: "require-grant",
+    })) as { readonly data: string; readonly text: string };
+    const frame = PNG.sync.read(Buffer.from(result.data, "base64"));
+
+    expect(result.text).toBe("Screenshot captured.");
+    expect([...frame.data]).toEqual([0, 0, 0, 255]);
   });
 
   it("exposes registered memory handlers and protects sensitive writes", async () => {

--- a/apps/server/src/provider/AkeruToolRuntime.ts
+++ b/apps/server/src/provider/AkeruToolRuntime.ts
@@ -14,6 +14,7 @@ import {
 import * as Schema from "effect/Schema";
 
 import type { UserActionIncidentInput } from "../bot-inbox/userActionIncidents.ts";
+import { redactComputerScreenshot } from "../mcp/PreviewSnapshotRedaction.ts";
 import {
   AkeruMemoryToolInputSchemas,
   type AkeruMemoryToolHandler,
@@ -319,7 +320,7 @@ export function createAkeruToolRuntime(options?: AkeruToolRuntimeOptions): Akeru
         input.toolId === "AwaitShell" || input.toolId === "AwaitExternalShell"
           ? { pid: requiredString(decoded, "handleId"), wait: true }
           : decoded;
-      return backend.execute(backendInput, {
+      const result = await backend.execute(backendInput, {
         workspace,
         requestContext: new RequestContext(),
         observe: {
@@ -327,6 +328,21 @@ export function createAkeruToolRuntime(options?: AkeruToolRuntimeOptions): Akeru
           log: () => undefined,
         },
       });
+      if (input.toolId !== "Screenshot") return result;
+
+      const mediaType = field(result, "mediaType");
+      const data = field(result, "data");
+      if (mediaType !== "image/png" || typeof data !== "string") {
+        throw new Error("Screenshot result is invalid.");
+      }
+      const redacted = redactComputerScreenshot({
+        mediaType,
+        data: Buffer.from(data, "base64"),
+      });
+      return {
+        ...(result as Record<string, unknown>),
+        data: Buffer.from(redacted.data).toString("base64"),
+      };
     },
   };
 }


### PR DESCRIPTION
The Akeru tool runtime returned Mastra screenshot media before applying the computer-frame redaction policy. Raw frame pixels could reach model context and persisted tool results.

The fix applies redactComputerScreenshot at the shared runtime result boundary. It preserves the Mastra media wrapper and text while replacing the PNG bytes with the redacted frame. A focused test proves white source pixels cannot escape and the safe media result remains valid.

- [LEO-242](https://linear.app/opencoredev/issue/LEO-242/redact-screenshots-and-computer-use-frames)
- [LEO-294](https://linear.app/opencoredev/issue/LEO-294/own-launch-stacks-and-shared-file-integration)

Tests:
- vp test run apps/server/src/provider/AkeruToolRuntime.test.ts apps/server/src/mcp/PreviewSnapshotRedaction.test.ts
- vp run --filter akeru-bot typecheck
- targeted lint and format checks

Model: gpt-5.6-sol
Harness: Codex in T3 Code