### PR TITLE
feat(server): add durable remote sandboxes

### DIFF
--- a/apps/server/package.json
+++ b/apps/server/package.json
@@ -24,6 +24,7 @@
   "dependencies": {
     "@ai-sdk/anthropic": "3.0.113",
     "@anthropic-ai/claude-agent-sdk": "^0.3.170",
+    "@daytona/sdk": "^0.207.0",
     "@effect/platform-bun": "catalog:",
     "@effect/platform-node": "catalog:",
     "@effect/platform-node-shared": "catalog:",
@@ -35,6 +36,9 @@
     "@mastra/memory": "1.28.0",
     "@opencode-ai/sdk": "^1.3.15",
     "@pierre/diffs": "catalog:",
+    "@upstash/box": "0.5.3",
+    "@vercel/sandbox": "^2.5.0",
+    "e2b": "^2.32.0",
     "effect": "catalog:",
     "msgpackr-extract": "3.0.4",
     "node-pty": "^1.1.0",

--- a/apps/server/src/orchestration/Layers/BotPersistence.test.ts
+++ b/apps/server/src/orchestration/Layers/BotPersistence.test.ts
@@ -518,7 +518,7 @@ it.layer(TestLayer)("bot persistence", (it) => {
       const engine = yield* OrchestrationEngineService;
       const snapshots = yield* ProjectionSnapshotQuery;
 
-      for (const sandbox of [null, "local", "akeru-cloud"] as const) {
+      for (const sandbox of [null, "local", "vercel"] as const) {
         yield* engine.dispatch({
           type: "bot.create",
           commandId: CommandId.make(`cmd-bot-default-${sandbox ?? "null"}`),
@@ -544,7 +544,7 @@ it.layer(TestLayer)("bot persistence", (it) => {
         "approval-required",
       );
       assert.equal(
-        bots.find((bot) => bot.id === BotId.make("bot-default-akeru-cloud"))?.runtimeMode,
+        bots.find((bot) => bot.id === BotId.make("bot-default-vercel"))?.runtimeMode,
         "full-access",
       );
     }),

--- a/apps/server/src/provider/AkeruSessionResources.test.ts
+++ b/apps/server/src/provider/AkeruSessionResources.test.ts
@@ -8,6 +8,7 @@ import { McpServerId } from "@t3tools/contracts";
 import { afterEach, describe, expect, it, vi } from "vite-plus/test";
 
 import { AkeruSessionResources } from "./AkeruSessionResources.ts";
+import type { AkeruBotWorkspace } from "./botWorkspace.ts";
 
 const directories = new Set<string>();
 
@@ -22,6 +23,18 @@ function workspace() {
     filesystem: new LocalFilesystem({ basePath: process.cwd() }),
     sandbox: new LocalSandbox({ workingDirectory: process.cwd() }),
   });
+}
+
+function localBotWorkspace(value: Workspace): AkeruBotWorkspace {
+  return {
+    id: value.id,
+    provider: "local",
+    workspace: value,
+    inspect: async () => "running",
+    wake: () => value.init(),
+    sleep: () => value.stop(),
+    destroy: () => value.destroy(),
+  };
 }
 
 function browser(overrides?: { reconnect?: () => Promise<void>; close?: () => Promise<void> }) {
@@ -61,7 +74,7 @@ describe("AkeruSessionResources", () => {
 
   it("shares one workspace and browser across thread sessions", async () => {
     const remote = workspace();
-    const makeRemoteWorkspace = vi.fn(async () => remote);
+    const makeRemoteWorkspace = vi.fn(async () => localBotWorkspace(remote));
     const sharedBrowser = browser();
     const makeBotBrowser = vi.fn(() => sharedBrowser);
     const resources = new AkeruSessionResources({
@@ -169,7 +182,7 @@ describe("AkeruSessionResources", () => {
       .mockReturnValueOnce(replacementBrowser);
     const resources = new AkeruSessionResources({
       stateDir: stateDir(),
-      makeRemoteWorkspace: async () => workspace(),
+      makeRemoteWorkspace: async () => localBotWorkspace(workspace()),
       makeBotBrowser,
       toMcpServerConfigs: () => ({}),
     });
@@ -193,8 +206,8 @@ describe("AkeruSessionResources", () => {
     const replacement = workspace();
     const makeRemoteWorkspace = vi
       .fn()
-      .mockResolvedValueOnce(failed)
-      .mockResolvedValueOnce(replacement);
+      .mockResolvedValueOnce(localBotWorkspace(failed))
+      .mockResolvedValueOnce(localBotWorkspace(replacement));
     const staleBrowser = browser();
     const replacementBrowser = browser();
     const makeBotBrowser = vi
@@ -230,7 +243,7 @@ describe("AkeruSessionResources", () => {
       .mockReturnValueOnce(replacementBrowser);
     const resources = new AkeruSessionResources({
       stateDir: stateDir(),
-      makeRemoteWorkspace: async () => workspace(),
+      makeRemoteWorkspace: async () => localBotWorkspace(workspace()),
       makeBotBrowser,
       toMcpServerConfigs: () => ({}),
     });
@@ -257,7 +270,7 @@ describe("AkeruSessionResources", () => {
     const sharedBrowser = browser();
     const resources = new AkeruSessionResources({
       stateDir: stateDir(),
-      makeRemoteWorkspace: async () => remote,
+      makeRemoteWorkspace: async () => localBotWorkspace(remote),
       makeBotBrowser: () => sharedBrowser,
       toMcpServerConfigs: () => ({}),
     });
@@ -280,7 +293,7 @@ describe("AkeruSessionResources", () => {
     const sharedBrowser = browser();
     const resources = new AkeruSessionResources({
       stateDir: stateDir(),
-      makeRemoteWorkspace: async () => remote,
+      makeRemoteWorkspace: async () => localBotWorkspace(remote),
       makeBotBrowser: () => sharedBrowser,
       toMcpServerConfigs: () => ({}),
     });
@@ -314,13 +327,62 @@ describe("AkeruSessionResources", () => {
       userComputerCwd: project,
       mcpServers: [],
     });
-    await acquired.workspace.filesystem?.writeFile("bot.txt", "bot");
-    await acquired.userComputerWorkspace?.filesystem?.writeFile("user.txt", "user");
+    await acquired.botWorkspace.filesystem?.writeFile("bot.txt", "bot");
+    await acquired.workspace.filesystem?.writeFile("user.txt", "user");
+    expect(resources.getWorkspace("local-thread")).toBe(acquired.workspace);
     expect(
       NodeFS.existsSync(NodePath.join(directory, "bot-workspaces", "akeru-bot-one", "bot.txt")),
     ).toBe(true);
     expect(NodeFS.existsSync(NodePath.join(project, "user.txt"))).toBe(true);
     expect(NodeFS.existsSync(NodePath.join(project, "bot.txt"))).toBe(false);
+    await resources.shutdown();
+  });
+
+  it("does not create or attach a browser for remote workspaces", async () => {
+    const remote: AkeruBotWorkspace = {
+      id: "akeru-shared",
+      provider: "vercel",
+      providerId: "vercel-native-id",
+      workspace: workspace(),
+      inspect: async () => "running",
+      wake: vi.fn(async () => undefined),
+      sleep: vi.fn(async () => undefined),
+      destroy: vi.fn(async () => undefined),
+    };
+    const manager = {
+      init: vi.fn(async () => undefined),
+      disconnect: vi.fn(async () => undefined),
+      getTools: vi.fn(() => ({ exa_search: {} })),
+    };
+    const makeBotBrowser = vi.fn(() => browser());
+    const toMcpServerConfigs = vi.fn(() => ({}));
+    const resources = new AkeruSessionResources({
+      stateDir: stateDir(),
+      makeRemoteWorkspace: async () => remote,
+      makeBotBrowser,
+      makeMcpManager: vi.fn(() => manager as never),
+      toMcpServerConfigs,
+    });
+
+    await resources.acquire({
+      ...remoteInput,
+      threadId: "remote-mcp",
+      mcpServers: [
+        {
+          id: McpServerId.make("builtin-exa"),
+          name: "Exa",
+          transport: "url",
+          url: "https://mcp.exa.ai/mcp",
+          enabled: true,
+          createdAt: "2026-01-01T00:00:00.000Z",
+          updatedAt: "2026-01-01T00:00:00.000Z",
+        },
+      ],
+    });
+
+    expect(makeBotBrowser).not.toHaveBeenCalled();
+    expect(toMcpServerConfigs).toHaveBeenCalledWith(expect.any(Array), undefined);
+    expect(resources.getConnectorTools("remote-mcp")).toEqual({ exa_search: {} });
     await resources.shutdown();
   });
 });

--- a/apps/server/src/provider/AkeruSessionResources.test.ts
+++ b/apps/server/src/provider/AkeruSessionResources.test.ts
@@ -353,6 +353,7 @@ describe("AkeruSessionResources", () => {
       init: vi.fn(async () => undefined),
       disconnect: vi.fn(async () => undefined),
       getTools: vi.fn(() => ({ exa_search: {} })),
+      getServerStatuses: vi.fn(() => []),
     };
     const makeBotBrowser = vi.fn(() => browser());
     const toMcpServerConfigs = vi.fn(() => ({}));

--- a/apps/server/src/provider/AkeruSessionResources.test.ts
+++ b/apps/server/src/provider/AkeruSessionResources.test.ts
@@ -8,7 +8,11 @@ import { McpServerId } from "@t3tools/contracts";
 import { afterEach, describe, expect, it, vi } from "vite-plus/test";
 
 import { AkeruSessionResources } from "./AkeruSessionResources.ts";
-import type { AkeruBotWorkspace } from "./botWorkspace.ts";
+import {
+  type AkeruBotWorkspace,
+  type AkeruRemoteSession,
+  createRemoteBotWorkspace,
+} from "./botWorkspace.ts";
 
 const directories = new Set<string>();
 
@@ -286,7 +290,7 @@ describe("AkeruSessionResources", () => {
     await resources.shutdown();
   });
 
-  it("destroys pooled workspaces and browsers during shutdown", async () => {
+  it("stops pooled workspaces and browsers during shutdown", async () => {
     const remote = workspace();
     const stop = vi.spyOn(remote, "stop");
     const destroy = vi.spyOn(remote, "destroy");
@@ -302,11 +306,54 @@ describe("AkeruSessionResources", () => {
     expect(stop).toHaveBeenCalledOnce();
 
     await resources.shutdown();
-    expect(destroy).toHaveBeenCalledOnce();
+    expect(destroy).not.toHaveBeenCalled();
     expect(sharedBrowser.close).toHaveBeenCalledOnce();
     await expect(resources.acquire({ ...remoteInput, threadId: "late" })).rejects.toThrow(
       "shutting down",
     );
+  });
+
+  it("reattaches a durable remote workspace after shutdown", async () => {
+    const directory = stateDir();
+    const sleep = vi.fn(async () => undefined);
+    const destroy = vi.fn(async () => undefined);
+    const openSession = vi.fn(
+      async (providerId?: string): Promise<AkeruRemoteSession> => ({
+        providerId: providerId ?? "provider-1",
+        inspect: async () => "running",
+        run: async () => ({ exitCode: 0, stdout: "", stderr: "" }),
+        wake: async () => undefined,
+        sleep,
+        destroy,
+      }),
+    );
+    const options = {
+      stateDir: directory,
+      makeRemoteWorkspace: (input: Parameters<typeof createRemoteBotWorkspace>[0]) =>
+        createRemoteBotWorkspace({ ...input, openSession }),
+      toMcpServerConfigs: () => ({}),
+    };
+
+    const first = new AkeruSessionResources(options);
+    await first.acquire({ ...remoteInput, threadId: "before-restart" });
+    await first.shutdown();
+
+    expect(sleep).toHaveBeenCalledOnce();
+    expect(destroy).not.toHaveBeenCalled();
+    const identityFile = NodePath.join(
+      directory,
+      "bot-workspaces",
+      remoteInput.workspaceId,
+      "provider.json",
+    );
+    expect(NodeFS.existsSync(identityFile)).toBe(true);
+
+    const second = new AkeruSessionResources(options);
+    await second.acquire({ ...remoteInput, threadId: "after-restart" });
+    expect(openSession).toHaveBeenNthCalledWith(2, "provider-1");
+    await second.release("after-restart", { destroy: true });
+    expect(destroy).toHaveBeenCalledOnce();
+    expect(NodeFS.existsSync(identityFile)).toBe(false);
   });
 
   it("keeps the bot workspace separate from the user computer workspace", async () => {

--- a/apps/server/src/provider/AkeruSessionResources.ts
+++ b/apps/server/src/provider/AkeruSessionResources.ts
@@ -17,6 +17,7 @@ import {
   type CreateBotBrowserInput,
 } from "./botBrowser.ts";
 import {
+  type AkeruBotWorkspace,
   createBotWorkspace,
   isRemoteBotSandbox,
   type CreateRemoteBotWorkspaceInput,
@@ -35,14 +36,15 @@ export interface AkeruSessionResourceInput {
 
 export interface AkeruSessionResourceView {
   readonly workspace: Workspace;
-  readonly userComputerWorkspace?: Workspace;
-  readonly workspaceType: "local" | "cloud";
+  readonly botWorkspace: Workspace;
 }
 
 export interface AkeruSessionResourcesOptions {
   readonly stateDir: string;
   readonly makeMcpManager?: typeof createMcpManager;
-  readonly makeRemoteWorkspace?: (input: CreateRemoteBotWorkspaceInput) => Promise<Workspace>;
+  readonly makeRemoteWorkspace?: (
+    input: CreateRemoteBotWorkspaceInput,
+  ) => Promise<AkeruBotWorkspace | Workspace>;
   readonly makeBotBrowser?: (input: CreateBotBrowserInput) => BotBrowser;
   readonly onMcpServerConnectionFailure?: (serverId: McpServer["id"]) => void;
   readonly toMcpServerConfigs: (
@@ -100,6 +102,12 @@ export class AkeruSessionResources {
           const workspace = await createBotWorkspace({
             threadId: input.resourceScope,
             workspaceId: input.workspaceId,
+            identityFile: NodePath.join(
+              this.options.stateDir,
+              "bot-workspaces",
+              input.workspaceId,
+              "provider.json",
+            ),
             ...(isRemoteBotSandbox(input.botSandbox)
               ? { sandbox: input.botSandbox }
               : {
@@ -120,7 +128,8 @@ export class AkeruSessionResources {
       );
       this.workspaceLeases.set(key, workspaceLease);
 
-      const userComputerCwd = input.userComputerCwd;
+      const remote = isRemoteBotSandbox(input.botSandbox);
+      const userComputerCwd = remote ? undefined : input.userComputerCwd;
       const userComputerWorkspaceLease = userComputerCwd
         ? await this.workspacePool.acquire(`user-computer:${key}:${userComputerCwd}`, async () => {
             const workspace = await createBotWorkspace({
@@ -137,39 +146,42 @@ export class AkeruSessionResources {
         this.userComputerWorkspaceLeases.set(key, userComputerWorkspaceLease);
       }
 
-      const existingBrowser = this.resourceBrowsers.get(input.workspaceResourceKey);
-      const browser =
-        existingBrowser ??
-        (this.options.makeBotBrowser ?? createBotBrowser)({
-          threadId: input.resourceScope,
-          workspace: workspaceLease.workspace,
-          cacheDir: NodePath.join(this.options.stateDir, "bot-browser-runtime"),
-        });
+      let browser: BotBrowser | undefined;
+      if (workspaceLease.workspace.provider === "local") {
+        const existingBrowser = this.resourceBrowsers.get(input.workspaceResourceKey);
+        browser =
+          existingBrowser ??
+          (this.options.makeBotBrowser ?? createBotBrowser)({
+            threadId: input.resourceScope,
+            workspace: workspaceLease.workspace.workspace,
+            cacheDir: NodePath.join(this.options.stateDir, "bot-browser-runtime"),
+          });
 
-      this.resourceBrowsers.set(input.workspaceResourceKey, browser);
-      this.threadBrowsers.set(key, browser);
-      this.browserResourceKeys.set(key, input.workspaceResourceKey);
-      this.browserReferences.set(
-        input.workspaceResourceKey,
-        (this.browserReferences.get(input.workspaceResourceKey) ?? 0) + 1,
-      );
+        this.resourceBrowsers.set(input.workspaceResourceKey, browser);
+        this.threadBrowsers.set(key, browser);
+        this.browserResourceKeys.set(key, input.workspaceResourceKey);
+        this.browserReferences.set(
+          input.workspaceResourceKey,
+          (this.browserReferences.get(input.workspaceResourceKey) ?? 0) + 1,
+        );
 
-      let reconnect = this.browserReconnects.get(input.workspaceResourceKey);
-      if (existingBrowser && workspaceLease.wokeFromSleep && !reconnect) {
-        reconnect = browser.reconnect().finally(() => {
-          this.browserReconnects.delete(input.workspaceResourceKey);
-        });
-        this.browserReconnects.set(input.workspaceResourceKey, reconnect);
-      }
-      try {
-        await reconnect;
-      } catch (cause) {
-        await this.invalidateBrowser(input.workspaceResourceKey, browser);
-        throw cause;
+        let reconnect = this.browserReconnects.get(input.workspaceResourceKey);
+        if (existingBrowser && workspaceLease.wokeFromSleep && !reconnect) {
+          reconnect = browser.reconnect().finally(() => {
+            this.browserReconnects.delete(input.workspaceResourceKey);
+          });
+          this.browserReconnects.set(input.workspaceResourceKey, reconnect);
+        }
+        try {
+          await reconnect;
+        } catch (cause) {
+          await this.invalidateBrowser(input.workspaceResourceKey, browser);
+          throw cause;
+        }
       }
 
       if (input.mcpServers.length > 0) {
-        const attachment = await browser.attachment();
+        const attachment = await browser?.attachment();
         const manager = (this.options.makeMcpManager ?? createMcpManager)(
           NodePath.join(this.options.stateDir, "bot-mcp-runtime"),
           ".akeru-runtime",
@@ -193,11 +205,9 @@ export class AkeruSessionResources {
       }
 
       return {
-        workspace: workspaceLease.workspace,
-        ...(userComputerWorkspaceLease
-          ? { userComputerWorkspace: userComputerWorkspaceLease.workspace }
-          : {}),
-        workspaceType: isRemoteBotSandbox(input.botSandbox) ? "cloud" : "local",
+        workspace:
+          userComputerWorkspaceLease?.workspace.workspace ?? workspaceLease.workspace.workspace,
+        botWorkspace: workspaceLease.workspace.workspace,
       };
     } catch (cause) {
       await this.releaseOnce(key, { destroy: true }).catch(() => undefined);
@@ -212,12 +222,11 @@ export class AkeruSessionResources {
     };
   }
 
-  getMcpManager(threadId: string): McpManager | undefined {
-    return this.mcpManagers.get(threadId);
-  }
-
   getWorkspace(threadId: string): Workspace | undefined {
-    return this.workspaceLeases.get(threadId)?.workspace;
+    return (
+      this.userComputerWorkspaceLeases.get(threadId)?.workspace.workspace ??
+      this.workspaceLeases.get(threadId)?.workspace.workspace
+    );
   }
 
   async release(threadId: string, options?: { readonly destroy?: boolean }): Promise<void> {

--- a/apps/server/src/provider/AkeruSessionResources.ts
+++ b/apps/server/src/provider/AkeruSessionResources.ts
@@ -303,14 +303,11 @@ export class AkeruSessionResources {
       ...this.mcpManagers.keys(),
       ...this.threadBrowsers.keys(),
     ]);
-    await Promise.allSettled(
-      [...threadIds].map((threadId) => this.release(threadId, { destroy: true })),
-    );
+    await Promise.allSettled([...threadIds].map((threadId) => this.release(threadId)));
     await Promise.allSettled([...this.resourceBrowsers.values()].map((browser) => browser.close()));
     this.resourceBrowsers.clear();
     this.browserReferences.clear();
     this.browserDestroyRequests.clear();
     this.browserReconnects.clear();
-    await this.workspacePool.destroyAll();
   }
 }

--- a/apps/server/src/provider/Layers/AgentController.test.ts
+++ b/apps/server/src/provider/Layers/AgentController.test.ts
@@ -1214,9 +1214,16 @@ describe("AgentControllerLive", () => {
       sandbox: new LocalSandbox({ workingDirectory: process.cwd() }),
     });
     const makeRemoteWorkspace = vi.fn(async () => remote);
+    const makeBotBrowser = vi.fn(() => ({
+      tools: {},
+      attachment: vi.fn(async () => undefined),
+      reconnect: vi.fn(async () => undefined),
+      close: vi.fn(async () => undefined),
+    }));
     const layer = makeAgentControllerLive({
       makeMastraHarness: mastra.factory,
       makeRemoteWorkspace,
+      makeBotBrowser: makeBotBrowser as never,
     }).pipe(
       Layer.provide(
         Layer.merge(
@@ -1241,17 +1248,21 @@ describe("AgentControllerLive", () => {
       });
 
       expect(makeRemoteWorkspace).toHaveBeenCalledOnce();
-      expect(makeRemoteWorkspace).toHaveBeenCalledWith({
-        threadId: `thread-${codexThreadId}`,
-        sandbox: "upstash",
-        workspaceId: expect.stringMatching(/^akeru-[a-f0-9]{24}$/),
-      });
+      expect(makeRemoteWorkspace).toHaveBeenCalledWith(
+        expect.objectContaining({
+          threadId: `thread-${codexThreadId}`,
+          sandbox: "upstash",
+          workspaceId: expect.stringMatching(/^akeru-[a-f0-9]{24}$/),
+          identityFile: expect.stringMatching(/provider\.json$/),
+        }),
+      );
       expect(mastra.createSession.mock.calls[0]?.[0]).toMatchObject({ workspace: remote });
+      expect(makeBotBrowser).not.toHaveBeenCalled();
       yield* controller.stopSession({ threadId: codexThreadId });
     }).pipe(Effect.provide(layer), Effect.orDie);
   });
 
-  it.effect("destroys obsolete and final pooled session resources", () => {
+  it.effect("destroys obsolete and final pooled remote workspaces", () => {
     const bridge = makeBridge();
     const mastra = makeMastraHarness();
     const firstWorkspace = new Workspace({
@@ -1268,26 +1279,9 @@ describe("AgentControllerLive", () => {
       .fn()
       .mockResolvedValueOnce(firstWorkspace)
       .mockResolvedValueOnce(secondWorkspace);
-    const firstBrowser = {
-      tools: {},
-      attachment: vi.fn(async () => undefined),
-      reconnect: vi.fn(async () => undefined),
-      close: vi.fn(async () => undefined),
-    };
-    const secondBrowser = {
-      tools: {},
-      attachment: vi.fn(async () => undefined),
-      reconnect: vi.fn(async () => undefined),
-      close: vi.fn(async () => undefined),
-    };
-    const makeBotBrowser = vi
-      .fn()
-      .mockReturnValueOnce(firstBrowser)
-      .mockReturnValueOnce(secondBrowser);
     const layer = makeAgentControllerLive({
       makeMastraHarness: mastra.factory,
       makeRemoteWorkspace,
-      makeBotBrowser: makeBotBrowser as never,
     }).pipe(
       Layer.provide(
         Layer.merge(
@@ -1315,11 +1309,9 @@ describe("AgentControllerLive", () => {
         yield* controller.startSession(codexThreadId, { ...input, botSandbox: "upstash" });
         yield* controller.startSession(codexThreadId, { ...input, botSandbox: "vercel" });
         expect(firstDestroy).toHaveBeenCalledOnce();
-        expect(firstBrowser.close).toHaveBeenCalledOnce();
       }).pipe(Effect.provide(layer), Effect.orDie);
 
       expect(secondDestroy).toHaveBeenCalledOnce();
-      expect(secondBrowser.close).toHaveBeenCalledOnce();
     });
   });
 
@@ -1360,7 +1352,7 @@ describe("AgentControllerLive", () => {
     });
   });
 
-  it.effect("keeps the same workspace when only session input changes", () => {
+  it.effect("keeps the same remote workspace when only cwd changes", () => {
     const bridge = makeBridge();
     const mastra = makeMastraHarness();
     const remote = new Workspace({
@@ -1369,16 +1361,11 @@ describe("AgentControllerLive", () => {
     });
     const destroy = vi.spyOn(remote, "destroy");
     const makeRemoteWorkspace = vi.fn(async () => remote);
-    const sharedBrowser = {
-      tools: {},
-      attachment: vi.fn(async () => undefined),
-      reconnect: vi.fn(async () => undefined),
-      close: vi.fn(async () => undefined),
-    };
+    const makeBotBrowser = vi.fn();
     const layer = makeAgentControllerLive({
       makeMastraHarness: mastra.factory,
       makeRemoteWorkspace,
-      makeBotBrowser: (() => sharedBrowser) as never,
+      makeBotBrowser: makeBotBrowser as never,
     }).pipe(
       Layer.provide(
         Layer.merge(
@@ -1406,7 +1393,7 @@ describe("AgentControllerLive", () => {
 
       expect(makeRemoteWorkspace).toHaveBeenCalledOnce();
       expect(destroy).not.toHaveBeenCalled();
-      expect(sharedBrowser.reconnect).toHaveBeenCalledOnce();
+      expect(makeBotBrowser).not.toHaveBeenCalled();
     }).pipe(Effect.provide(layer), Effect.orDie);
   });
 

--- a/apps/server/src/provider/Layers/AgentController.test.ts
+++ b/apps/server/src/provider/Layers/AgentController.test.ts
@@ -1262,7 +1262,7 @@ describe("AgentControllerLive", () => {
     }).pipe(Effect.provide(layer), Effect.orDie);
   });
 
-  it.effect("destroys obsolete and final pooled remote workspaces", () => {
+  it.effect("destroys obsolete and stops final pooled remote workspaces", () => {
     const bridge = makeBridge();
     const mastra = makeMastraHarness();
     const firstWorkspace = new Workspace({
@@ -1274,6 +1274,7 @@ describe("AgentControllerLive", () => {
       sandbox: new LocalSandbox({ workingDirectory: process.cwd() }),
     });
     const firstDestroy = vi.spyOn(firstWorkspace, "destroy");
+    const secondStop = vi.spyOn(secondWorkspace, "stop");
     const secondDestroy = vi.spyOn(secondWorkspace, "destroy");
     const makeRemoteWorkspace = vi
       .fn()
@@ -1311,7 +1312,8 @@ describe("AgentControllerLive", () => {
         expect(firstDestroy).toHaveBeenCalledOnce();
       }).pipe(Effect.provide(layer), Effect.orDie);
 
-      expect(secondDestroy).toHaveBeenCalledOnce();
+      expect(secondStop).toHaveBeenCalledOnce();
+      expect(secondDestroy).not.toHaveBeenCalled();
     });
   });
 

--- a/apps/server/src/provider/Layers/AgentController.ts
+++ b/apps/server/src/provider/Layers/AgentController.ts
@@ -69,7 +69,7 @@ import {
 } from "../AkeruToolRuntime.ts";
 import type { BotBrowser, BotBrowserAttachment, CreateBotBrowserInput } from "../botBrowser.ts";
 import { AkeruSessionResources } from "../AkeruSessionResources.ts";
-import type { CreateRemoteBotWorkspaceInput } from "../botWorkspace.ts";
+import type { AkeruBotWorkspace, CreateRemoteBotWorkspaceInput } from "../botWorkspace.ts";
 import {
   botRuntimeResourceScope,
   botWorkspaceIdentity,
@@ -129,7 +129,9 @@ interface ActiveSession {
 export interface AgentControllerLiveOptions {
   readonly makeMastraHarness?: (options: AkeruMastraHarnessOptions) => Promise<AkeruMastraHarness>;
   readonly makeMcpManager?: typeof createMcpManager;
-  readonly makeRemoteWorkspace?: (input: CreateRemoteBotWorkspaceInput) => Promise<Workspace>;
+  readonly makeRemoteWorkspace?: (
+    input: CreateRemoteBotWorkspaceInput,
+  ) => Promise<AkeruBotWorkspace | Workspace>;
   readonly makeBotBrowser?: (input: CreateBotBrowserInput) => BotBrowser;
   readonly entityMemoryRepository?: EntityMemoryRepositoryShape;
   readonly memoryCandidateRepository?: MemoryCandidateRepositoryShape;
@@ -873,15 +875,17 @@ const make = (options?: AgentControllerLiveOptions) =>
         );
       }
       const registeredMemoryHandlers = memoryHandlers(input.memoryAccess);
+      const workspaceType: "cloud" | "local" =
+        input.botSandbox && input.botSandbox !== "local" ? "cloud" : "local";
+      const userComputerWorkspace =
+        workspaceType === "local" && input.cwd ? resources.workspace : undefined;
       const toolSession: AkeruToolSession = {
         ...(input.botId ? { botId: input.botId } : {}),
         ...(input.botName ? { botName: input.botName } : {}),
         runtimeMode: input.runtimeMode,
-        workspaceType: resources.workspaceType,
-        workspace: resources.workspace,
-        ...(resources.userComputerWorkspace
-          ? { userComputerWorkspace: resources.userComputerWorkspace }
-          : {}),
+        workspaceType,
+        workspace: resources.botWorkspace,
+        ...(userComputerWorkspace ? { userComputerWorkspace } : {}),
         ...(registeredMemoryHandlers ? { memoryHandlers: registeredMemoryHandlers } : {}),
       };
       toolRuntime.registerSession(key, toolSession);

--- a/apps/server/src/provider/botWorkspace.test.ts
+++ b/apps/server/src/provider/botWorkspace.test.ts
@@ -8,14 +8,30 @@ import { assert, describe, expect, it, vi } from "vite-plus/test";
 
 import {
   createBotWorkspace,
-  createRemoteMastraWorkspace,
+  createRemoteBotWorkspace,
+  daytona,
+  type AkeruRemoteSession,
   isRemoteBotSandbox,
+  upstash,
+  upstashWorkspaceState,
+  vercelWorkspaceState,
 } from "./botWorkspace.ts";
+
+function remoteSession(providerId: string): AkeruRemoteSession {
+  return {
+    providerId,
+    inspect: async () => "running",
+    run: async () => ({ exitCode: 0, stdout: "", stderr: "" }),
+    wake: async () => undefined,
+    sleep: async () => undefined,
+    destroy: async () => undefined,
+  };
+}
 
 describe("createBotWorkspace", () => {
   it("classifies every managed provider", () => {
     expect(isRemoteBotSandbox("local")).toBe(false);
-    for (const sandbox of ["vercel", "akeru-cloud", "upstash"] as const) {
+    for (const sandbox of ["e2b", "daytona", "vercel", "upstash"] as const) {
       expect(isRemoteBotSandbox(sandbox)).toBe(true);
     }
   });
@@ -33,9 +49,9 @@ describe("createBotWorkspace", () => {
       sandbox: "local",
     });
     assert.isDefined(workspace);
-    expect(workspace.sandbox).toBeInstanceOf(LocalSandbox);
-    expect(workspace.filesystem).toBeInstanceOf(LocalFilesystem);
-    await workspace.filesystem?.writeFile("identity.txt", "bot-owned");
+    expect(workspace.workspace.sandbox).toBeInstanceOf(LocalSandbox);
+    expect(workspace.workspace.filesystem).toBeInstanceOf(LocalFilesystem);
+    await workspace.workspace.filesystem?.writeFile("identity.txt", "bot-owned");
     expect(NodeFS.readFileSync(NodePath.join(botRoot, "identity.txt"), "utf8")).toBe("bot-owned");
     expect(NodeFS.existsSync(NodePath.join(projectDir, "identity.txt"))).toBe(false);
     await workspace.destroy();
@@ -62,12 +78,124 @@ describe("createBotWorkspace", () => {
     await remote.destroy();
   });
 
-  it.each(["vercel", "upstash", "akeru-cloud"] as const)(
-    "fails closed while the %s adapter is unavailable",
-    async (sandbox) => {
-      await expect(
-        createRemoteMastraWorkspace({ threadId: "thread-remote", sandbox }),
-      ).rejects.toThrow(`Remote sandbox '${sandbox}' is unavailable`);
-    },
-  );
+  it("requires stable identity for remote workspaces", async () => {
+    await expect(
+      createRemoteBotWorkspace({ threadId: "thread-remote", sandbox: "e2b" }),
+    ).rejects.toThrow("needs a stable workspace identity");
+  });
+
+  it("persists the provider identity and uses it to reattach", async () => {
+    const baseDir = NodeFS.mkdtempSync(NodePath.join(NodeOS.tmpdir(), "akeru-identity-"));
+    const identityFile = NodePath.join(baseDir, "provider.json");
+    const openSession = vi.fn(async (providerId?: string) =>
+      remoteSession(providerId ?? "native-workspace-id"),
+    );
+    const input = {
+      threadId: "thread-remote",
+      sandbox: "e2b" as const,
+      workspaceId: "akeru-stable-id",
+      identityFile,
+      openSession,
+    };
+
+    const created = await createRemoteBotWorkspace(input);
+    const reattached = await createRemoteBotWorkspace(input);
+
+    expect(created.id).toBe("akeru-stable-id");
+    expect(reattached.id).toBe("akeru-stable-id");
+    expect(reattached.providerId).toBe("native-workspace-id");
+    expect(openSession).toHaveBeenNthCalledWith(1, undefined);
+    expect(openSession).toHaveBeenNthCalledWith(2, "native-workspace-id");
+    expect(JSON.parse(NodeFS.readFileSync(identityFile, "utf8"))).toEqual({
+      provider: "e2b",
+      providerId: "native-workspace-id",
+    });
+    await reattached.destroy();
+    expect(NodeFS.existsSync(identityFile)).toBe(false);
+    NodeFS.rmSync(baseDir, { recursive: true, force: true });
+  });
+
+  it("fails closed when a persisted remote workspace is missing", async () => {
+    const baseDir = NodeFS.mkdtempSync(NodePath.join(NodeOS.tmpdir(), "akeru-missing-"));
+    const identityFile = NodePath.join(baseDir, "provider.json");
+    NodeFS.writeFileSync(
+      identityFile,
+      `${JSON.stringify({ provider: "vercel", providerId: "missing-id" })}\n`,
+    );
+
+    await expect(
+      createRemoteBotWorkspace({
+        threadId: "thread-remote",
+        sandbox: "vercel",
+        workspaceId: "akeru-stable-id",
+        identityFile,
+        openSession: async () => Promise.reject(new Error("not found")),
+      }),
+    ).rejects.toThrow(`Remove '${identityFile}' to create a replacement`);
+    expect(NodeFS.existsSync(identityFile)).toBe(true);
+    NodeFS.rmSync(baseDir, { recursive: true, force: true });
+  });
+
+  it("pauses and restarts Daytona workspaces", async () => {
+    let state = "started";
+    const pause = vi.fn(async () => {
+      state = "paused";
+    });
+    const start = vi.fn(async () => {
+      state = "started";
+    });
+    const sandbox = {
+      id: "daytona-id",
+      get state() {
+        return state;
+      },
+      refreshData: vi.fn(async () => undefined),
+      pause,
+      start,
+      delete: vi.fn(async () => undefined),
+      process: { executeCommand: vi.fn() },
+    } as unknown as import("@daytona/sdk").Sandbox;
+    const client = {
+      [Symbol.asyncDispose]: vi.fn(async () => undefined),
+    } as unknown as import("@daytona/sdk").Daytona;
+    const session = daytona(client, sandbox);
+
+    await session.sleep();
+    expect(await session.inspect()).toBe("sleeping");
+    await session.wake();
+
+    expect(pause).toHaveBeenCalledOnce();
+    expect(start).toHaveBeenCalledOnce();
+    expect(await session.inspect()).toBe("running");
+  });
+
+  it("resumes a paused Upstash workspace after reattach", async () => {
+    let status = "paused";
+    const resume = vi.fn(async () => {
+      status = "running";
+    });
+    const box = {
+      id: "upstash-id",
+      getStatus: vi.fn(async () => ({ status })),
+      resume,
+      pause: vi.fn(async () => undefined),
+      delete: vi.fn(async () => undefined),
+      exec: { command: vi.fn() },
+    } as unknown as import("@upstash/box").Box;
+    const session = upstash(box);
+
+    await session.wake();
+
+    expect(resume).toHaveBeenCalledOnce();
+    expect(await session.inspect()).toBe("running");
+  });
+
+  it("does not classify unavailable provider states as running", () => {
+    expect(upstashWorkspaceState("creating")).toBe("sleeping");
+    expect(upstashWorkspaceState("error")).toBe("missing");
+    expect(upstashWorkspaceState("deleted")).toBe("missing");
+    expect(vercelWorkspaceState("failed")).toBe("missing");
+    expect(vercelWorkspaceState("aborted")).toBe("missing");
+    expect(vercelWorkspaceState("stopped")).toBe("sleeping");
+  });
 });

--- a/apps/server/src/provider/botWorkspace.ts
+++ b/apps/server/src/provider/botWorkspace.ts
@@ -1,62 +1,440 @@
 // @effect-diagnostics nodeBuiltinImport:off
 import * as NodeFS from "node:fs";
+import * as NodePath from "node:path";
 
 import { TOOL_NAME_OVERRIDES } from "@mastra/code-sdk/tool-names";
-import { LocalFilesystem, LocalSandbox, Workspace } from "@mastra/core/workspace";
+import {
+  type CommandResult,
+  type ExecuteCommandOptions,
+  LocalFilesystem,
+  LocalSandbox,
+  MastraSandbox,
+  type ProviderStatus,
+  Workspace,
+} from "@mastra/core/workspace";
 import type { BotSandbox } from "@t3tools/contracts";
+import { BotWorkspaceFilesystem } from "./botWorkspaceFilesystem.ts";
 
-export const REMOTE_BOT_SANDBOXES = ["vercel", "akeru-cloud", "upstash"] as const;
+export const REMOTE_BOT_SANDBOXES = ["e2b", "daytona", "vercel", "upstash"] as const;
 export type RemoteBotSandbox = (typeof REMOTE_BOT_SANDBOXES)[number];
+export type AkeruWorkspaceState = "running" | "sleeping" | "missing";
 
-export function isRemoteBotSandbox(
-  value: BotSandbox | null | undefined,
-): value is RemoteBotSandbox {
-  return REMOTE_BOT_SANDBOXES.some((sandbox) => sandbox === value);
+export interface AkeruBotWorkspace {
+  readonly id: string;
+  readonly provider: BotSandbox;
+  readonly providerId?: string;
+  readonly workspace: Workspace;
+  readonly inspect: () => Promise<AkeruWorkspaceState>;
+  readonly wake: () => Promise<void>;
+  readonly sleep: () => Promise<void>;
+  readonly destroy: () => Promise<void>;
+}
+
+export interface AkeruRemoteSession {
+  readonly providerId: string;
+  readonly inspect: () => Promise<AkeruWorkspaceState>;
+  readonly run: (
+    command: string,
+    args: readonly string[],
+    options?: { cwd?: string; env?: Record<string, string>; timeout?: number },
+  ) => Promise<{ exitCode: number; stdout: string; stderr: string }>;
+  readonly wake: () => Promise<void>;
+  readonly sleep: () => Promise<void>;
+  readonly destroy: () => Promise<void>;
 }
 
 export interface CreateRemoteBotWorkspaceInput {
   readonly threadId: string;
   readonly sandbox: RemoteBotSandbox;
-  readonly cwd?: string;
+  readonly identityFile?: string;
   readonly workspaceId?: string;
+  readonly openSession?: (providerId?: string) => Promise<AkeruRemoteSession>;
 }
 
 export interface CreateBotWorkspaceInput {
   readonly threadId: string;
   readonly cwd?: string;
+  readonly identityFile?: string;
   readonly localRoot?: string;
   readonly sandbox?: BotSandbox | null;
   readonly workspaceId?: string;
-  readonly makeRemoteWorkspace?: (input: CreateRemoteBotWorkspaceInput) => Promise<Workspace>;
+  readonly makeRemoteWorkspace?: (
+    input: CreateRemoteBotWorkspaceInput,
+  ) => Promise<AkeruBotWorkspace | Workspace>;
+}
+
+export function isRemoteBotSandbox(
+  value: BotSandbox | null | undefined,
+): value is RemoteBotSandbox {
+  return REMOTE_BOT_SANDBOXES.some((provider) => provider === value);
 }
 
 export async function createBotWorkspace(
   input: CreateBotWorkspaceInput,
-): Promise<Workspace | undefined> {
+): Promise<AkeruBotWorkspace | undefined> {
   if (isRemoteBotSandbox(input.sandbox)) {
-    return await (input.makeRemoteWorkspace ?? createRemoteMastraWorkspace)({
+    const remote = await (input.makeRemoteWorkspace ?? createRemoteBotWorkspace)({
       threadId: input.threadId,
       sandbox: input.sandbox,
-      ...(input.cwd ? { cwd: input.cwd } : {}),
+      ...(input.identityFile ? { identityFile: input.identityFile } : {}),
       ...(input.workspaceId ? { workspaceId: input.workspaceId } : {}),
     });
+    return remote instanceof Workspace ? wrap(remote, input.sandbox) : remote;
   }
-  const localRoot = input.localRoot ?? input.cwd;
-  if (!localRoot) return undefined;
-  await NodeFS.promises.mkdir(localRoot, { recursive: true, mode: 0o700 });
-  return new Workspace({
+  const root = input.localRoot ?? input.cwd;
+  if (!root) return undefined;
+  await NodeFS.promises.mkdir(root, { recursive: true, mode: 0o700 });
+  const workspace = new Workspace({
     id: input.workspaceId ?? `akeru-${input.threadId}`,
     name: `Akeru ${input.threadId}`,
-    filesystem: new LocalFilesystem({ basePath: localRoot }),
-    sandbox: new LocalSandbox({ workingDirectory: localRoot }),
+    filesystem: new LocalFilesystem({ basePath: root }),
+    sandbox: new LocalSandbox({ workingDirectory: root }),
     tools: TOOL_NAME_OVERRIDES,
   });
+  return wrap(workspace, "local");
 }
 
-export async function createRemoteMastraWorkspace(
+export async function createRemoteBotWorkspace(
   input: CreateRemoteBotWorkspaceInput,
-): Promise<Workspace> {
-  throw new Error(
-    `Remote sandbox '${input.sandbox}' is unavailable until its Akeru-native adapter is installed.`,
-  );
+): Promise<AkeruBotWorkspace> {
+  if (!input.identityFile || !input.workspaceId)
+    throw new Error(`Remote sandbox '${input.sandbox}' needs a stable workspace identity.`);
+  const identityFile = input.identityFile;
+  const persisted = await readIdentity(identityFile);
+  if (persisted && persisted.provider !== input.sandbox)
+    throw new Error(
+      `Workspace '${input.workspaceId}' belongs to '${persisted.provider}', not '${input.sandbox}'.`,
+    );
+  let session: AkeruRemoteSession;
+  try {
+    session = input.openSession
+      ? await input.openSession(persisted?.providerId)
+      : persisted
+        ? await open(input.sandbox, persisted.providerId)
+        : await create(input.sandbox, input.workspaceId);
+  } catch (cause) {
+    if (!persisted) throw cause;
+    throw new Error(
+      `Remote ${input.sandbox} workspace '${persisted.providerId}' is missing or unavailable. Remove '${identityFile}' to create a replacement.`,
+      { cause },
+    );
+  }
+  if (!persisted) {
+    try {
+      await writeIdentity(identityFile, {
+        provider: input.sandbox,
+        providerId: session.providerId,
+      });
+    } catch (cause) {
+      await session.destroy().catch(() => undefined);
+      throw cause;
+    }
+  }
+  const workspace = new Workspace({
+    id: input.workspaceId,
+    name: `Akeru ${input.workspaceId}`,
+    filesystem: new BotWorkspaceFilesystem(input.workspaceId, input.sandbox, session),
+    sandbox: new RemoteSandbox(input.workspaceId, input.sandbox, session),
+    tools: TOOL_NAME_OVERRIDES,
+  });
+  return {
+    id: input.workspaceId,
+    provider: input.sandbox,
+    providerId: session.providerId,
+    workspace,
+    inspect: session.inspect,
+    wake: () => workspace.init(),
+    sleep: () => workspace.stop(),
+    destroy: async () => {
+      await workspace.destroy();
+      await NodeFS.promises.rm(identityFile, { force: true });
+    },
+  };
+}
+
+function wrap(workspace: Workspace, provider: "local" | RemoteBotSandbox): AkeruBotWorkspace {
+  return {
+    id: workspace.id,
+    provider,
+    workspace,
+    inspect: async () =>
+      workspace.status === "destroyed"
+        ? "missing"
+        : workspace.status === "paused"
+          ? "sleeping"
+          : "running",
+    wake: () => workspace.init(),
+    sleep: () => workspace.stop(),
+    destroy: () => workspace.destroy(),
+  };
+}
+
+class RemoteSandbox extends MastraSandbox {
+  readonly name: string;
+  readonly provider: string;
+  readonly id: string;
+  private readonly session: AkeruRemoteSession;
+  status: ProviderStatus = "pending";
+  constructor(id: string, provider: RemoteBotSandbox, session: AkeruRemoteSession) {
+    super({ name: `Akeru ${provider}` });
+    this.id = id;
+    this.name = `Akeru ${provider}`;
+    this.provider = provider;
+    this.session = session;
+  }
+  override async start() {
+    await this.session.wake();
+    return { outcome: "connected" as const };
+  }
+  override stop() {
+    return this.session.sleep();
+  }
+  override destroy() {
+    return this.session.destroy();
+  }
+  override async executeCommand(
+    command: string,
+    args: string[] = [],
+    options?: ExecuteCommandOptions,
+  ): Promise<CommandResult> {
+    const startedAt = performance.now();
+    const env = options?.env
+      ? Object.fromEntries(
+          Object.entries(options.env).filter(
+            (entry): entry is [string, string] => entry[1] !== undefined,
+          ),
+        )
+      : undefined;
+    const result = await this.session.run(command, args, {
+      ...(options?.cwd ? { cwd: options.cwd } : {}),
+      ...(env ? { env } : {}),
+      ...(options?.timeout !== undefined ? { timeout: options.timeout } : {}),
+    });
+    return {
+      ...result,
+      success: result.exitCode === 0,
+      executionTimeMs: performance.now() - startedAt,
+    };
+  }
+}
+
+async function readIdentity(path: string) {
+  try {
+    const value = JSON.parse(await NodeFS.promises.readFile(path, "utf8")) as {
+      provider?: unknown;
+      providerId?: unknown;
+    };
+    if (
+      !REMOTE_BOT_SANDBOXES.includes(value.provider as RemoteBotSandbox) ||
+      typeof value.providerId !== "string" ||
+      !value.providerId
+    )
+      throw new Error(`Workspace identity file '${path}' is invalid.`);
+    return { provider: value.provider as RemoteBotSandbox, providerId: value.providerId };
+  } catch (cause) {
+    if ((cause as NodeJS.ErrnoException).code === "ENOENT") return undefined;
+    throw cause;
+  }
+}
+
+async function writeIdentity(
+  path: string,
+  identity: { provider: RemoteBotSandbox; providerId: string },
+) {
+  await NodeFS.promises.mkdir(NodePath.dirname(path), { recursive: true, mode: 0o700 });
+  const temporary = `${path}.${process.pid}.tmp`;
+  await NodeFS.promises.writeFile(temporary, `${JSON.stringify(identity)}\n`, { mode: 0o600 });
+  await NodeFS.promises.rename(temporary, path);
+}
+
+const quote = (value: string) => `'${value.replaceAll("'", `'\\''`)}'`;
+const commandLine = (command: string, args: readonly string[]) =>
+  [command, ...args].map(quote).join(" ");
+
+async function create(provider: RemoteBotSandbox, id: string): Promise<AkeruRemoteSession> {
+  if (provider === "e2b") {
+    const { Sandbox } = await import("e2b");
+    return e2b(await Sandbox.create({ lifecycle: { onTimeout: "pause" } }));
+  }
+  if (provider === "daytona") {
+    const { Daytona } = await import("@daytona/sdk");
+    const client = new Daytona();
+    return daytona(client, await client.create({ name: id }));
+  }
+  if (provider === "vercel") {
+    const { Sandbox } = await import("@vercel/sandbox");
+    return vercel(await Sandbox.create({ name: id, persistent: true }));
+  }
+  const { Box } = await import("@upstash/box");
+  return upstash(await Box.create());
+}
+
+async function open(provider: RemoteBotSandbox, id: string): Promise<AkeruRemoteSession> {
+  if (provider === "e2b") {
+    const { Sandbox } = await import("e2b");
+    return e2b(await Sandbox.connect(id));
+  }
+  if (provider === "daytona") {
+    const { Daytona } = await import("@daytona/sdk");
+    const client = new Daytona();
+    return daytona(client, await client.get(id));
+  }
+  if (provider === "vercel") {
+    const { Sandbox } = await import("@vercel/sandbox");
+    return vercel(await Sandbox.get({ name: id, resume: true }));
+  }
+  const { Box } = await import("@upstash/box");
+  return upstash(await Box.get(id));
+}
+
+function e2b(initial: import("e2b").Sandbox): AkeruRemoteSession {
+  let sandbox = initial;
+  const providerId = sandbox.sandboxId;
+  return {
+    providerId,
+    inspect: async () => {
+      const { Sandbox } = await import("e2b");
+      const info = await Sandbox.getInfo(providerId);
+      return info.state === "paused" ? "sleeping" : "running";
+    },
+    run: async (command, args, options) => {
+      const result = await sandbox.commands.run(commandLine(command, args), {
+        ...(options?.cwd ? { cwd: options.cwd } : {}),
+        ...(options?.env ? { envs: options.env } : {}),
+        ...(options?.timeout ? { timeoutMs: options.timeout } : {}),
+      });
+      return { exitCode: result.exitCode, stdout: result.stdout, stderr: result.stderr };
+    },
+    wake: async () => {
+      const { Sandbox } = await import("e2b");
+      sandbox = await Sandbox.connect(providerId);
+    },
+    sleep: async () => {
+      await sandbox.pause();
+    },
+    destroy: async () => {
+      await sandbox.kill();
+    },
+  };
+}
+
+export function daytona(
+  client: import("@daytona/sdk").Daytona,
+  sandbox: import("@daytona/sdk").Sandbox,
+): AkeruRemoteSession {
+  return {
+    providerId: sandbox.id,
+    inspect: async () => {
+      await sandbox.refreshData();
+      const current = String(sandbox.state);
+      return current === "destroyed" ? "missing" : current === "started" ? "running" : "sleeping";
+    },
+    run: async (command, args, options) => {
+      const result = await sandbox.process.executeCommand(
+        commandLine(command, args),
+        options?.cwd,
+        options?.env,
+        options?.timeout ? Math.ceil(options.timeout / 1000) : undefined,
+      );
+      return { exitCode: result.exitCode, stdout: result.result, stderr: "" };
+    },
+    wake: async () => {
+      if ((await sandbox.refreshData(), String(sandbox.state)) !== "started") {
+        await sandbox.start();
+      }
+    },
+    sleep: () => sandbox.pause(),
+    destroy: async () => {
+      await sandbox.delete(undefined, true);
+      await client[Symbol.asyncDispose]();
+    },
+  };
+}
+
+export function vercelWorkspaceState(
+  status: import("@vercel/sandbox").Sandbox["status"],
+): AkeruWorkspaceState {
+  if (status === "running") return "running";
+  if (status === "failed" || status === "aborted") return "missing";
+  return "sleeping";
+}
+
+function vercel(initial: import("@vercel/sandbox").Sandbox): AkeruRemoteSession {
+  let sandbox = initial;
+  return {
+    providerId: sandbox.name,
+    inspect: async () => {
+      const { Sandbox } = await import("@vercel/sandbox");
+      sandbox = await Sandbox.get({ name: sandbox.name, resume: false });
+      return vercelWorkspaceState(sandbox.status);
+    },
+    run: async (command, args, options) => {
+      const result = await sandbox.runCommand({
+        cmd: command,
+        args: [...args],
+        ...(options?.cwd ? { cwd: options.cwd } : {}),
+        ...(options?.env ? { env: options.env } : {}),
+        ...(options?.timeout ? { timeoutMs: options.timeout } : {}),
+      });
+      return {
+        exitCode: result.exitCode,
+        stdout: await result.stdout(),
+        stderr: await result.stderr(),
+      };
+    },
+    wake: async () => {
+      const { Sandbox } = await import("@vercel/sandbox");
+      sandbox = await Sandbox.get({ name: sandbox.name, resume: true });
+    },
+    sleep: async () => {
+      await sandbox.stop();
+    },
+    destroy: async () => {
+      await sandbox.delete();
+    },
+  };
+}
+
+export function upstash(box: import("@upstash/box").Box): AkeruRemoteSession {
+  const inspect = async () => {
+    const status = (await box.getStatus()).status;
+    return upstashWorkspaceState(status);
+  };
+  return {
+    providerId: box.id,
+    inspect,
+    run: async (command, args, options) => {
+      const assignments = Object.entries(options?.env ?? {}).map(
+        ([key, value]) => `${key}=${value}`,
+      );
+      let line =
+        assignments.length > 0
+          ? commandLine("env", ["--", ...assignments, command, ...args])
+          : commandLine(command, args);
+      if (options?.timeout !== undefined) {
+        line = commandLine("timeout", [`${options.timeout / 1_000}s`, "sh", "-lc", line]);
+      }
+      const result = await box.exec.command(
+        `${options?.cwd ? `cd ${quote(options.cwd)} && ` : ""}${line}`,
+      );
+      return { exitCode: result.exitCode ?? 1, stdout: result.result, stderr: "" };
+    },
+    wake: async () => {
+      const current = await inspect();
+      if (current === "missing") {
+        throw new Error(`Upstash workspace '${box.id}' is missing.`);
+      }
+      if (current === "sleeping") {
+        await box.resume();
+      }
+    },
+    sleep: () => box.pause(),
+    destroy: () => box.delete(),
+  };
+}
+
+export function upstashWorkspaceState(status: string): AkeruWorkspaceState {
+  if (status === "running" || status === "idle") return "running";
+  if (status === "error" || status === "deleted") return "missing";
+  return "sleeping";
 }

--- a/apps/server/src/provider/botWorkspaceFilesystem.test.ts
+++ b/apps/server/src/provider/botWorkspaceFilesystem.test.ts
@@ -1,0 +1,24 @@
+import { describe, expect, it, vi } from "vite-plus/test";
+
+import { BotWorkspaceFilesystem } from "./botWorkspaceFilesystem.ts";
+
+describe("BotWorkspaceFilesystem", () => {
+  it("reads and writes binary-safe content through the remote command session", async () => {
+    const run = vi.fn(async (_command: string, args: readonly string[]) => ({
+      exitCode: 0,
+      stdout: args[1]?.startsWith("base64")
+        ? Buffer.from("remote contents").toString("base64")
+        : "",
+      stderr: "",
+    }));
+    const filesystem = new BotWorkspaceFilesystem("workspace", "e2b", { run });
+
+    await expect(filesystem.readFile("file.txt", { encoding: "utf8" })).resolves.toBe(
+      "remote contents",
+    );
+    await filesystem.writeFile("file.txt", Buffer.from([0, 1, 2]));
+
+    expect(run).toHaveBeenNthCalledWith(1, "sh", ["-lc", "base64 < 'file.txt'"]);
+    expect(run.mock.calls[1]?.[1]?.[1]).toContain(Buffer.from([0, 1, 2]).toString("base64"));
+  });
+});

--- a/apps/server/src/provider/botWorkspaceFilesystem.ts
+++ b/apps/server/src/provider/botWorkspaceFilesystem.ts
@@ -1,0 +1,162 @@
+// @effect-diagnostics globalDate:off nodeBuiltinImport:off
+import * as NodePath from "node:path";
+
+import type {
+  CopyOptions,
+  FileContent,
+  FileEntry,
+  FileStat,
+  ListOptions,
+  ReadOptions,
+  RemoveOptions,
+  ProviderStatus,
+  WorkspaceFilesystem,
+  WriteOptions,
+} from "@mastra/core/workspace";
+
+interface RemoteCommandSession {
+  readonly run: (
+    command: string,
+    args: readonly string[],
+  ) => Promise<{ exitCode: number; stdout: string; stderr: string }>;
+}
+
+const quote = (value: string) => `'${value.replaceAll("'", `'\\''`)}'`;
+
+export class BotWorkspaceFilesystem implements WorkspaceFilesystem {
+  readonly id: string;
+  readonly name: string;
+  readonly provider: string;
+  readonly status: ProviderStatus = "ready";
+  private readonly session: RemoteCommandSession;
+
+  constructor(id: string, provider: string, session: RemoteCommandSession) {
+    this.id = `${id}-filesystem`;
+    this.name = `Akeru ${provider}`;
+    this.provider = provider;
+    this.session = session;
+  }
+
+  async readFile(path: string, options?: ReadOptions): Promise<string | Buffer> {
+    const result = await this.shell(`base64 < ${quote(path)}`);
+    const content = Buffer.from(result.trim(), "base64");
+    return options?.encoding ? content.toString(options.encoding) : content;
+  }
+
+  async writeFile(path: string, content: FileContent, options?: WriteOptions): Promise<void> {
+    const checks = [
+      options?.recursive ? `mkdir -p -- ${quote(NodePath.posix.dirname(path))}` : "",
+      options?.overwrite === false ? `test ! -e ${quote(path)}` : "",
+      options?.expectedMtime
+        ? `test "$(stat -c %Y -- ${quote(path)})" = ${quote(String(Math.floor(options.expectedMtime.getTime() / 1_000)))}`
+        : "",
+      `printf %s ${quote(Buffer.from(content).toString("base64"))} | base64 -d > ${quote(path)}`,
+    ].filter(Boolean);
+    await this.shell(checks.join(" && "));
+  }
+
+  async appendFile(path: string, content: FileContent): Promise<void> {
+    await this.shell(
+      `printf %s ${quote(Buffer.from(content).toString("base64"))} | base64 -d >> ${quote(path)}`,
+    );
+  }
+
+  async deleteFile(path: string, options?: RemoveOptions): Promise<void> {
+    await this.command("rm", [options?.force ? "-f" : "", "--", path].filter(Boolean));
+  }
+
+  async copyFile(src: string, dest: string, options?: CopyOptions): Promise<void> {
+    await this.command(
+      "cp",
+      [
+        options?.recursive ? "-R" : "",
+        options?.overwrite === false ? "-n" : "",
+        "--",
+        src,
+        dest,
+      ].filter(Boolean),
+    );
+  }
+
+  async moveFile(src: string, dest: string, options?: CopyOptions): Promise<void> {
+    await this.command(
+      "mv",
+      [options?.overwrite === false ? "-n" : "", "--", src, dest].filter(Boolean),
+    );
+  }
+
+  async mkdir(path: string, options?: { recursive?: boolean }): Promise<void> {
+    await this.command("mkdir", [options?.recursive ? "-p" : "", "--", path].filter(Boolean));
+  }
+
+  async rmdir(path: string, options?: RemoveOptions): Promise<void> {
+    await this.command(
+      "rm",
+      [options?.recursive ? "-R" : "-d", options?.force ? "-f" : "", "--", path].filter(Boolean),
+    );
+  }
+
+  async readdir(path: string, options?: ListOptions): Promise<FileEntry[]> {
+    const maxDepth = options?.recursive ? options.maxDepth : 1;
+    const output = await this.command("find", [
+      path,
+      "-mindepth",
+      "1",
+      ...(maxDepth === undefined ? [] : ["-maxdepth", String(maxDepth)]),
+      "-printf",
+      "%P\\037%y\\037%s\\037%l\\036",
+    ]);
+    const extensions = options?.extension
+      ? Array.isArray(options.extension)
+        ? options.extension
+        : [options.extension]
+      : undefined;
+    return output
+      .split("\u001e")
+      .filter(Boolean)
+      .map((record) => {
+        const [name = "", type = "f", size = "0", symlinkTarget = ""] = record.split("\u001f");
+        return {
+          name,
+          type: type === "d" ? ("directory" as const) : ("file" as const),
+          ...(type === "d" ? {} : { size: Number(size) }),
+          ...(type === "l" ? { isSymlink: true, symlinkTarget } : {}),
+        };
+      })
+      .filter(
+        (entry) => !extensions || extensions.some((extension) => entry.name.endsWith(extension)),
+      );
+  }
+
+  async exists(path: string): Promise<boolean> {
+    const result = await this.session.run("test", ["-e", path]);
+    return result.exitCode === 0;
+  }
+
+  async stat(path: string): Promise<FileStat> {
+    const output = await this.command("stat", ["-c", "%F\\037%s\\037%W\\037%Y", "--", path]);
+    const [kind = "", size = "0", createdAt = "0", modifiedAt = "0"] = output
+      .trim()
+      .split("\u001f");
+    return {
+      name: NodePath.posix.basename(path),
+      path,
+      type: kind.includes("directory") ? "directory" : "file",
+      size: kind.includes("directory") ? 0 : Number(size),
+      createdAt: new Date(Math.max(0, Number(createdAt)) * 1_000),
+      modifiedAt: new Date(Number(modifiedAt) * 1_000),
+    };
+  }
+
+  private async shell(script: string): Promise<string> {
+    return this.command("sh", ["-lc", script]);
+  }
+
+  private async command(command: string, args: readonly string[]): Promise<string> {
+    const result = await this.session.run(command, args);
+    if (result.exitCode !== 0) {
+      throw new Error(result.stderr || `${command} exited with code ${result.exitCode}.`);
+    }
+    return result.stdout;
+  }
+}

--- a/apps/server/src/provider/botWorkspacePool.test.ts
+++ b/apps/server/src/provider/botWorkspacePool.test.ts
@@ -89,6 +89,79 @@ describe("BotWorkspacePool", () => {
     expect(destroy).toHaveBeenCalledOnce();
   });
 
+  it("destroys once after every caller observes a failed wake", async () => {
+    const pool = new BotWorkspacePool();
+    const workspace = localWorkspace();
+    let rejectWake!: (cause: Error) => void;
+    let markWakeStarted!: () => void;
+    const wakeStarted = new Promise<void>((resolve) => (markWakeStarted = resolve));
+    vi.spyOn(workspace, "init")
+      .mockResolvedValueOnce(undefined)
+      .mockImplementationOnce(
+        () =>
+          new Promise<void>((_, reject) => {
+            rejectWake = reject;
+            markWakeStarted();
+          }),
+      );
+    const destroy = vi.spyOn(workspace, "destroy");
+    const initial = await pool.acquire("failed-wake", async () => workspace);
+    await initial.release();
+
+    const first = pool.acquire("failed-wake", async () => workspace);
+    await wakeStarted;
+    const second = pool.acquire("failed-wake", async () => workspace);
+    rejectWake(new Error("wake failed"));
+
+    await expect(first).rejects.toThrow("wake failed");
+    await expect(second).rejects.toThrow("wake failed");
+    await vi.waitFor(() => expect(destroy).toHaveBeenCalledOnce());
+  });
+
+  it("isolates a failed workspace from other pool entries", async () => {
+    const pool = new BotWorkspacePool();
+    const failed = localWorkspace();
+    const healthy = localWorkspace();
+    vi.spyOn(failed, "stop").mockRejectedValueOnce(new Error("sleep failed"));
+    const healthyStop = vi.spyOn(healthy, "stop");
+    const failedLease = await pool.acquire("failed", async () => failed);
+    const healthyLease = await pool.acquire("healthy", async () => healthy);
+
+    await expect(failedLease.release()).rejects.toThrow("sleep failed");
+    await expect(healthyLease.release()).resolves.toBeUndefined();
+    expect(healthyStop).toHaveBeenCalledOnce();
+    await pool.destroyAll();
+  });
+
+  it("waits for failed workspace cleanup before replacement", async () => {
+    const pool = new BotWorkspacePool();
+    const failed = localWorkspace();
+    const replacement = localWorkspace();
+    let finishDestroy!: () => void;
+    let markDestroyStarted!: () => void;
+    const destroyStarted = new Promise<void>((resolve) => (markDestroyStarted = resolve));
+    vi.spyOn(failed, "stop").mockRejectedValueOnce(new Error("sleep failed"));
+    vi.spyOn(failed, "destroy").mockImplementationOnce(
+      () =>
+        new Promise<void>((resolve) => {
+          finishDestroy = resolve;
+          markDestroyStarted();
+        }),
+    );
+    const initial = await pool.acquire("replace", async () => failed);
+    const release = initial.release();
+    await destroyStarted;
+    const createReplacement = vi.fn(async () => replacement);
+    const reacquire = pool.acquire("replace", createReplacement);
+
+    expect(createReplacement).not.toHaveBeenCalled();
+    finishDestroy();
+    await expect(release).rejects.toThrow("sleep failed");
+    const lease = await reacquire;
+    expect(createReplacement).toHaveBeenCalledOnce();
+    await lease.release({ destroy: true });
+  });
+
   it("retries failed creation", async () => {
     const pool = new BotWorkspacePool();
     const create = vi

--- a/apps/server/src/provider/botWorkspacePool.ts
+++ b/apps/server/src/provider/botWorkspacePool.ts
@@ -1,8 +1,9 @@
 // @effect-diagnostics nodeBuiltinImport:off
 import * as NodeCrypto from "node:crypto";
 
-import type { Workspace } from "@mastra/core/workspace";
+import { Workspace } from "@mastra/core/workspace";
 import type { BotId, BotSandbox, BotSandboxBrowserSharing } from "@t3tools/contracts";
+import type { AkeruBotWorkspace } from "./botWorkspace.ts";
 
 export function botRuntimeResourceScope(input: {
   readonly sharing: BotSandboxBrowserSharing;
@@ -29,13 +30,13 @@ export function botWorkspaceIdentity(resourceKey: string): string {
 }
 
 export interface BotWorkspaceLease {
-  readonly workspace: Workspace;
+  readonly workspace: AkeruBotWorkspace;
   readonly wokeFromSleep: boolean;
   readonly release: (options?: { readonly destroy?: boolean }) => Promise<void>;
 }
 
 interface BotWorkspacePoolEntry {
-  readonly workspace: Promise<Workspace>;
+  readonly workspace: Promise<AkeruBotWorkspace>;
   references: number;
   sleeping?: Promise<void>;
   waking?: Promise<void>;
@@ -47,7 +48,10 @@ interface BotWorkspacePoolEntry {
 export class BotWorkspacePool {
   private readonly entries = new Map<string, BotWorkspacePoolEntry>();
 
-  async acquire(key: string, create: () => Promise<Workspace>): Promise<BotWorkspaceLease> {
+  async acquire(
+    key: string,
+    create: () => Promise<AkeruBotWorkspace | Workspace>,
+  ): Promise<BotWorkspaceLease> {
     const current = this.entries.get(key);
     if (current?.destroying) {
       await current.destroying;
@@ -57,9 +61,10 @@ export class BotWorkspacePool {
     const entry =
       current ??
       ({
-        workspace: create().then(async (workspace) => {
+        workspace: create().then(async (created) => {
+          const workspace = created instanceof Workspace ? wrapMastraWorkspace(created) : created;
           try {
-            await workspace.init();
+            await workspace.wake();
           } catch (error) {
             await workspace.destroy().catch(() => undefined);
             throw error;
@@ -73,14 +78,14 @@ export class BotWorkspacePool {
     const wake = current !== undefined && (entry.references === 0 || entry.waking !== undefined);
     entry.references += 1;
 
-    let workspace: Workspace;
+    let workspace: AkeruBotWorkspace;
     try {
       workspace = await entry.workspace;
       if (wake && !entry.waking) {
         entry.waking = (async () => {
           await entry.sleeping;
           delete entry.sleeping;
-          await workspace.init();
+          await workspace.wake();
         })().finally(() => {
           delete entry.waking;
         });
@@ -117,31 +122,17 @@ export class BotWorkspacePool {
 
         entry.sleeping = (async () => {
           await entry.waking;
-          await workspace.stop();
+          await workspace.sleep();
         })().catch(async (error: unknown) => {
-          if (this.entries.get(key) === entry) this.entries.delete(key);
-          await workspace.destroy().catch(() => undefined);
+          entry.destroying ??= workspace.destroy().finally(() => {
+            if (this.entries.get(key) === entry) this.entries.delete(key);
+          });
+          await entry.destroying.catch(() => undefined);
           throw error;
         });
         await entry.sleeping;
       },
     };
-  }
-
-  async stopAll(): Promise<void> {
-    const entries = [...this.entries.values()];
-    const results = await Promise.allSettled(
-      entries.map(async (entry) => {
-        const workspace = await entry.workspace;
-        entry.sleeping ??= (async () => {
-          await entry.waking;
-          await workspace.stop();
-        })();
-        await entry.sleeping;
-      }),
-    );
-    const failure = results.find((result) => result.status === "rejected");
-    if (failure?.status === "rejected") throw failure.reason;
   }
 
   async destroyAll(): Promise<void> {
@@ -167,4 +158,16 @@ export class BotWorkspacePool {
       });
     await entry.destroying;
   }
+}
+
+function wrapMastraWorkspace(workspace: Workspace): AkeruBotWorkspace {
+  return {
+    id: workspace.id,
+    provider: "local",
+    workspace,
+    inspect: async () => "running",
+    wake: () => workspace.init(),
+    sleep: () => workspace.stop(),
+    destroy: () => workspace.destroy(),
+  };
 }

--- a/apps/web/src/components/roster/botSandbox.test.ts
+++ b/apps/web/src/components/roster/botSandbox.test.ts
@@ -30,10 +30,11 @@ describe("botSandbox", () => {
   it("lists the first sandbox providers", () => {
     expect(BOT_SANDBOX_OPTIONS.map((option) => option.value)).toEqual([
       "local",
+      "e2b",
+      "daytona",
       "vercel",
-      "akeru-cloud",
       "upstash",
     ]);
-    expect(botSandboxLabel("akeru-cloud")).toBe("Akeru Cloud");
+    expect(botSandboxLabel("vercel")).toBe("Vercel Sandbox");
   });
 });

--- a/apps/web/src/components/roster/botSandbox.test.ts
+++ b/apps/web/src/components/roster/botSandbox.test.ts
@@ -22,7 +22,7 @@ describe("botSandbox", () => {
   });
 
   it("runs cloud sandbox tools without a local approval prompt", () => {
-    for (const sandbox of ["vercel", "akeru-cloud", "upstash"] as const) {
+    for (const { value: sandbox } of BOT_SANDBOX_OPTIONS.slice(1)) {
       expect(resolveBotRuntimeMode(sandbox, "approval-required")).toBe("full-access");
     }
   });

--- a/apps/web/src/components/roster/botSandbox.ts
+++ b/apps/web/src/components/roster/botSandbox.ts
@@ -10,9 +10,10 @@ export const DEFAULT_BOT_RUNTIME_MODE: RuntimeMode = DEFAULT_LOCAL_EXECUTION_MOD
 
 export const BOT_SANDBOX_OPTIONS = [
   { value: "local", label: "Local" },
-  { value: "vercel", label: "Vercel" },
-  { value: "akeru-cloud", label: "Akeru Cloud" },
-  { value: "upstash", label: "Upstash" },
+  { value: "e2b", label: "E2B" },
+  { value: "daytona", label: "Daytona" },
+  { value: "vercel", label: "Vercel Sandbox" },
+  { value: "upstash", label: "Upstash Box" },
 ] as const;
 
 export type BotSandboxChoice = (typeof BOT_SANDBOX_OPTIONS)[number]["value"];

--- a/apps/web/src/components/roster/types.ts
+++ b/apps/web/src/components/roster/types.ts
@@ -31,7 +31,7 @@ export interface Bot {
   disabledMcpServerIds: readonly McpServerId[];
   avatar: BotAvatar;
   engine: { provider: string; model: string } | null;
-  sandbox: "local" | "vercel" | "akeru-cloud" | "upstash" | null;
+  sandbox: "local" | "e2b" | "daytona" | "vercel" | "upstash" | null;
   runtimeMode: "approval-required" | "auto-accept-edits" | "auto" | "full-access";
   usageCap: { unit: "tokens"; limit: number } | null;
   voiceEnabled: boolean;

--- a/docs/user/bots.md
+++ b/docs/user/bots.md
@@ -12,7 +12,7 @@ Open a bot to edit its profile in the panel beside the conversation.
 
 Akeru Bot stores the profile in the connected environment. Other clients connected to the same environment see the same bot configuration. Workspace-disabled tools stay unavailable to all bots.
 
-Settings controls whether bots share their workspace and browser. **Separate** is the default and gives each bot its own workspace identity and browser profile. **Shared** lets bots share files and cookies. Bots use a local workspace. Remote sandbox options stay unavailable.
+Settings controls whether bots share their workspace and browser. **Separate** is the default and gives each bot its own workspace identity and browser profile. **Shared** lets bots share files and cookies. Bots can use Local, E2B, Daytona, Vercel Sandbox, or Upstash Box workspaces. Remote workspaces use the provider credentials available to the environment and fail if those credentials are missing.
 
 Local bots ask before file changes and shell commands by default. Select **Settings > General > Local execution > Full access** to skip those local prompts. Actions that send, pay, delete, change production, or use secrets still ask. Bots that run in a cloud sandbox do not show the local computer prompt.
 

--- a/packages/contracts/src/botConfig.test.ts
+++ b/packages/contracts/src/botConfig.test.ts
@@ -39,7 +39,7 @@ describe("BotUsageCap", () => {
   });
 
   it("accepts cloud sandbox providers on bot events", () => {
-    for (const sandbox of ["local", "vercel", "akeru-cloud", "upstash"] as const) {
+    for (const sandbox of ["local", "e2b", "daytona", "vercel", "upstash"] as const) {
       expect(
         decodeCreated({
           botId: "bot-sandbox",
@@ -54,21 +54,5 @@ describe("BotUsageCap", () => {
         }).sandbox,
       ).toBe(sandbox);
     }
-  });
-
-  it.each(["e2b", "daytona"])("rejects the unsupported %s sandbox", (sandbox) => {
-    expect(() =>
-      decodeCreated({
-        botId: "bot-sandbox",
-        name: "Sandbox bot",
-        title: "Generalist",
-        avatar: { kind: "blob", shape: "circle", color: "#5B7FD4" },
-        engine: null,
-        sandbox,
-        groupId: null,
-        createdAt: "2026-01-01T00:00:00.000Z",
-        updatedAt: "2026-01-01T00:00:00.000Z",
-      }),
-    ).toThrow();
   });
 });

--- a/packages/contracts/src/orchestration.ts
+++ b/packages/contracts/src/orchestration.ts
@@ -301,7 +301,7 @@ export const BotEngine = Schema.Struct({
 });
 export type BotEngine = typeof BotEngine.Type;
 
-export const BotSandbox = Schema.Literals(["local", "vercel", "akeru-cloud", "upstash"]);
+export const BotSandbox = Schema.Literals(["local", "e2b", "daytona", "vercel", "upstash"]);
 export type BotSandbox = typeof BotSandbox.Type;
 
 export const BotSandboxBrowserSharing = Schema.Literals(["shared", "separate"]);

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -463,6 +463,9 @@ importers:
       '@anthropic-ai/claude-agent-sdk':
         specifier: ^0.3.170
         version: 0.3.170(@anthropic-ai/sdk@0.93.0(zod@4.4.3))(@modelcontextprotocol/sdk@1.29.0(zod@4.4.3))(zod@4.4.3)
+      '@daytona/sdk':
+        specifier: ^0.207.0
+        version: 0.207.0(bufferutil@4.1.0)(utf-8-validate@6.0.6)
       '@effect/platform-bun':
         specifier: 4.0.0-beta.103
         version: 4.0.0-beta.103(bufferutil@4.1.0)(effect@4.0.0-beta.103(patch_hash=af36b7948b6f9c56623074662b51dade5699880c1a7c71245de73e13c3185fb6))(utf-8-validate@6.0.6)
@@ -496,6 +499,15 @@ importers:
       '@pierre/diffs':
         specifier: 'catalog:'
         version: 1.3.0-beta.10(patch_hash=7ef7cb0cbabb17c15cdb137554068b36f15f6f5265e73fb51452aa3380db91aa)(@shikijs/themes@4.3.0)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
+      '@upstash/box':
+        specifier: 0.5.3
+        version: 0.5.3(zod@4.4.3)
+      '@vercel/sandbox':
+        specifier: ^2.5.0
+        version: 2.9.2
+      e2b:
+        specifier: ^2.32.0
+        version: 2.46.1
       effect:
         specifier: 4.0.0-beta.103
         version: 4.0.0-beta.103(patch_hash=af36b7948b6f9c56623074662b51dade5699880c1a7c71245de73e13c3185fb6)
@@ -1517,8 +1529,16 @@ packages:
   '@aws-crypto/util@5.2.0':
     resolution: {integrity: sha512-4RkU9EsI6ZpBve5fseQlGNUWKMa1RLPQ1dnjnQoe07ldfIzcsGb5hC5W0Dm7u423KWzawlrpbjXBrXCEv9zazQ==}
 
+  '@aws-sdk/checksums@3.1000.29':
+    resolution: {integrity: sha512-Dtu0gr4dnATZAPwEYbpCsG+MpLM7OAliy2gTepEFQwl1vZ6DL3QMH2FveMa3HLvPsOdhJsPRB3KtxVhph9T75A==}
+    engines: {node: '>=20.0.0'}
+
   '@aws-sdk/client-cognito-identity@3.1062.0':
     resolution: {integrity: sha512-QA5z/Pl3aTMR3+bmiHoC6MpKYa4FMk/9lNP7k104uKuUsjMqP4ysRa43IwdcbI9sH023T//kSJCLxrxa2CP/Tw==}
+    engines: {node: '>=20.0.0'}
+
+  '@aws-sdk/client-s3@3.1121.0':
+    resolution: {integrity: sha512-hBnoqaVBeWdkgXcJElMXA2yUZWkBCBntu2qmN+tfqmzC+j4LzJC3ox8qIgS2WdMS1cb8UwyBogUVrkRXybNm0A==}
     engines: {node: '>=20.0.0'}
 
   '@aws-sdk/core@3.974.17':
@@ -1607,6 +1627,16 @@ packages:
 
   '@aws-sdk/credential-providers@3.1118.0':
     resolution: {integrity: sha512-UDo7cEXbIEDqcHOiVBCrk4tuJhWwtREKH5hMtW+BYetA++SgfNutmTm0fmcuT6TpKFBLxA2Jm5PRzXXs2pImGw==}
+    engines: {node: '>=20.0.0'}
+
+  '@aws-sdk/lib-storage@3.1121.0':
+    resolution: {integrity: sha512-sx86QqM0/HjKNCS5eQGcaP9Q8GKg3FtCExO/6FfGyw00JNUsFJPmEKNCJIkWY7OmKS9jIOuJe/DtAgfr/+G/bQ==}
+    engines: {node: '>=20.0.0'}
+    peerDependencies:
+      '@aws-sdk/client-s3': ^3.1121.0
+
+  '@aws-sdk/middleware-sdk-s3@3.972.75':
+    resolution: {integrity: sha512-wMIsNumRVKaNMKhvU/s9VrdEwE8S6gSzXp4RygFG5BEMnGkkXf8cjh8zf7cKJBpUDpqTWqwbz5isEgp9rH6Lng==}
     engines: {node: '>=20.0.0'}
 
   '@aws-sdk/nested-clients@3.997.16':
@@ -2334,6 +2364,29 @@ packages:
 
   '@cloudflare/workers-types@5.20260726.1':
     resolution: {integrity: sha512-fKgRSm3sDmOdak1LGWehS4vSPSj7/zeu0NfmE62VPjBMqWgODcOGljYvq6A75sL+7YfY3iGFGb0jVEDYq+hlmw==}
+
+  '@connectrpc/connect-web@2.1.2':
+    resolution: {integrity: sha512-1tfaK85MU+gJjwwmL31d2rzdf0XCYX99chZf63uG89SGBUd4XuZ4ZzhGo2u79TPXOE6nLIZQ2okrpyey42PYdg==}
+    peerDependencies:
+      '@bufbuild/protobuf': ^2.7.0
+      '@connectrpc/connect': 2.1.2
+
+  '@connectrpc/connect@2.1.2':
+    resolution: {integrity: sha512-MXkBijtcX09R10Eb6sFeIetc6w6746eio6xtfuyVOH7oQAacT1X0GzMIQFux6Qy8cq3W/T5qX5Bei8YbFtmRGA==}
+    peerDependencies:
+      '@bufbuild/protobuf': ^2.7.0
+
+  '@daytona/analytics-api-client@0.207.0':
+    resolution: {integrity: sha512-5jQ8NVhx4aYDlMCVl+VWqGg4w2Hs+WUgDSNcbkevdcnnTU9Yk/3qHBtYRtOs46pXlIec1NsVfI9c4BGE/xFsmg==}
+
+  '@daytona/api-client@0.207.0':
+    resolution: {integrity: sha512-1rJpQoKdYn4KUQTOCosw2XYPobMwbhNCbDmnyMlUvH/nJE1qoom3krJ6VW+mx5f1lwknd23vl5Shqn0IN2a+xg==}
+
+  '@daytona/sdk@0.207.0':
+    resolution: {integrity: sha512-eq5VxZJ4F2WPAjP5LQN1p2hR1AzF9sICY9xedW0QFkTjtYovB4vdoN/S9i5BdHFrN111y5ZA2Z9WaPq/ykLgnQ==}
+
+  '@daytona/toolbox-api-client@0.207.0':
+    resolution: {integrity: sha512-3YlwbVN81KpF6CFTjno2jO45EzNQ97FF2hh+DeYzu9O9vSWRFrO16ae1XiJ5eMzFlkMvF+R4zwqnqtBenIg3HA==}
 
   '@distilled.cloud/aws@0.30.2':
     resolution: {integrity: sha512-Uw2yZf7PJ2ienrKG49HN1ajnke65mTtHBUrSb/3ykeZ/8cLaSgwVhPscHxSzGByY0TEtYcYKNNmfUVISgGQl9g==}
@@ -4035,6 +4088,10 @@ packages:
   '@opencode-ai/sdk@1.15.13':
     resolution: {integrity: sha512-4TwojIoQ8EG6/mVBuUVYZXiFcwNmiiytEnjnvyuvSJjGwFIlw2YIBFxtSVC3FbwwbwHT63teh1RHiQUUC4U5xw==}
 
+  '@opentelemetry/api-logs@0.221.0':
+    resolution: {integrity: sha512-OlanaW1vv7ufTqQ3/fPLI4arGt5ZoM+P8abOMki6uEYnpRazepSWDwDnnw+la7kE26SHVC18//SMccrDvLKOXQ==}
+    engines: {node: '>=8.0.0'}
+
   '@opentelemetry/api@1.9.0':
     resolution: {integrity: sha512-3giAOQvZiH5F9bMlMiv8+GSPMeqg0dbaeo58/0SlA9sxSqZhnUtxzX9/2FzyhS9sWQf5S0GJE0AKBrFqjpeYcg==}
     engines: {node: '>=8.0.0'}
@@ -4042,6 +4099,178 @@ packages:
   '@opentelemetry/api@1.9.1':
     resolution: {integrity: sha512-gLyJlPHPZYdAk1JENA9LeHejZe1Ti77/pTeFm/nMXmQH/HFZlcS/O2XJB+L8fkbrNSqhdtlvjBVjxwUYanNH5Q==}
     engines: {node: '>=8.0.0'}
+
+  '@opentelemetry/configuration@0.221.0':
+    resolution: {integrity: sha512-uE9y56Zdi9Gt/RdxYnVOo3YmFZkKJJMA0gqtBe8wh8gdtF5Asqe+Oh/TWiDtFb1s+31jNY4CWgnfIB1KOITfFA==}
+    engines: {node: ^18.19.0 || >=20.6.0}
+    peerDependencies:
+      '@opentelemetry/api': ^1.9.0
+
+  '@opentelemetry/context-async-hooks@2.10.0':
+    resolution: {integrity: sha512-bvyMcgLEkozzSzpEEEo1OMoeQ97bxj6Qs2uN3mPrSdDvObMI1myffD/BPqcLlzZO9//d1SqQA/WPw7Cz2AiqhA==}
+    engines: {node: ^18.19.0 || >=20.6.0}
+    peerDependencies:
+      '@opentelemetry/api': '>=1.0.0 <1.10.0'
+
+  '@opentelemetry/core@2.10.0':
+    resolution: {integrity: sha512-/wNZ8twnEQQA4HoHu22+vcsdru6pWPWxW+7w+FlxT6Id7PE/WIbZmVKkte+PF72e0F2dnImFeHD2syyE1Mw6MQ==}
+    engines: {node: ^18.19.0 || >=20.6.0}
+    peerDependencies:
+      '@opentelemetry/api': '>=1.0.0 <1.10.0'
+
+  '@opentelemetry/exporter-logs-otlp-grpc@0.221.0':
+    resolution: {integrity: sha512-txG1G0IrYSsKKMeiWZfj/i5cQmWB+h+hf3HzPpF3RqZVwp+iQQEIsv8Vtmzy6RWVdHdJZfygmVrBI39YTBvWcw==}
+    engines: {node: ^18.19.0 || >=20.6.0}
+    peerDependencies:
+      '@opentelemetry/api': ^1.3.0
+
+  '@opentelemetry/exporter-logs-otlp-http@0.221.0':
+    resolution: {integrity: sha512-nKXkr4Tomi6fjYVOf+ytcW3dZAVr4v4Bv5gsT6dr2gvpUPJpKgHB4XbMufMsPotRE3g0XH2GwVVCkN2w6SON+Q==}
+    engines: {node: ^18.19.0 || >=20.6.0}
+    peerDependencies:
+      '@opentelemetry/api': ^1.3.0
+
+  '@opentelemetry/exporter-logs-otlp-proto@0.221.0':
+    resolution: {integrity: sha512-AH6EY+47gXFaWYgG3hfeOneGiE9xIZGtDBk+9g0sM8NZWzsQhhmqPbQQXJzS7pyCh5jRRr2nYNXVrkCmoojRvQ==}
+    engines: {node: ^18.19.0 || >=20.6.0}
+    peerDependencies:
+      '@opentelemetry/api': ^1.3.0
+
+  '@opentelemetry/exporter-metrics-otlp-grpc@0.221.0':
+    resolution: {integrity: sha512-KOgCtO15FC6C1T/xOqBcr7EyUs7B+7yomGNb5Y97d3s38rPbCCk5sewkmE2b0/itOkQ/PptX8CLlD+kn2mEtTg==}
+    engines: {node: ^18.19.0 || >=20.6.0}
+    peerDependencies:
+      '@opentelemetry/api': ^1.3.0
+
+  '@opentelemetry/exporter-metrics-otlp-http@0.221.0':
+    resolution: {integrity: sha512-sRfCKbOzgy8xZQV2as0RzIZlnCmCseCKZGLfRcrpo2CBngJDr+rPtX0zkG0+oUCV5kfQPUoW3W3C96Ag3Y/Clg==}
+    engines: {node: ^18.19.0 || >=20.6.0}
+    peerDependencies:
+      '@opentelemetry/api': ^1.3.0
+
+  '@opentelemetry/exporter-metrics-otlp-proto@0.221.0':
+    resolution: {integrity: sha512-YMF4LveY2I3yhw61rn6nmC9FE8U24IZHPeKU1Duc5+sbwjMd8FwZAwba318ImdThCg/HuVQvhm2y6bfgNPnfYg==}
+    engines: {node: ^18.19.0 || >=20.6.0}
+    peerDependencies:
+      '@opentelemetry/api': ^1.3.0
+
+  '@opentelemetry/exporter-prometheus@0.221.0':
+    resolution: {integrity: sha512-kW79a20qWESIuAdDrxzg9WKM98twV/NBWBFRAH57ap/+ssZhiCo0hckzKT0zpuwR/gSHrFAQhJL0bYDrnEM34g==}
+    engines: {node: ^18.19.0 || >=20.6.0}
+    peerDependencies:
+      '@opentelemetry/api': ^1.3.0
+
+  '@opentelemetry/exporter-trace-otlp-grpc@0.221.0':
+    resolution: {integrity: sha512-zXminlZedtq9LvOW64CnNkOqk15zV75k8JgtdTuWFge6+jk2m4GmAUm6L2eIiG1o2a2bZxXw2PDrszm+bps0IA==}
+    engines: {node: ^18.19.0 || >=20.6.0}
+    peerDependencies:
+      '@opentelemetry/api': ^1.3.0
+
+  '@opentelemetry/exporter-trace-otlp-http@0.221.0':
+    resolution: {integrity: sha512-AySXiKoC+meiWm6zdVj5T2LnPDZuatveBby1cMOeQteIWsYXAUxs8Sru13G2pVSPrUXz6vF+og7QVBX6GdC/oQ==}
+    engines: {node: ^18.19.0 || >=20.6.0}
+    peerDependencies:
+      '@opentelemetry/api': ^1.3.0
+
+  '@opentelemetry/exporter-trace-otlp-proto@0.221.0':
+    resolution: {integrity: sha512-Z9i2T7vgZbWe9rSLYxXVIbeW+XyzUq4rZanW3ZyVNwVDqCsh0EJKUgBWWQ0CZfeuUA+RQPzKgJQHMuWAUnKqXw==}
+    engines: {node: ^18.19.0 || >=20.6.0}
+    peerDependencies:
+      '@opentelemetry/api': ^1.3.0
+
+  '@opentelemetry/exporter-zipkin@2.10.0':
+    resolution: {integrity: sha512-7gsvgf0UDoJ4l9ObrwBmz5G/ZogiPk+lq+g5GpLp24YQF/vPM/BSsnOfcLnfinast5ASUgLo78uSC/ObjlnXgg==}
+    engines: {node: ^18.19.0 || >=20.6.0}
+    peerDependencies:
+      '@opentelemetry/api': ^1.0.0
+
+  '@opentelemetry/instrumentation-http@0.221.0':
+    resolution: {integrity: sha512-oIP91CPIANuYr09tGFElPFKAh6JUar+awJf1kBRYlaeo9b0gDwZHEB2zBfFlvdNFHm0wAVutMZODVi5smKT30g==}
+    engines: {node: ^18.19.0 || >=20.6.0}
+    peerDependencies:
+      '@opentelemetry/api': ^1.3.0
+
+  '@opentelemetry/instrumentation@0.221.0':
+    resolution: {integrity: sha512-cCk80Z/iRDf/5gfsKMB4f74LqVA5yKETB/9ojPzVW/6/f70iu89nJvGxsFCxx4XfSohaOofkU19kiYm84AiAlw==}
+    engines: {node: ^18.19.0 || >=20.6.0}
+    peerDependencies:
+      '@opentelemetry/api': ^1.3.0
+
+  '@opentelemetry/otlp-exporter-base@0.221.0':
+    resolution: {integrity: sha512-UFPIq80OH3Ns/oPFHRj14d4DTOxUo+MUFU8hUiCq5jTqFhdeJnfVSANHT+xp92409cA+oxzvlZCe6NM1wvCuBA==}
+    engines: {node: ^18.19.0 || >=20.6.0}
+    peerDependencies:
+      '@opentelemetry/api': ^1.3.0
+
+  '@opentelemetry/otlp-grpc-exporter-base@0.221.0':
+    resolution: {integrity: sha512-rQDmNgyiGCTrescjnzH2ntVyUKVIq6I2UjuK8+stT/Xg0ZOT71FVJqwjFdspQl6Yol/Yqsut9bDo+ame8oTmDQ==}
+    engines: {node: ^18.19.0 || >=20.6.0}
+    peerDependencies:
+      '@opentelemetry/api': ^1.3.0
+
+  '@opentelemetry/otlp-transformer@0.221.0':
+    resolution: {integrity: sha512-lg6lkOU08Az23jVcn/0Els9HP+V8PnR4Km6p0KgpTggS0n/WuhnmY64rSh83Of9iR9nD+dpWr6adlcX8KzAwjg==}
+    engines: {node: ^18.19.0 || >=20.6.0}
+    peerDependencies:
+      '@opentelemetry/api': ^1.3.0
+
+  '@opentelemetry/propagator-b3@2.10.0':
+    resolution: {integrity: sha512-GnA5B24H+1w8BO21J0q+IWNB0z1v+AGbcquTdIt/dufibhnhgxaA8YKvz0I3akRZhB1jHT+/tlzK+qlAjEDybQ==}
+    engines: {node: ^18.19.0 || >=20.6.0}
+    peerDependencies:
+      '@opentelemetry/api': '>=1.0.0 <1.10.0'
+
+  '@opentelemetry/propagator-jaeger@2.10.0':
+    resolution: {integrity: sha512-yw/IX8DL470dSMZJoE82ScfYGp7JWZ/G8kFJo35ZILUVTB2jFPTOaioN+8s09pH0RHsWNhweVZb+ZnjJJpCChg==}
+    engines: {node: ^18.19.0 || >=20.6.0}
+    peerDependencies:
+      '@opentelemetry/api': '>=1.0.0 <1.10.0'
+
+  '@opentelemetry/resources@2.10.0':
+    resolution: {integrity: sha512-q6MMm2zhggzsHVNbabYwut+a6nbuQQe3URUoxaojM/8K1IBfwwPzvxIjNi2/lI1TFe+fMHMW9MWhrtDLEXEnkA==}
+    engines: {node: ^18.19.0 || >=20.6.0}
+    peerDependencies:
+      '@opentelemetry/api': '>=1.3.0 <1.10.0'
+
+  '@opentelemetry/sdk-logs@0.221.0':
+    resolution: {integrity: sha512-FaDcazjyMp7TZZZAsqbo4IkovP0UegoCu0EBkiNt+qCqvUf7FPAsfcrZ3+ZEkKgXZ/jHafop+JoGPDk3A0SmLg==}
+    engines: {node: ^18.19.0 || >=20.6.0}
+    peerDependencies:
+      '@opentelemetry/api': '>=1.4.0 <1.10.0'
+
+  '@opentelemetry/sdk-metrics@2.10.0':
+    resolution: {integrity: sha512-t6r1VSvXNtSDnPXU1FbZeetJb7yyovHmgu0wRSoftxtE0g2rSNhQZQUy69sRUCL+iioJpX8SN/S6wq6ZtvLySQ==}
+    engines: {node: ^18.19.0 || >=20.6.0}
+    peerDependencies:
+      '@opentelemetry/api': '>=1.9.0 <1.10.0'
+
+  '@opentelemetry/sdk-node@0.221.0':
+    resolution: {integrity: sha512-UbYuvtBrQQB5Prsh9KOKy4kxzexFxfMs5MkteHeWMoswsEB7kiNhyUVkAOFW/qsEzNHtrkgyghrD2ilZJa+5YA==}
+    engines: {node: ^18.19.0 || >=20.6.0}
+    peerDependencies:
+      '@opentelemetry/api': '>=1.3.0 <1.10.0'
+
+  '@opentelemetry/sdk-trace-base@2.10.0':
+    resolution: {integrity: sha512-GuYQQT7QD2EeO8lcZLRQzcbOyhqAzL+6WWTKTU9mSUBYBazkEDl+VrQcXQhbB08OWM9anD1aHleVadzulpOaUQ==}
+    engines: {node: ^18.19.0 || >=20.6.0}
+    peerDependencies:
+      '@opentelemetry/api': '>=1.3.0 <1.10.0'
+
+  '@opentelemetry/sdk-trace-node@2.10.0':
+    resolution: {integrity: sha512-GZK/G6oZyBLGlH1pUgeDch7D91KoHd2uotUGIkWCPi9GI5T9X0p4L7nNAMDR1BQjkRYoDqo+ddfVx9t5Uhys+Q==}
+    engines: {node: ^18.19.0 || >=20.6.0}
+    peerDependencies:
+      '@opentelemetry/api': '>=1.0.0 <1.10.0'
+
+  '@opentelemetry/sdk-trace@2.10.0':
+    resolution: {integrity: sha512-MfQGq3GRmTh5fM/y+OjaO0vj6+luCB1XO2gfXCalKCfgKw0eHL++sm75DNweC6ohlp+aFvACqeE0fYayqdRaoQ==}
+    engines: {node: ^18.19.0 || >=20.6.0}
+    peerDependencies:
+      '@opentelemetry/api': '>=1.3.0 <1.10.0'
+
+  '@opentelemetry/semantic-conventions@1.43.0':
+    resolution: {integrity: sha512-eSYWTm620tTk45EKSedaUL8MFYI8hW164hIXsgIHyxu3VobUB3fFCu5t0hQby6OoWRPsG1KkKUG2M5UadiLiVg==}
+    engines: {node: '>=14'}
 
   '@oslojs/encoding@1.1.0':
     resolution: {integrity: sha512-70wQhgYmndg4GCPxPPxPGevRKqTIJ2Nh4OkiMWmDAVYsTQ+Ta7Sq+rPevXyXGdzr30/qZBnyOalCszoMxlyldQ==}
@@ -5407,6 +5636,9 @@ packages:
     resolution: {integrity: sha512-7wNWV7SugHpcMA7uzEawJNpE0GrasXM7a9E+1+Wm6NxVuDClESac/AKt+G7jMZNUz5vBLWqKlqVV7Sv7AtUr6Q==}
     engines: {node: '>=18.0.0'}
 
+  '@socket.io/component-emitter@3.1.2':
+    resolution: {integrity: sha512-9BCxFwvbGg/RsZK9tjXd8s4UcwR0MWeFQ1XEKIQVVvAGJyINdrqKMcTRyLoK8Rse1GjzLV9cwjWV1olXRWEXVA==}
+
   '@stablelib/base64@1.0.1':
     resolution: {integrity: sha512-1bnPQqSxSuc3Ii6MhBysoWCg58j97aUjuCSZrGSmDxNqtytIi0k8utUenAwTZN4V5mXXYGsVUI9zeBqy+jBOSQ==}
 
@@ -6066,6 +6298,12 @@ packages:
   '@upsetjs/venn.js@2.0.0':
     resolution: {integrity: sha512-WbBhLrooyePuQ1VZxrJjtLvTc4NVfpOyKx0sKqioq9bX1C1m7Jgykkn8gLrtwumBioXIqam8DLxp88Adbue6Hw==}
 
+  '@upstash/box@0.5.3':
+    resolution: {integrity: sha512-gV2yWK7ayfIUDbakAPFz4fefNC6DmJFsToQAj6vpc8HL3I/ghzf2e5iGfky8kkE7IzppeYXLmMYFoDrjCnmYFA==}
+    engines: {node: '>=18.0.0'}
+    peerDependencies:
+      zod: ^3.25.0 || ^4.0.0
+
   '@vercel/config@0.3.0':
     resolution: {integrity: sha512-Tf5k5y2F478oTiQcU5R8Ntix1UejE6NdduZnI7aa1XXxjCtifX1XdRS/D2uTjiQAwIL3pLa1LSAN80ABbba+TQ==}
     hasBin: true
@@ -6080,6 +6318,9 @@ packages:
 
   '@vercel/routing-utils@6.2.0':
     resolution: {integrity: sha512-YI2cGYZmJKEyGSEgf5Fw5rVuW7X1bTOQ7/pnLRNTFMH3YB3qqP5erCLCJGv2kIvNo1iQAPINHQRJj6ykEdGoPg==}
+
+  '@vercel/sandbox@2.9.2':
+    resolution: {integrity: sha512-tnPtCNL6MZKM9eRYvmyL0geA2Nifq+PSxVXBNhk/lQNeCWgMp/EYzCDOotKEWR/VH+c0Yv9HG4qk0w2I65xnLA==}
 
   '@vitejs/plugin-react@6.0.2':
     resolution: {integrity: sha512-DlSMqo4WhThw4vB8Mpn0Woe9J+Jfq1geJ61AKW0QEgLzGMNwtIMdxbDUzLxcun8W7NbJO0e2Jg/Nxm3cCSVzzg==}
@@ -6641,6 +6882,9 @@ packages:
   async-mutex@0.5.0:
     resolution: {integrity: sha512-1A94B18jkJ3DYq284ohPxoXbfTA5HsQ7/Mf4DEhcyLx3Bz27Rh59iScbB6EPiP+B+joue6YCxcMXSbFC1tZKwA==}
 
+  async-retry@1.3.3:
+    resolution: {integrity: sha512-wfr/jstw9xNi/0teMHrRW7dsz3Lt5ARhYNZ2ewpadnhaIp5mbALhOAP+EAdsC7t4Z6wqsDVv9+W6gm1Dk9mEyw==}
+
   async@3.2.6:
     resolution: {integrity: sha512-htCUDlxyyCLMgaM3xXg0C0LW2xqfuQ6p05pCEIsXuyQ+a1koYKTuBMzRNwmybfLgvJDMd0r1LTn4+E0Ti6C2AA==}
 
@@ -6923,6 +7167,9 @@ packages:
   buffer-from@1.1.2:
     resolution: {integrity: sha512-E+XQCRwSbaaiChtv6k6Dwgc+bx+Bs6vuKJHHl5kox/BaKbhiXzqQOwK4cO22yElGp2OCmjwVhT3HmxgyPGnJfQ==}
 
+  buffer@5.6.0:
+    resolution: {integrity: sha512-/gDYp/UtU0eA1ys8bOs9J6a+E/KWIY+DZ+Q2WESNUA0jFRsJOc0SNUO6xJ5SGA1xueg3NL65W6s+NY5l9cunuw==}
+
   buffer@5.7.1:
     resolution: {integrity: sha512-EHcyIPBQ4BSGlvjB16k5KgAJ27CIsHY/2JBmCRReo48y9rQ3MaUzWX3KVlBa4U7MyX02HdVj0K7C3WaB3ju7FQ==}
 
@@ -6947,6 +7194,10 @@ packages:
 
   bun-types@1.3.14:
     resolution: {integrity: sha512-4N0ig0fEomHt5R0KCFWjovxow98rIoRwKolrYdCcknNwMekCXRnWEUvgu5soYV8QXtVsrUD8B95MBOZGPvr6KQ==}
+
+  busboy@1.6.0:
+    resolution: {integrity: sha512-8SFQbg/0hQ9xy3UNTB0YEnsNBbWfhf7RtnzpL7TkBiTBRfrQ9Fxcnz7VJsleJpyp6rVLvXiuORqjlHi5q+PYuA==}
+    engines: {node: '>=10.16.0'}
 
   bytes@3.1.2:
     resolution: {integrity: sha512-/Nf7TyzTx6S3yRJObOAV7956r8cr2+Oj8AC5dt8wSP3BQAoeX58NoHyCU8P8zGkNXStjTSi6fzO6F0pBdcYbEg==}
@@ -7084,6 +7335,9 @@ packages:
     resolution: {integrity: sha512-77PSwercCZU2Fc4sX94eF8k8Pxte6JAwL4/ICZLFjJLqegs7kCuAsqqj/70NQF6TvDpgFjkubQB2FW2ZZddvQg==}
     engines: {node: '>=8'}
 
+  cjs-module-lexer@2.2.1:
+    resolution: {integrity: sha512-Ca8swihM+/4yKecYHY52kgJd300hi2lADU/a1RxNTRe+RJ9jvqQlESpbz9DnG9mowez8qwXHB8qYdIUw9e+F5Q==}
+
   class-variance-authority@0.7.1:
     resolution: {integrity: sha512-Ka+9Trutv7G8M6WT6SeiRWz792K5qEqIGEGzXKhAE6xOWAY6pPH8U+9IY3oCMv6kqTmLsv7Xh/2w2RigkePMsg==}
 
@@ -7217,6 +7471,9 @@ packages:
   compare-version@0.1.2:
     resolution: {integrity: sha512-pJDh5/4wrEnXX/VWRZvruAGHkzKdr46z11OlTPN+VrATlWWhSKewNCJ1futCO5C7eJB3nPMFZA1LeYtcFboZ2A==}
     engines: {node: '>=0.10.0'}
+
+  compare-versions@6.1.1:
+    resolution: {integrity: sha512-4hm4VPpIecmlg59CHXnRDnqGplJFrbLG4aFEl5vl6cK1u76ws3LLvX7ikFnTDl5vo39sjWD6AaDPYodJp/NNHg==}
 
   compress-commons@6.0.2:
     resolution: {integrity: sha512-6FqVXeETqWPoGcfzrXb37E50NP0LXT8kAMu5ooZayhWWdgEY4lBEEcbQNXtkuKQsGduxiIcI4gOTsxTmuq/bSg==}
@@ -7685,6 +7942,9 @@ packages:
   dnssd-advertise@1.1.4:
     resolution: {integrity: sha512-AmGyK9WpNf06WeP5TjHZq/wNzP76OuEeaiTlKr9E/EEelYLczywUKoqRz+DPRq/ErssjT4lU+/W7wzJW+7K/ZA==}
 
+  dockerfile-ast@0.7.1:
+    resolution: {integrity: sha512-oX/A4I0EhSkGqrFv0YuvPkBUSYp1XiY8O8zAKc8Djglx8ocz+JfOr8gP0ryRMC2myqvDLagmnZaU9ot1vG2ijw==}
+
   dom-accessibility-api@0.5.16:
     resolution: {integrity: sha512-X7BJ2yElsnOJ30pZF4uIIDfBEVgF4XEBxL9Bxhy6dnrm5hkzqmsWHGTiHqRiITNhMyFLyAiWndIJP7Z1NTteDg==}
 
@@ -7884,6 +8144,10 @@ packages:
   duplexer2@0.1.4:
     resolution: {integrity: sha512-asLFVfWWtJ90ZyOUHMqk7/S2w2guQKxUI2itj3d92ADHhxUSbCMGi1f1cBcJ7xM1To+pE/Khbwo1yuNbMEPKeA==}
 
+  e2b@2.46.1:
+    resolution: {integrity: sha512-OqYovS2oFrt4mk737CgfW/RoMadBYK84l5qjKpvbEoOB9KKxaZIXm7YUwOKSRTlijrrwDRX7oZlyPoVXiCpyTw==}
+    engines: {node: '>=20.18.1 <21 || >=22'}
+
   eastasianwidth@0.2.0:
     resolution: {integrity: sha512-I88TYZWc9XiYHRQ4/3c5rjjfgkjhLyW2luGIheGERbNQ6OY7yTybanSpDXZa8y7VUP9YmDcYa+eyq4ca7iLqWA==}
 
@@ -7965,6 +8229,13 @@ packages:
   end-of-stream@1.4.5:
     resolution: {integrity: sha512-ooEGc6HP26xXq/N+GCGOT0JKCLDGrq2bQUZrQ7gyrJiZANJ/8YDTxTpQBXGMn+WbIQXNVpyWymm7KYVICQnyOg==}
 
+  engine.io-client@6.6.6:
+    resolution: {integrity: sha512-iY6QdftLQ9pyiPoX082bpf/u1UewnOaJrtJIF9T0++QB34lZrj0uP+Q/bj8AlUsAxqhnkTV2BS8SBZSxOmoV5Q==}
+
+  engine.io-parser@5.2.3:
+    resolution: {integrity: sha512-HqD3yTBfnBxIrbnM1DoD6Pcq8NECnh8d4As1Qgh0z5Gg3jRRIqijury0CL3ghu/edArpUYiYqQiDUQBIs4np3Q==}
+    engines: {node: '>=10.0.0'}
+
   enhanced-resolve@5.22.1:
     resolution: {integrity: sha512-6QEuw3zoX1SJQc7b87aBXke/no+mG2bTBgw29gWMQonLmpEkWoCAVkl+M49e48AZlWzxiDzDZzYdp6kobcyLww==}
     engines: {node: '>=10.13.0'}
@@ -8005,6 +8276,9 @@ packages:
 
   es-module-lexer@2.1.0:
     resolution: {integrity: sha512-n27zTYMjYu1aj4MjCWzSP7G9r75utsaoc8m61weK+W8JMBGGQybd43GstCXZ3WNmSFtGT9wi59qQTW6mhTR5LQ==}
+
+  es-module-lexer@2.3.2:
+    resolution: {integrity: sha512-poHGpORABojJJucnV9KbOavETW8lBVnphkW77ER5/BQ5Fz7oXSoCNek7IH3vR5nRjdsEz926ibFYX8KtLQmdyw==}
 
   es-object-atoms@1.1.2:
     resolution: {integrity: sha512-HWcBoN6NileqtSydK2FqHbS/LoDd2pqrnQHLyJzBj4kOp/ky2MWMN694xOfkK8/SnUsW2DH7EfyVlydKCsm1Zw==}
@@ -8120,6 +8394,10 @@ packages:
   expand-template@2.0.3:
     resolution: {integrity: sha512-XYfuKMvj4O35f/pOXLObndIRvyQ+/+6AhODh+OKWj9S9498pHHn/IMszH+gt0fBCRWMNfk1ZSp5x3AifmnI2vg==}
     engines: {node: '>=6'}
+
+  expand-tilde@2.0.2:
+    resolution: {integrity: sha512-A5EmesHW6rfnZ9ysHQjPdJRni0SRar0tjtG5MNtm9n5TUvsYU8oozprtRD4AqHxcZWWlVuAmQo2nWKfN9oyjTw==}
+    engines: {node: '>=0.10.0'}
 
   expect-type@1.4.0:
     resolution: {integrity: sha512-KfYbmpRm0VbLjEvVa9yGwCi9GI34xvi7A/HXYWQO65CSD2u3MczUJSuwXKFIxlGsgBQizV9q5J9NHj4VG0n+pA==}
@@ -8646,6 +8924,9 @@ packages:
     resolution: {integrity: sha512-buewHzMvYL29jdeQTVILecSaZKnt/RJWjoZCF5OW60Z67/GmSLBkOFM7qh1PI3zFNtJbaZL5eQu1vLfazOwj4g==}
     engines: {node: '>=12.20.0'}
 
+  forwarded-parse@2.1.2:
+    resolution: {integrity: sha512-alTFZZQDKMporBH77856pXgzhEzaUVmLCDk+egLgIgHst3Tpndzz8MnKe+GzRJRfvVdn69HhpW7cmXzvtLvJAw==}
+
   forwarded@0.2.0:
     resolution: {integrity: sha512-buRG0fpBtRHSTCOASe6hD258tEubFoRLb4ZNA6NxMVHNw2gOcwHo9wyablzMzOA5z9xA9L1KNjk/Nt6MT9aYow==}
     engines: {node: '>= 0.6'}
@@ -8937,6 +9218,10 @@ packages:
   hoist-non-react-statics@3.3.2:
     resolution: {integrity: sha512-/gGivxi8JPKWNm/W0jSmzcMPpfpPLc3dY/6GxhX2hQ9iGj3aDfklV4ET7NjKpSinLpJ5vafa9iiGIEZg10SfBw==}
 
+  homedir-polyfill@1.0.3:
+    resolution: {integrity: sha512-eSmmWE5bZTK2Nou4g0AI3zZ9rswp7GRKoKXS1BLUkvPviOqs4YTN1djQIqrXy9k5gEtdLPy86JjRwsNM9tnDcA==}
+    engines: {node: '>=0.10.0'}
+
   hono@4.12.27:
     resolution: {integrity: sha512-1yrb/+w6HWQJrUCLkJ2IF5jNIPvvFkblV5RNOYl6bV+OA6p9GLcMpHFFGTosSvHvcAUibuUukRqhlYI4z32C7Q==}
     engines: {node: '>=16.9.0'}
@@ -9030,6 +9315,10 @@ packages:
 
   immediate@3.0.6:
     resolution: {integrity: sha512-XXOFtyqDjNDAQxVfYxuF7g9Il/IbWmmlQg2MYKOH8ExIT1qg6xc4zyS3HaEEATgs1btfzxq15ciUiY7gjSXRGQ==}
+
+  import-in-the-middle@3.3.3:
+    resolution: {integrity: sha512-AiohS3H80sXO6owEltjGX+glb7qXaDhBoJb9XcQVH4UI207xu/bDLUcadVKp7Qe576reg9yr/PXZjV5qx8gfbA==}
+    engines: {node: '>=18'}
 
   import-meta-resolve@4.2.0:
     resolution: {integrity: sha512-Iqv2fzaTQN28s/FwZAoFq0ZSs/7hMAHJVX+w8PZl3cY19Pxk6jFFalxQoIfW2826i/fDLXv8IiEZRIT0lDuWcg==}
@@ -9236,6 +9525,11 @@ packages:
     resolution: {integrity: sha512-FFUtZMpoZ8RqHS3XeXEmHWLA4thH+ZxCv2lOiPIn1Xc7CxrqhWzNSDzD+/chS/zbYezmiwWLdQC09JdQKmthOw==}
     engines: {node: '>=20'}
 
+  isomorphic-ws@5.0.0:
+    resolution: {integrity: sha512-muId7Zzn9ywDsyXgTIafTry2sV3nySZeUDe6YedVd1Hvuuep5AsIlqK+XefWpYTyJG5e503F2xIuT2lcU6rCSw==}
+    peerDependencies:
+      ws: '*'
+
   isomorphic.js@0.2.5:
     resolution: {integrity: sha512-PIeMbHqMt4DnUP3MA/Flc0HElYjMXArsw1qwJZcm9sqR8mq3l8NYizFMty0pWwE/tzIGH3EKK5+jes5mAr85yw==}
 
@@ -9366,6 +9660,9 @@ packages:
 
   jsonfile@6.2.1:
     resolution: {integrity: sha512-zwOTdL3rFQ/lRdBnntKVOX6k5cKJwEc1HdilT71BWEu7J41gXIB2MRp+vxduPSwZJPWBxEzv4yH1wYLJGUHX4Q==}
+
+  jsonlines@0.1.1:
+    resolution: {integrity: sha512-ekDrAGso79Cvf+dtm+mL8OBI2bmAOt3gssYs833De/C9NmIpWDWyUO4zPgB5x2/OhY366dkhgfPMYfwZF7yOZA==}
 
   jszip@3.10.1:
     resolution: {integrity: sha512-xXDvecyTpGLrqFrvkrUSoxxfJI5AH7U8zxxtVclpsUtMCq4JQ290LY8AW5c7Ggnr/Y/oK+bQMbqK2qmtk3pN4g==}
@@ -10220,6 +10517,9 @@ packages:
     resolution: {integrity: sha512-t9VmxaqrmANnEOBhpSDI6HD192Ge48k8vmWqQQL7hSFEqHEYwZbbsu49+aKLWZeRvFs3j1pMhXOqqF4kPlvjkQ==}
     engines: {node: '>=18.0.0'}
 
+  module-details-from-path@1.0.4:
+    resolution: {integrity: sha512-EGWKgxALGMgzvxYF1UyGTy0HXX/2vHLkw6+NvDKW2jypWbHpjQuj4UMcqQWXHERJhVGKikolT06G3bcKe4fi7w==}
+
   mongodb-connection-string-url@3.0.2:
     resolution: {integrity: sha512-rMO7CGo/9BFwyZABcKAWL8UJwH/Kc2x0g72uhDWzG48URRax5TCIcJ7Rc3RZqffZzO/Gwff/jyKwCU9TN8gehA==}
 
@@ -10572,6 +10872,12 @@ packages:
       zod:
         optional: true
 
+  openapi-fetch@0.14.1:
+    resolution: {integrity: sha512-l7RarRHxlEZYjMLd/PR0slfMVse2/vvIAGm75/F7J6MlQ8/b9uUQmUF2kCPrQhJqMXSxmYWObVgeYXbFYzZR+A==}
+
+  openapi-typescript-helpers@0.0.15:
+    resolution: {integrity: sha512-opyTPaunsklCBpTK8JGef6mfPhLSnyy5a0IN9vKtx3+4aExf+KxEqYwIy3hqkedXIB97u357uLMJsOnm3GVjsw==}
+
   ora@3.4.0:
     resolution: {integrity: sha512-eNwHudNbO1folBP3JsZ19v9azXWtQZjICdr3Q0TDPIaeBQ3mXLrh54wM+er0+hSp+dWKf+Z8KM58CYzEyIYxYg==}
     engines: {node: '>=6'}
@@ -10579,6 +10885,10 @@ packages:
   ora@9.4.0:
     resolution: {integrity: sha512-84cglkRILFxdtA8hAvLNdMrtBpPNBTrQ9/ulg0FA7xLMnD6mifv+enAIeRmvtv+WgdCE+LPGOfQmtJRrVaIVhQ==}
     engines: {node: '>=20'}
+
+  os-paths@4.4.0:
+    resolution: {integrity: sha512-wrAwOeXp1RRMFfQY8Sy7VaGVmPocaLwSFOYCGKSyo8qmJ+/yaafCl5BCA1IQZWqFSRBrKDYFeR9d/VyQzfH/jg==}
+    engines: {node: '>= 6.0'}
 
   outvariant@1.4.3:
     resolution: {integrity: sha512-+Sl2UErvtsoajRDKCE5/dBz4DIvHXQQnAxtQTF04OJxY0+DyZXSo5P5Bb7XYWOh81syohlYL24hbDwxedPUJCA==}
@@ -10686,6 +10996,10 @@ packages:
   parse-ms@4.0.0:
     resolution: {integrity: sha512-TXfryirbmq34y8QBwgqCVLi+8oA3oWx2eAnSn62ITyEhEYaWRlVZ2DvMM9eZbMs/RfxPu/PK/aBLyGj4IrqMHw==}
     engines: {node: '>=18'}
+
+  parse-passwd@1.0.0:
+    resolution: {integrity: sha512-1Y1A//QUXEZK7YKz+rD9WydcE1+EuPr6ZBgKecAB8tmoW6UFv0NREVJe1p+jRxtThkcbbKkfwIbWJe/IeE6m2Q==}
+    engines: {node: '>=0.10.0'}
 
   parse-png@2.1.0:
     resolution: {integrity: sha512-Nt/a5SfCLiTnQAjx3fHlqp8hRgTL3z7kTQZzvIMS9uCAepnCyjpdEc6M/sz69WqMBdaDBw9sF1F1UaHROYzGkQ==}
@@ -10869,6 +11183,9 @@ packages:
   pkijs@3.4.0:
     resolution: {integrity: sha512-emEcLuomt2j03vxD54giVB4SxTjnsqkU692xZOZXHDVoYyypEm+b3jpiTcc+Cf+myooc+/Ly0z01jqeNHVgJGw==}
     engines: {node: '>=16.0.0'}
+
+  platform@1.3.6:
+    resolution: {integrity: sha512-fnWVljUchTro6RiCFvCXBbNhJc2NijN7oIQxbwsyL0buWJPG85v81ehlHI9fXrJsMNgTofEoWIQeClKpgxFLrg==}
 
   playwright-core@1.60.0:
     resolution: {integrity: sha512-9bW6zvX/m0lEbgTKJ6YppOKx8H3VOPBMOCFh2irXFOT4BbHgrx5hPjwJYLT40Lu+4qtD36qKc/Hn56StUW57IA==}
@@ -11474,6 +11791,10 @@ packages:
     resolution: {integrity: sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw==}
     engines: {node: '>=0.10.0'}
 
+  require-in-the-middle@8.0.1:
+    resolution: {integrity: sha512-QT7FVMXfWOYFbeRBF6nu+I6tr2Tf3u0q8RIEjNob/heKY/nh7drD/k7eeMFmSQgnTtCzLDcCu/XEnpW2wk4xCQ==}
+    engines: {node: '>=9.3.0 || >=8.10.0 <9.0.0'}
+
   resedit@1.7.2:
     resolution: {integrity: sha512-vHjcY2MlAITJhC0eRD/Vv8Vlgmu9Sd3LX9zZvtGzU5ZImdTN3+d6e/4mnTyV8vEbyf1sgNIrWxhWlrys52OkEA==}
     engines: {node: '>=12', npm: '>=6'}
@@ -11833,6 +12154,14 @@ packages:
     resolution: {integrity: sha512-aqVvWoyO21L23mb+drl4RmMXbf6N7FdHjAhTRA9ZBL7apWBgfWC16KjrASI+1p9GAroljyMHj6fK67i0UiTNvQ==}
     engines: {node: '>= 18'}
 
+  socket.io-client@4.8.3:
+    resolution: {integrity: sha512-uP0bpjWrjQmUt5DTHq9RuoCBdFJF10cdX9X+a368j/Ft0wmaVgxlrjvK3kjvgCODOMMOz9lcaRzxmso0bTWZ/g==}
+    engines: {node: '>=10.0.0'}
+
+  socket.io-parser@4.2.7:
+    resolution: {integrity: sha512-IH/iSeO9T6gz1KkFleGDWkG9N3dl4jXVYUtMhIqH10Md0ttMer8nUNWiP1DKuNrybD2xBrixLJdCC9J6ECoYkg==}
+    engines: {node: '>=10.0.0'}
+
   socks-proxy-agent@8.0.5:
     resolution: {integrity: sha512-HehCEsotFqbPW9sJ8WVYB6UbmIMv7kUUORIF2Nncq4VQvBfNBLibW9YZR5dlYCSUhwcD628pRllm7n+E+YTzJw==}
     engines: {node: '>= 14'}
@@ -11931,12 +12260,19 @@ packages:
     resolution: {integrity: sha512-eCPu1qRxPVkl5605OTWF8Wz40b4Mf45NY5LQmVPQ599knfs5QhASUm9GbJ5BDMDOXgrnh0wyEdvzmL//YMlw0A==}
     engines: {node: '>=18'}
 
+  stream-browserify@3.0.0:
+    resolution: {integrity: sha512-H73RAHsVBapbim0tU2JwwOiXUj+fikfiaoYAKHF3VJfA0pe2BCzkhAHBlLG6REzE+2WNZcxOXjK7lkso+9euLA==}
+
   stream-buffers@2.2.0:
     resolution: {integrity: sha512-uyQK/mx5QjHun80FLJTfaWE7JtwfRMKBLkMne6udYOmvH0CawotVa7TfgYHzAnpphn4+TweIx1QKMnRIbipmUg==}
     engines: {node: '>= 0.10.0'}
 
   stream-parser@0.3.1:
     resolution: {integrity: sha512-bJ/HgKq41nlKvlhccD5kaCr/P+Hu0wPNKPJOH7en+YrJu/9EgqUF+88w5Jb6KNcjOFMhfX4B2asfeAtIGuHObQ==}
+
+  streamsearch@1.1.0:
+    resolution: {integrity: sha512-Mcc5wHehp9aXz1ax6bZUyY5afg9u2rv5cqQI3mRrYkGC8rW2hM02jWuwjtL++LS5qinSyhj2QfLyNsuc+VsExg==}
+    engines: {node: '>=10.0.0'}
 
   streamx@2.28.1:
     resolution: {integrity: sha512-zEzXb0s5Cds7tqMH6rhZ05lcJydCWiQPEwiNngVqzsxCc962vLY4Uw+mW7od8kDH258k2Uz/JrOkdIAAhSh9VA==}
@@ -12086,12 +12422,11 @@ packages:
     resolution: {integrity: sha512-ujeqbceABgwMZxEJnk2HDY2DlnUZ+9oEcb1KzTVfYHio0UE6dG71n60d8D2I4qNvleWrrXpmjpt7vZeF1LnMZQ==}
     engines: {node: '>=6'}
 
+  tar-stream@3.1.7:
+    resolution: {integrity: sha512-qJj60CXt7IU1Ffyc3NJMjh6EkuCFej46zUqJ4J7pqYlThyd9bO0XBTmcOIhSzZJVWfsLks0+nle/j538YAW9RQ==}
+
   tar-stream@3.2.1:
     resolution: {integrity: sha512-nqsEO8zLZJvrOMdEwkA0QdCLFbetHMn95Zqu4fKwX+hkaTWJPZZOrxx/PwtxoK0MMGQmBQNRW3CPs8IFYQz4cQ==}
-
-  tar@7.5.16:
-    resolution: {integrity: sha512-56adEpPMouktRlBLXiaYFFzZ/3+JXa8P9n7WbR+ibIjtviN55mEaOkiysCnPnWm+7kkui1Dn8J9l+g6zV8731w==}
-    engines: {node: '>=18'}
 
   tar@7.5.22:
     resolution: {integrity: sha512-MFO/QzvtAOmJbkhOaCTvbGcFN9L9b+JunIsDwaKljSOdcLMea3NJ1k9Usz/rjdfSXTq4dfzfeS7W4p4YOAAHeA==}
@@ -12315,6 +12650,14 @@ packages:
   undici@7.27.1:
     resolution: {integrity: sha512-UDdpiex+mzigiyrXrGbiUaF4HzTNhKbh2vRNFaTMzcqmLIPrZxaCtwo/1TMSuWoM1Xz3WiTo9KdgI3kRqYzJGg==}
     engines: {node: '>=20.18.1'}
+
+  undici@7.29.0:
+    resolution: {integrity: sha512-IDxfleLmmbSskfWSUATiN1nfn2rDuvnMOqb5CWR92iIfojA0Ud+ulOAAEQ57LPr9rWmsreUyf5lwyao+7GNNVw==}
+    engines: {node: '>=20.18.1'}
+
+  undici@8.10.0:
+    resolution: {integrity: sha512-HvltHd7avK13QIw/oLe4qoOLyoVSoafqJ2jYOrtMRBkbYT31eiBQ8O0ehRKZiEZCMEyLFQNIADpgCWC5fALvYQ==}
+    engines: {node: '>=22.19.0'}
 
   undici@8.9.0:
     resolution: {integrity: sha512-aWZpUj7XoGonMClx4gdDRfgBjqeA+F473aDmROQQbM9n6PRfK/u1q/a0X4wMTgcHfT8H6fpbt98PFuDUwFg2YA==}
@@ -12945,6 +13288,14 @@ packages:
     resolution: {integrity: sha512-kCz5k7J7XbJtjABOvkc5lJmkiDh8VhjVCGNiqdKCscmVpdVUpEAyXv1xmCLkQJ5dsHqx3IPO4XW+NTDhU/fatA==}
     engines: {node: '>=10.0.0'}
 
+  xdg-app-paths@5.1.0:
+    resolution: {integrity: sha512-RAQ3WkPf4KTU1A8RtFx3gWywzVKe00tfOPFfl2NDGqbIFENQO4kqAJp7mhQjNj/33W5x5hiWWUdyfPq/5SU3QA==}
+    engines: {node: '>=6'}
+
+  xdg-portable@7.3.0:
+    resolution: {integrity: sha512-sqMMuL1rc0FmMBOzCpd0yuy9trqF2yTTVe+E9ogwCSWQCdDEtQUwrZPT6AxqtsFGRNxycgncbP/xmOOSPw5ZUw==}
+    engines: {node: '>= 6.0'}
+
   xml-naming@0.1.0:
     resolution: {integrity: sha512-k8KO9hrMyNk6tUWqUfkTEZbezRRpONVOzUTnc97VnCvyj6Tf9lyUR9EDAIeiVLv56jsMcoXEwjW8Kv5yPY52lw==}
     engines: {node: '>=16.0.0'}
@@ -12960,6 +13311,10 @@ packages:
   xmlbuilder@15.1.1:
     resolution: {integrity: sha512-yMqGBqtXyeN1e3TGYvgNgDVZ3j84W4cwkOXQswghol6APgZWaff9lnbvN7MHYJOiXsvGPXtjTYJEiC9J2wv9Eg==}
     engines: {node: '>=8.0'}
+
+  xmlhttprequest-ssl@2.1.2:
+    resolution: {integrity: sha512-TEU+nJVUUnA4CYJFLvK5X9AOeH4KvDvhIfm0vV1GaQRtchnG0hgK5p8hw/xjv8cunWYCsiPCSDzObPyhEwq3KQ==}
+    engines: {node: '>=0.4.0'}
 
   xtend@4.0.2:
     resolution: {integrity: sha512-LKYU1iAXJXUgAXn9URjiu+MWhyUXHsvfp7mcuYm9dSUKK0/CjtrUwFAxD82/mCWbtLsGjFIad0wIsod4zrTAEQ==}
@@ -13586,6 +13941,14 @@ snapshots:
       '@smithy/util-utf8': 2.3.0
       tslib: 2.8.1
 
+  '@aws-sdk/checksums@3.1000.29':
+    dependencies:
+      '@aws-sdk/core': 3.977.9
+      '@aws-sdk/types': 3.974.5
+      '@smithy/core': 3.33.3
+      '@smithy/types': 4.17.2
+      tslib: 2.8.1
+
   '@aws-sdk/client-cognito-identity@3.1062.0':
     dependencies:
       '@aws-crypto/sha256-browser': 5.2.0
@@ -13596,6 +13959,20 @@ snapshots:
       '@smithy/core': 3.33.3
       '@smithy/fetch-http-handler': 5.4.6
       '@smithy/node-http-handler': 4.7.7
+      '@smithy/types': 4.17.2
+      tslib: 2.8.1
+
+  '@aws-sdk/client-s3@3.1121.0':
+    dependencies:
+      '@aws-sdk/checksums': 3.1000.29
+      '@aws-sdk/core': 3.977.9
+      '@aws-sdk/credential-provider-node': 3.972.81
+      '@aws-sdk/middleware-sdk-s3': 3.972.75
+      '@aws-sdk/signature-v4-multi-region': 3.996.46
+      '@aws-sdk/types': 3.974.5
+      '@smithy/core': 3.33.3
+      '@smithy/fetch-http-handler': 5.7.2
+      '@smithy/node-http-handler': 4.11.3
       '@smithy/types': 4.17.2
       tslib: 2.8.1
 
@@ -13844,6 +14221,25 @@ snapshots:
       '@smithy/types': 4.17.2
       tslib: 2.8.1
 
+  '@aws-sdk/lib-storage@3.1121.0(@aws-sdk/client-s3@3.1121.0)':
+    dependencies:
+      '@aws-sdk/client-s3': 3.1121.0
+      '@smithy/core': 3.33.3
+      '@smithy/types': 4.17.2
+      buffer: 5.6.0
+      events: 3.3.0
+      stream-browserify: 3.0.0
+      tslib: 2.8.1
+
+  '@aws-sdk/middleware-sdk-s3@3.972.75':
+    dependencies:
+      '@aws-sdk/core': 3.977.9
+      '@aws-sdk/signature-v4-multi-region': 3.996.46
+      '@aws-sdk/types': 3.974.5
+      '@smithy/core': 3.33.3
+      '@smithy/types': 4.17.2
+      tslib: 2.8.1
+
   '@aws-sdk/nested-clients@3.997.16':
     dependencies:
       '@aws-crypto/sha256-browser': 5.2.0
@@ -13871,7 +14267,7 @@ snapshots:
   '@aws-sdk/signature-v4-multi-region@3.996.31':
     dependencies:
       '@aws-sdk/types': 3.974.5
-      '@smithy/signature-v4': 5.4.6
+      '@smithy/signature-v4': 5.7.3
       '@smithy/types': 4.17.2
       tslib: 2.8.1
 
@@ -14473,11 +14869,11 @@ snapshots:
       ai: 5.0.245(zod@4.4.3)
       devtools-protocol: 0.0.1642743
       fetch-cookie: 3.2.0
-      openai: 4.104.0(ws@8.21.0(bufferutil@4.1.0)(utf-8-validate@6.0.6))(zod@4.4.3)
+      openai: 4.104.0(ws@8.21.3(bufferutil@4.1.0)(utf-8-validate@6.0.6))(zod@4.4.3)
       pino: 9.14.0
       pino-pretty: 13.1.3
       uuid: 11.1.1
-      ws: 8.21.0(bufferutil@4.1.0)(utf-8-validate@6.0.6)
+      ws: 8.21.3(bufferutil@4.1.0)(utf-8-validate@6.0.6)
       zod: 4.4.3
       zod-to-json-schema: 3.25.2(zod@4.4.3)
     optionalDependencies:
@@ -14535,8 +14931,7 @@ snapshots:
   '@bruits/satteri-win32-x64-msvc@0.9.3':
     optional: true
 
-  '@bufbuild/protobuf@2.14.0':
-    optional: true
+  '@bufbuild/protobuf@2.14.0': {}
 
   '@callstack/liquid-glass@0.7.1(react-native@0.85.3(@babel/core@7.29.7)(@react-native/metro-config@0.85.3(@babel/core@7.29.7)(bufferutil@4.1.0)(utf-8-validate@6.0.6))(@types/react@19.2.16)(bufferutil@4.1.0)(react@19.2.3)(utf-8-validate@6.0.6))(react@19.2.3)':
     dependencies:
@@ -14728,6 +15123,71 @@ snapshots:
   '@cloudflare/workers-types@4.20260604.1': {}
 
   '@cloudflare/workers-types@5.20260726.1': {}
+
+  '@connectrpc/connect-web@2.1.2(@bufbuild/protobuf@2.14.0)(@connectrpc/connect@2.1.2(@bufbuild/protobuf@2.14.0))':
+    dependencies:
+      '@bufbuild/protobuf': 2.14.0
+      '@connectrpc/connect': 2.1.2(@bufbuild/protobuf@2.14.0)
+
+  '@connectrpc/connect@2.1.2(@bufbuild/protobuf@2.14.0)':
+    dependencies:
+      '@bufbuild/protobuf': 2.14.0
+
+  '@daytona/analytics-api-client@0.207.0':
+    dependencies:
+      axios: 1.20.0
+    transitivePeerDependencies:
+      - debug
+      - supports-color
+
+  '@daytona/api-client@0.207.0':
+    dependencies:
+      axios: 1.20.0
+    transitivePeerDependencies:
+      - debug
+      - supports-color
+
+  '@daytona/sdk@0.207.0(bufferutil@4.1.0)(utf-8-validate@6.0.6)':
+    dependencies:
+      '@aws-sdk/client-s3': 3.1121.0
+      '@aws-sdk/lib-storage': 3.1121.0(@aws-sdk/client-s3@3.1121.0)
+      '@daytona/analytics-api-client': 0.207.0
+      '@daytona/api-client': 0.207.0
+      '@daytona/toolbox-api-client': 0.207.0
+      '@iarna/toml': 2.2.5
+      '@opentelemetry/api': 1.9.1
+      '@opentelemetry/exporter-trace-otlp-http': 0.221.0(@opentelemetry/api@1.9.1)
+      '@opentelemetry/instrumentation-http': 0.221.0(@opentelemetry/api@1.9.1)
+      '@opentelemetry/otlp-exporter-base': 0.221.0(@opentelemetry/api@1.9.1)
+      '@opentelemetry/resources': 2.10.0(@opentelemetry/api@1.9.1)
+      '@opentelemetry/sdk-node': 0.221.0(@opentelemetry/api@1.9.1)
+      '@opentelemetry/sdk-trace-base': 2.10.0(@opentelemetry/api@1.9.1)
+      '@opentelemetry/semantic-conventions': 1.43.0
+      axios: 1.20.0
+      busboy: 1.6.0
+      dotenv: 17.4.2
+      expand-tilde: 2.0.2
+      fast-glob: 3.3.3
+      form-data: 4.0.6
+      isomorphic-ws: 5.0.0(ws@8.21.3(bufferutil@4.1.0)(utf-8-validate@6.0.6))
+      pathe: 2.0.3
+      shell-quote: 1.8.4
+      socket.io-client: 4.8.3(bufferutil@4.1.0)(utf-8-validate@6.0.6)
+      tar: 7.5.22
+      tslib: 2.8.1
+      ws: 8.21.3(bufferutil@4.1.0)(utf-8-validate@6.0.6)
+    transitivePeerDependencies:
+      - bufferutil
+      - debug
+      - supports-color
+      - utf-8-validate
+
+  '@daytona/toolbox-api-client@0.207.0':
+    dependencies:
+      axios: 1.20.0
+    transitivePeerDependencies:
+      - debug
+      - supports-color
 
   '@distilled.cloud/aws@0.30.2(effect@4.0.0-beta.103(patch_hash=af36b7948b6f9c56623074662b51dade5699880c1a7c71245de73e13c3185fb6))':
     dependencies:
@@ -15352,7 +15812,7 @@ snapshots:
       '@expo/router-server': 56.0.14(@expo/metro-runtime@56.0.15)(expo-constants@56.0.18)(expo-font@56.0.7)(expo-router@56.2.11)(expo-server@56.0.5)(expo@56.0.12)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
       '@expo/schema-utils': 56.0.1
       '@expo/spawn-async': 1.8.0
-      '@expo/ws-tunnel': 2.0.0(ws@8.21.0(bufferutil@4.1.0)(utf-8-validate@6.0.6))
+      '@expo/ws-tunnel': 2.0.0(ws@8.21.3(bufferutil@4.1.0)(utf-8-validate@6.0.6))
       '@expo/xcpretty': 4.4.4
       '@react-native/dev-middleware': 0.85.3(bufferutil@4.1.0)(utf-8-validate@6.0.6)
       accepts: 1.3.8
@@ -15388,7 +15848,7 @@ snapshots:
       terminal-link: 2.1.1
       toqr: 0.1.1
       wrap-ansi: 7.0.0
-      ws: 8.21.0(bufferutil@4.1.0)(utf-8-validate@6.0.6)
+      ws: 8.21.3(bufferutil@4.1.0)(utf-8-validate@6.0.6)
       zod: 3.25.76
     optionalDependencies:
       expo-router: 56.2.11(e1497a99e5bc5be76c1cdb733671f865)
@@ -15428,7 +15888,7 @@ snapshots:
       '@expo/router-server': 56.0.14(@expo/metro-runtime@56.0.15)(expo-constants@56.0.18)(expo-font@56.0.7)(expo-router@56.2.11)(expo-server@56.0.5)(expo@56.0.12)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
       '@expo/schema-utils': 56.0.1
       '@expo/spawn-async': 1.8.0
-      '@expo/ws-tunnel': 2.0.0(ws@8.21.0(bufferutil@4.1.0)(utf-8-validate@6.0.6))
+      '@expo/ws-tunnel': 2.0.0(ws@8.21.3(bufferutil@4.1.0)(utf-8-validate@6.0.6))
       '@expo/xcpretty': 4.4.4
       '@react-native/dev-middleware': 0.85.3(bufferutil@4.1.0)(utf-8-validate@6.0.6)
       accepts: 1.3.8
@@ -15464,7 +15924,7 @@ snapshots:
       terminal-link: 2.1.1
       toqr: 0.1.1
       wrap-ansi: 7.0.0
-      ws: 8.21.0(bufferutil@4.1.0)(utf-8-validate@6.0.6)
+      ws: 8.21.3(bufferutil@4.1.0)(utf-8-validate@6.0.6)
       zod: 3.25.76
     optionalDependencies:
       expo-router: 56.2.11(80beea6a31a5d2003a696c1401258797)
@@ -15871,9 +16331,9 @@ snapshots:
       - '@types/react'
       - '@types/react-dom'
 
-  '@expo/ws-tunnel@2.0.0(ws@8.21.0(bufferutil@4.1.0)(utf-8-validate@6.0.6))':
+  '@expo/ws-tunnel@2.0.0(ws@8.21.3(bufferutil@4.1.0)(utf-8-validate@6.0.6))':
     dependencies:
-      ws: 8.21.0(bufferutil@4.1.0)(utf-8-validate@6.0.6)
+      ws: 8.21.3(bufferutil@4.1.0)(utf-8-validate@6.0.6)
 
   '@expo/xcpretty@4.4.4':
     dependencies:
@@ -15956,7 +16416,7 @@ snapshots:
       google-auth-library: 10.9.1
       p-retry: 4.6.2
       protobufjs: 7.6.5
-      ws: 8.21.0(bufferutil@4.1.0)(utf-8-validate@6.0.6)
+      ws: 8.21.3(bufferutil@4.1.0)(utf-8-validate@6.0.6)
     optionalDependencies:
       '@modelcontextprotocol/sdk': 1.29.0(zod@4.4.3)
     transitivePeerDependencies:
@@ -15968,7 +16428,6 @@ snapshots:
     dependencies:
       '@grpc/proto-loader': 0.8.1
       '@js-sdsl/ordered-map': 4.4.2
-    optional: true
 
   '@grpc/proto-loader@0.8.1':
     dependencies:
@@ -15976,7 +16435,6 @@ snapshots:
       long: 5.3.2
       protobufjs: 7.6.5
       yargs: 17.7.2
-    optional: true
 
   '@hono/node-server@1.19.14(hono@4.12.27)':
     dependencies:
@@ -16195,8 +16653,7 @@ snapshots:
       '@jridgewell/resolve-uri': 3.1.2
       '@jridgewell/sourcemap-codec': 1.5.5
 
-  '@js-sdsl/ordered-map@4.4.2':
-    optional: true
+  '@js-sdsl/ordered-map@4.4.2': {}
 
   '@js-temporal/polyfill@0.5.1':
     dependencies:
@@ -16595,7 +17052,7 @@ snapshots:
       '@huggingface/hub': 2.16.0
       onnxruntime-node: 1.26.0
       progress: 2.0.3
-      tar: 7.5.16
+      tar: 7.5.22
 
   '@mastra/github-signals@0.3.0(@mastra/core@1.63.0(@bufbuild/protobuf@2.14.0)(@grpc/grpc-js@1.14.4)(ai@6.0.266(zod@4.4.3))(bufferutil@4.1.0)(express@5.2.1)(utf-8-validate@6.0.6)(zod@4.4.3))(zod@4.4.3)':
     dependencies:
@@ -16926,9 +17383,241 @@ snapshots:
     dependencies:
       cross-spawn: 7.0.6
 
+  '@opentelemetry/api-logs@0.221.0':
+    dependencies:
+      '@opentelemetry/api': 1.9.1
+
   '@opentelemetry/api@1.9.0': {}
 
   '@opentelemetry/api@1.9.1': {}
+
+  '@opentelemetry/configuration@0.221.0(@opentelemetry/api@1.9.1)':
+    dependencies:
+      '@opentelemetry/api': 1.9.1
+      '@opentelemetry/core': 2.10.0(@opentelemetry/api@1.9.1)
+      yaml: 2.9.0
+
+  '@opentelemetry/context-async-hooks@2.10.0(@opentelemetry/api@1.9.1)':
+    dependencies:
+      '@opentelemetry/api': 1.9.1
+
+  '@opentelemetry/core@2.10.0(@opentelemetry/api@1.9.1)':
+    dependencies:
+      '@opentelemetry/api': 1.9.1
+      '@opentelemetry/semantic-conventions': 1.43.0
+
+  '@opentelemetry/exporter-logs-otlp-grpc@0.221.0(@opentelemetry/api@1.9.1)':
+    dependencies:
+      '@opentelemetry/api': 1.9.1
+      '@opentelemetry/otlp-exporter-base': 0.221.0(@opentelemetry/api@1.9.1)
+      '@opentelemetry/otlp-grpc-exporter-base': 0.221.0(@opentelemetry/api@1.9.1)
+      '@opentelemetry/otlp-transformer': 0.221.0(@opentelemetry/api@1.9.1)
+      '@opentelemetry/sdk-logs': 0.221.0(@opentelemetry/api@1.9.1)
+
+  '@opentelemetry/exporter-logs-otlp-http@0.221.0(@opentelemetry/api@1.9.1)':
+    dependencies:
+      '@opentelemetry/api': 1.9.1
+      '@opentelemetry/otlp-exporter-base': 0.221.0(@opentelemetry/api@1.9.1)
+      '@opentelemetry/otlp-transformer': 0.221.0(@opentelemetry/api@1.9.1)
+      '@opentelemetry/sdk-logs': 0.221.0(@opentelemetry/api@1.9.1)
+
+  '@opentelemetry/exporter-logs-otlp-proto@0.221.0(@opentelemetry/api@1.9.1)':
+    dependencies:
+      '@opentelemetry/api': 1.9.1
+      '@opentelemetry/otlp-exporter-base': 0.221.0(@opentelemetry/api@1.9.1)
+      '@opentelemetry/otlp-transformer': 0.221.0(@opentelemetry/api@1.9.1)
+      '@opentelemetry/sdk-logs': 0.221.0(@opentelemetry/api@1.9.1)
+
+  '@opentelemetry/exporter-metrics-otlp-grpc@0.221.0(@opentelemetry/api@1.9.1)':
+    dependencies:
+      '@opentelemetry/api': 1.9.1
+      '@opentelemetry/exporter-metrics-otlp-http': 0.221.0(@opentelemetry/api@1.9.1)
+      '@opentelemetry/otlp-grpc-exporter-base': 0.221.0(@opentelemetry/api@1.9.1)
+      '@opentelemetry/otlp-transformer': 0.221.0(@opentelemetry/api@1.9.1)
+
+  '@opentelemetry/exporter-metrics-otlp-http@0.221.0(@opentelemetry/api@1.9.1)':
+    dependencies:
+      '@opentelemetry/api': 1.9.1
+      '@opentelemetry/core': 2.10.0(@opentelemetry/api@1.9.1)
+      '@opentelemetry/otlp-exporter-base': 0.221.0(@opentelemetry/api@1.9.1)
+      '@opentelemetry/otlp-transformer': 0.221.0(@opentelemetry/api@1.9.1)
+      '@opentelemetry/resources': 2.10.0(@opentelemetry/api@1.9.1)
+      '@opentelemetry/sdk-metrics': 2.10.0(@opentelemetry/api@1.9.1)
+
+  '@opentelemetry/exporter-metrics-otlp-proto@0.221.0(@opentelemetry/api@1.9.1)':
+    dependencies:
+      '@opentelemetry/api': 1.9.1
+      '@opentelemetry/exporter-metrics-otlp-http': 0.221.0(@opentelemetry/api@1.9.1)
+      '@opentelemetry/otlp-exporter-base': 0.221.0(@opentelemetry/api@1.9.1)
+      '@opentelemetry/otlp-transformer': 0.221.0(@opentelemetry/api@1.9.1)
+
+  '@opentelemetry/exporter-prometheus@0.221.0(@opentelemetry/api@1.9.1)':
+    dependencies:
+      '@opentelemetry/api': 1.9.1
+      '@opentelemetry/core': 2.10.0(@opentelemetry/api@1.9.1)
+      '@opentelemetry/resources': 2.10.0(@opentelemetry/api@1.9.1)
+      '@opentelemetry/sdk-metrics': 2.10.0(@opentelemetry/api@1.9.1)
+      '@opentelemetry/semantic-conventions': 1.43.0
+
+  '@opentelemetry/exporter-trace-otlp-grpc@0.221.0(@opentelemetry/api@1.9.1)':
+    dependencies:
+      '@opentelemetry/api': 1.9.1
+      '@opentelemetry/otlp-exporter-base': 0.221.0(@opentelemetry/api@1.9.1)
+      '@opentelemetry/otlp-grpc-exporter-base': 0.221.0(@opentelemetry/api@1.9.1)
+      '@opentelemetry/otlp-transformer': 0.221.0(@opentelemetry/api@1.9.1)
+      '@opentelemetry/sdk-trace': 2.10.0(@opentelemetry/api@1.9.1)
+
+  '@opentelemetry/exporter-trace-otlp-http@0.221.0(@opentelemetry/api@1.9.1)':
+    dependencies:
+      '@opentelemetry/api': 1.9.1
+      '@opentelemetry/otlp-exporter-base': 0.221.0(@opentelemetry/api@1.9.1)
+      '@opentelemetry/otlp-transformer': 0.221.0(@opentelemetry/api@1.9.1)
+      '@opentelemetry/sdk-trace': 2.10.0(@opentelemetry/api@1.9.1)
+
+  '@opentelemetry/exporter-trace-otlp-proto@0.221.0(@opentelemetry/api@1.9.1)':
+    dependencies:
+      '@opentelemetry/api': 1.9.1
+      '@opentelemetry/otlp-exporter-base': 0.221.0(@opentelemetry/api@1.9.1)
+      '@opentelemetry/otlp-transformer': 0.221.0(@opentelemetry/api@1.9.1)
+      '@opentelemetry/sdk-trace': 2.10.0(@opentelemetry/api@1.9.1)
+
+  '@opentelemetry/exporter-zipkin@2.10.0(@opentelemetry/api@1.9.1)':
+    dependencies:
+      '@opentelemetry/api': 1.9.1
+      '@opentelemetry/core': 2.10.0(@opentelemetry/api@1.9.1)
+      '@opentelemetry/resources': 2.10.0(@opentelemetry/api@1.9.1)
+      '@opentelemetry/sdk-trace': 2.10.0(@opentelemetry/api@1.9.1)
+      '@opentelemetry/semantic-conventions': 1.43.0
+
+  '@opentelemetry/instrumentation-http@0.221.0(@opentelemetry/api@1.9.1)':
+    dependencies:
+      '@opentelemetry/api': 1.9.1
+      '@opentelemetry/core': 2.10.0(@opentelemetry/api@1.9.1)
+      '@opentelemetry/instrumentation': 0.221.0(@opentelemetry/api@1.9.1)
+      '@opentelemetry/semantic-conventions': 1.43.0
+      forwarded-parse: 2.1.2
+    transitivePeerDependencies:
+      - supports-color
+
+  '@opentelemetry/instrumentation@0.221.0(@opentelemetry/api@1.9.1)':
+    dependencies:
+      '@opentelemetry/api': 1.9.1
+      '@opentelemetry/api-logs': 0.221.0
+      import-in-the-middle: 3.3.3
+      require-in-the-middle: 8.0.1
+    transitivePeerDependencies:
+      - supports-color
+
+  '@opentelemetry/otlp-exporter-base@0.221.0(@opentelemetry/api@1.9.1)':
+    dependencies:
+      '@opentelemetry/api': 1.9.1
+      '@opentelemetry/core': 2.10.0(@opentelemetry/api@1.9.1)
+      '@opentelemetry/otlp-transformer': 0.221.0(@opentelemetry/api@1.9.1)
+
+  '@opentelemetry/otlp-grpc-exporter-base@0.221.0(@opentelemetry/api@1.9.1)':
+    dependencies:
+      '@grpc/grpc-js': 1.14.4
+      '@opentelemetry/api': 1.9.1
+      '@opentelemetry/core': 2.10.0(@opentelemetry/api@1.9.1)
+      '@opentelemetry/otlp-exporter-base': 0.221.0(@opentelemetry/api@1.9.1)
+      '@opentelemetry/otlp-transformer': 0.221.0(@opentelemetry/api@1.9.1)
+
+  '@opentelemetry/otlp-transformer@0.221.0(@opentelemetry/api@1.9.1)':
+    dependencies:
+      '@opentelemetry/api': 1.9.1
+      '@opentelemetry/api-logs': 0.221.0
+      '@opentelemetry/core': 2.10.0(@opentelemetry/api@1.9.1)
+      '@opentelemetry/resources': 2.10.0(@opentelemetry/api@1.9.1)
+      '@opentelemetry/sdk-logs': 0.221.0(@opentelemetry/api@1.9.1)
+      '@opentelemetry/sdk-metrics': 2.10.0(@opentelemetry/api@1.9.1)
+      '@opentelemetry/sdk-trace': 2.10.0(@opentelemetry/api@1.9.1)
+
+  '@opentelemetry/propagator-b3@2.10.0(@opentelemetry/api@1.9.1)':
+    dependencies:
+      '@opentelemetry/api': 1.9.1
+      '@opentelemetry/core': 2.10.0(@opentelemetry/api@1.9.1)
+
+  '@opentelemetry/propagator-jaeger@2.10.0(@opentelemetry/api@1.9.1)':
+    dependencies:
+      '@opentelemetry/api': 1.9.1
+      '@opentelemetry/core': 2.10.0(@opentelemetry/api@1.9.1)
+
+  '@opentelemetry/resources@2.10.0(@opentelemetry/api@1.9.1)':
+    dependencies:
+      '@opentelemetry/api': 1.9.1
+      '@opentelemetry/core': 2.10.0(@opentelemetry/api@1.9.1)
+      '@opentelemetry/semantic-conventions': 1.43.0
+
+  '@opentelemetry/sdk-logs@0.221.0(@opentelemetry/api@1.9.1)':
+    dependencies:
+      '@opentelemetry/api': 1.9.1
+      '@opentelemetry/api-logs': 0.221.0
+      '@opentelemetry/core': 2.10.0(@opentelemetry/api@1.9.1)
+      '@opentelemetry/resources': 2.10.0(@opentelemetry/api@1.9.1)
+      '@opentelemetry/semantic-conventions': 1.43.0
+
+  '@opentelemetry/sdk-metrics@2.10.0(@opentelemetry/api@1.9.1)':
+    dependencies:
+      '@opentelemetry/api': 1.9.1
+      '@opentelemetry/core': 2.10.0(@opentelemetry/api@1.9.1)
+      '@opentelemetry/resources': 2.10.0(@opentelemetry/api@1.9.1)
+
+  '@opentelemetry/sdk-node@0.221.0(@opentelemetry/api@1.9.1)':
+    dependencies:
+      '@opentelemetry/api': 1.9.1
+      '@opentelemetry/api-logs': 0.221.0
+      '@opentelemetry/configuration': 0.221.0(@opentelemetry/api@1.9.1)
+      '@opentelemetry/context-async-hooks': 2.10.0(@opentelemetry/api@1.9.1)
+      '@opentelemetry/core': 2.10.0(@opentelemetry/api@1.9.1)
+      '@opentelemetry/exporter-logs-otlp-grpc': 0.221.0(@opentelemetry/api@1.9.1)
+      '@opentelemetry/exporter-logs-otlp-http': 0.221.0(@opentelemetry/api@1.9.1)
+      '@opentelemetry/exporter-logs-otlp-proto': 0.221.0(@opentelemetry/api@1.9.1)
+      '@opentelemetry/exporter-metrics-otlp-grpc': 0.221.0(@opentelemetry/api@1.9.1)
+      '@opentelemetry/exporter-metrics-otlp-http': 0.221.0(@opentelemetry/api@1.9.1)
+      '@opentelemetry/exporter-metrics-otlp-proto': 0.221.0(@opentelemetry/api@1.9.1)
+      '@opentelemetry/exporter-prometheus': 0.221.0(@opentelemetry/api@1.9.1)
+      '@opentelemetry/exporter-trace-otlp-grpc': 0.221.0(@opentelemetry/api@1.9.1)
+      '@opentelemetry/exporter-trace-otlp-http': 0.221.0(@opentelemetry/api@1.9.1)
+      '@opentelemetry/exporter-trace-otlp-proto': 0.221.0(@opentelemetry/api@1.9.1)
+      '@opentelemetry/exporter-zipkin': 2.10.0(@opentelemetry/api@1.9.1)
+      '@opentelemetry/instrumentation': 0.221.0(@opentelemetry/api@1.9.1)
+      '@opentelemetry/otlp-exporter-base': 0.221.0(@opentelemetry/api@1.9.1)
+      '@opentelemetry/otlp-grpc-exporter-base': 0.221.0(@opentelemetry/api@1.9.1)
+      '@opentelemetry/propagator-b3': 2.10.0(@opentelemetry/api@1.9.1)
+      '@opentelemetry/propagator-jaeger': 2.10.0(@opentelemetry/api@1.9.1)
+      '@opentelemetry/resources': 2.10.0(@opentelemetry/api@1.9.1)
+      '@opentelemetry/sdk-logs': 0.221.0(@opentelemetry/api@1.9.1)
+      '@opentelemetry/sdk-metrics': 2.10.0(@opentelemetry/api@1.9.1)
+      '@opentelemetry/sdk-trace': 2.10.0(@opentelemetry/api@1.9.1)
+      '@opentelemetry/sdk-trace-base': 2.10.0(@opentelemetry/api@1.9.1)
+      '@opentelemetry/sdk-trace-node': 2.10.0(@opentelemetry/api@1.9.1)
+      '@opentelemetry/semantic-conventions': 1.43.0
+    transitivePeerDependencies:
+      - supports-color
+
+  '@opentelemetry/sdk-trace-base@2.10.0(@opentelemetry/api@1.9.1)':
+    dependencies:
+      '@opentelemetry/api': 1.9.1
+      '@opentelemetry/core': 2.10.0(@opentelemetry/api@1.9.1)
+      '@opentelemetry/resources': 2.10.0(@opentelemetry/api@1.9.1)
+      '@opentelemetry/sdk-trace': 2.10.0(@opentelemetry/api@1.9.1)
+      '@opentelemetry/semantic-conventions': 1.43.0
+
+  '@opentelemetry/sdk-trace-node@2.10.0(@opentelemetry/api@1.9.1)':
+    dependencies:
+      '@opentelemetry/api': 1.9.1
+      '@opentelemetry/context-async-hooks': 2.10.0(@opentelemetry/api@1.9.1)
+      '@opentelemetry/core': 2.10.0(@opentelemetry/api@1.9.1)
+      '@opentelemetry/sdk-trace-base': 2.10.0(@opentelemetry/api@1.9.1)
+
+  '@opentelemetry/sdk-trace@2.10.0(@opentelemetry/api@1.9.1)':
+    dependencies:
+      '@opentelemetry/api': 1.9.1
+      '@opentelemetry/core': 2.10.0(@opentelemetry/api@1.9.1)
+      '@opentelemetry/resources': 2.10.0(@opentelemetry/api@1.9.1)
+      '@opentelemetry/semantic-conventions': 1.43.0
+
+  '@opentelemetry/semantic-conventions@1.43.0': {}
 
   '@oslojs/encoding@1.1.0': {}
 
@@ -18302,6 +18991,8 @@ snapshots:
       '@smithy/core': 3.33.3
       tslib: 2.8.1
 
+  '@socket.io/component-emitter@3.1.2': {}
+
   '@stablelib/base64@1.0.1': {}
 
   '@standard-schema/spec@1.1.0': {}
@@ -18971,6 +19662,11 @@ snapshots:
       d3-selection: 3.0.0
       d3-transition: 3.0.1(d3-selection@3.0.0)
 
+  '@upstash/box@0.5.3(zod@4.4.3)':
+    dependencies:
+      zod: 4.4.3
+      zod-to-json-schema: 3.25.2(zod@4.4.3)
+
   '@vercel/config@0.3.0':
     dependencies:
       '@vercel/routing-utils': 6.2.0
@@ -18987,6 +19683,23 @@ snapshots:
       path-to-regexp-updated: path-to-regexp@6.3.0
     optionalDependencies:
       ajv: 6.15.0
+
+  '@vercel/sandbox@2.9.2':
+    dependencies:
+      '@vercel/oidc': 3.2.0
+      '@workflow/serde': 4.1.0-beta.2
+      async-retry: 1.3.3
+      jose: 6.2.3
+      jsonlines: 0.1.1
+      ms: 2.1.3
+      picocolors: 1.1.1
+      tar-stream: 3.1.7
+      undici: 7.27.1
+      xdg-app-paths: 5.1.0
+      zod: 4.4.3
+    transitivePeerDependencies:
+      - bare-abort-controller
+      - react-native-b4a
 
   '@vitejs/plugin-react@6.0.2(@rolldown/plugin-babel@0.2.3(@babel/core@7.29.7)(@babel/plugin-transform-runtime@7.29.7(@babel/core@7.29.7))(@babel/runtime@7.29.7)(@voidzero-dev/vite-plus-core@0.2.2(@types/node@24.12.4)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.48.0)(typescript@6.0.3)(unrun@0.2.39)(yaml@2.9.0))(rolldown@1.1.5))(@voidzero-dev/vite-plus-core@0.2.2(@types/node@24.12.4)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.48.0)(typescript@6.0.3)(unrun@0.2.39)(yaml@2.9.0))(babel-plugin-react-compiler@1.0.0)':
     dependencies:
@@ -19294,7 +20007,7 @@ snapshots:
       node-simctl: 7.7.5
       playwright-core: 1.60.0
       webdriverio: 9.31.3(bufferutil@4.1.0)(utf-8-validate@6.0.6)
-      ws: 8.21.0(bufferutil@4.1.0)(utf-8-validate@6.0.6)
+      ws: 8.21.3(bufferutil@4.1.0)(utf-8-validate@6.0.6)
       zod: 3.25.76
     transitivePeerDependencies:
       - bare-abort-controller
@@ -19758,6 +20471,10 @@ snapshots:
     dependencies:
       tslib: 2.8.1
 
+  async-retry@1.3.3:
+    dependencies:
+      retry: 0.13.1
+
   async@3.2.6: {}
 
   asyncbox@3.0.0:
@@ -20114,6 +20831,11 @@ snapshots:
 
   buffer-from@1.1.2: {}
 
+  buffer@5.6.0:
+    dependencies:
+      base64-js: 1.5.1
+      ieee754: 1.2.1
+
   buffer@5.7.1:
     dependencies:
       base64-js: 1.5.1
@@ -20166,6 +20888,10 @@ snapshots:
   bun-types@1.3.14:
     dependencies:
       '@types/node': 24.12.4
+
+  busboy@1.6.0:
+    dependencies:
+      streamsearch: 1.1.0
 
   bytes@3.1.2: {}
 
@@ -20316,6 +21042,8 @@ snapshots:
 
   ci-info@4.4.0: {}
 
+  cjs-module-lexer@2.2.1: {}
+
   class-variance-authority@0.7.1:
     dependencies:
       clsx: 2.1.1
@@ -20422,6 +21150,8 @@ snapshots:
   common-ancestor-path@2.0.0: {}
 
   compare-version@0.1.2: {}
+
+  compare-versions@6.1.1: {}
 
   compress-commons@6.0.2:
     dependencies:
@@ -20890,6 +21620,11 @@ snapshots:
 
   dnssd-advertise@1.1.4: {}
 
+  dockerfile-ast@0.7.1:
+    dependencies:
+      vscode-languageserver-textdocument: 1.0.12
+      vscode-languageserver-types: 3.17.5
+
   dom-accessibility-api@0.5.16: {}
 
   dom-accessibility-api@0.6.3:
@@ -20965,6 +21700,22 @@ snapshots:
   duplexer2@0.1.4:
     dependencies:
       readable-stream: 2.3.8
+
+  e2b@2.46.1:
+    dependencies:
+      '@bufbuild/protobuf': 2.14.0
+      '@connectrpc/connect': 2.1.2(@bufbuild/protobuf@2.14.0)
+      '@connectrpc/connect-web': 2.1.2(@bufbuild/protobuf@2.14.0)(@connectrpc/connect@2.1.2(@bufbuild/protobuf@2.14.0))
+      chalk: 5.6.2
+      compare-versions: 6.1.1
+      dockerfile-ast: 0.7.1
+      glob: 13.0.6
+      openapi-fetch: 0.14.1
+      platform: 1.3.6
+      tar: 7.5.22
+      undici: 7.29.0
+    optionalDependencies:
+      undici8: undici@8.10.0
 
   eastasianwidth@0.2.0: {}
 
@@ -21112,6 +21863,20 @@ snapshots:
     dependencies:
       once: 1.4.0
 
+  engine.io-client@6.6.6(bufferutil@4.1.0)(utf-8-validate@6.0.6):
+    dependencies:
+      '@socket.io/component-emitter': 3.1.2
+      debug: 4.4.3
+      engine.io-parser: 5.2.3
+      ws: 8.21.3(bufferutil@4.1.0)(utf-8-validate@6.0.6)
+      xmlhttprequest-ssl: 2.1.2
+    transitivePeerDependencies:
+      - bufferutil
+      - supports-color
+      - utf-8-validate
+
+  engine.io-parser@5.2.3: {}
+
   enhanced-resolve@5.22.1:
     dependencies:
       graceful-fs: 4.2.11
@@ -21138,6 +21903,8 @@ snapshots:
   es-errors@1.3.0: {}
 
   es-module-lexer@2.1.0: {}
+
+  es-module-lexer@2.3.2: {}
 
   es-object-atoms@1.1.2:
     dependencies:
@@ -21288,6 +22055,10 @@ snapshots:
 
   expand-template@2.0.3:
     optional: true
+
+  expand-tilde@2.0.2:
+    dependencies:
+      homedir-polyfill: 1.0.3
 
   expect-type@1.4.0: {}
 
@@ -22141,6 +22912,8 @@ snapshots:
     dependencies:
       fetch-blob: 3.2.0
 
+  forwarded-parse@2.1.2: {}
+
   forwarded@0.2.0: {}
 
   framer-motion@13.1.1(react-dom@19.2.6(react@19.2.6))(react@19.2.6):
@@ -22561,6 +23334,10 @@ snapshots:
     dependencies:
       react-is: 16.13.1
 
+  homedir-polyfill@1.0.3:
+    dependencies:
+      parse-passwd: 1.0.0
+
   hono@4.12.27: {}
 
   hosted-git-info@4.1.0:
@@ -22657,6 +23434,12 @@ snapshots:
 
   immediate@3.0.6: {}
 
+  import-in-the-middle@3.3.3:
+    dependencies:
+      cjs-module-lexer: 2.2.1
+      es-module-lexer: 2.3.2
+      module-details-from-path: 1.0.4
+
   import-meta-resolve@4.2.0: {}
 
   indent-string@4.0.0:
@@ -22702,7 +23485,7 @@ snapshots:
       type-fest: 5.7.0
       widest-line: 6.0.0
       wrap-ansi: 9.0.2
-      ws: 8.21.0(bufferutil@4.1.0)(utf-8-validate@6.0.6)
+      ws: 8.21.3(bufferutil@4.1.0)(utf-8-validate@6.0.6)
       yoga-layout: 3.2.1
     optionalDependencies:
       '@types/react': 19.2.16
@@ -22826,6 +23609,10 @@ snapshots:
 
   isexe@4.0.0: {}
 
+  isomorphic-ws@5.0.0(ws@8.21.3(bufferutil@4.1.0)(utf-8-validate@6.0.6)):
+    dependencies:
+      ws: 8.21.3(bufferutil@4.1.0)(utf-8-validate@6.0.6)
+
   isomorphic.js@0.2.5: {}
 
   jackspeak@3.4.3:
@@ -22948,6 +23735,8 @@ snapshots:
       universalify: 2.0.1
     optionalDependencies:
       graceful-fs: 4.2.11
+
+  jsonlines@0.1.1: {}
 
   jszip@3.10.1:
     dependencies:
@@ -23254,8 +24043,7 @@ snapshots:
 
   lodash-es@4.18.1: {}
 
-  lodash.camelcase@4.3.0:
-    optional: true
+  lodash.camelcase@4.3.0: {}
 
   lodash.clonedeep@4.5.0: {}
 
@@ -24023,6 +24811,8 @@ snapshots:
 
   modern-tar@0.7.7: {}
 
+  module-details-from-path@1.0.4: {}
+
   mongodb-connection-string-url@3.0.2:
     dependencies:
       '@types/whatwg-url': 11.0.5
@@ -24367,7 +25157,7 @@ snapshots:
       is-docker: 2.2.1
       is-wsl: 2.2.0
 
-  openai@4.104.0(ws@8.21.0(bufferutil@4.1.0)(utf-8-validate@6.0.6))(zod@4.4.3):
+  openai@4.104.0(ws@8.21.3(bufferutil@4.1.0)(utf-8-validate@6.0.6))(zod@4.4.3):
     dependencies:
       '@types/node': 24.12.4
       '@types/node-fetch': 2.6.13
@@ -24377,10 +25167,16 @@ snapshots:
       formdata-node: 4.4.1
       node-fetch: 2.7.0
     optionalDependencies:
-      ws: 8.21.0(bufferutil@4.1.0)(utf-8-validate@6.0.6)
+      ws: 8.21.3(bufferutil@4.1.0)(utf-8-validate@6.0.6)
       zod: 4.4.3
     transitivePeerDependencies:
       - encoding
+
+  openapi-fetch@0.14.1:
+    dependencies:
+      openapi-typescript-helpers: 0.0.15
+
+  openapi-typescript-helpers@0.0.15: {}
 
   ora@3.4.0:
     dependencies:
@@ -24401,6 +25197,8 @@ snapshots:
       log-symbols: 7.0.1
       stdin-discarder: 0.3.2
       string-width: 8.2.1
+
+  os-paths@4.4.0: {}
 
   outvariant@1.4.3: {}
 
@@ -24547,6 +25345,8 @@ snapshots:
     optional: true
 
   parse-ms@4.0.0: {}
+
+  parse-passwd@1.0.0: {}
 
   parse-png@2.1.0:
     dependencies:
@@ -24738,6 +25538,8 @@ snapshots:
       pvtsutils: 1.3.6
       pvutils: 1.1.5
       tslib: 2.8.1
+
+  platform@1.3.6: {}
 
   playwright-core@1.60.0: {}
 
@@ -25440,7 +26242,6 @@ snapshots:
       inherits: 2.0.4
       string_decoder: 1.3.0
       util-deprecate: 1.0.2
-    optional: true
 
   readable-stream@4.7.0:
     dependencies:
@@ -25603,6 +26404,13 @@ snapshots:
   require-directory@2.1.1: {}
 
   require-from-string@2.0.2: {}
+
+  require-in-the-middle@8.0.1:
+    dependencies:
+      debug: 4.4.3
+      module-details-from-path: 1.0.4
+    transitivePeerDependencies:
+      - supports-color
 
   resedit@1.7.2:
     dependencies:
@@ -26134,6 +26942,24 @@ snapshots:
 
   smol-toml@1.7.0: {}
 
+  socket.io-client@4.8.3(bufferutil@4.1.0)(utf-8-validate@6.0.6):
+    dependencies:
+      '@socket.io/component-emitter': 3.1.2
+      debug: 4.4.3
+      engine.io-client: 6.6.6(bufferutil@4.1.0)(utf-8-validate@6.0.6)
+      socket.io-parser: 4.2.7
+    transitivePeerDependencies:
+      - bufferutil
+      - supports-color
+      - utf-8-validate
+
+  socket.io-parser@4.2.7:
+    dependencies:
+      '@socket.io/component-emitter': 3.1.2
+      debug: 4.4.3
+    transitivePeerDependencies:
+      - supports-color
+
   socks-proxy-agent@8.0.5:
     dependencies:
       agent-base: 7.1.4
@@ -26215,6 +27041,11 @@ snapshots:
 
   stdin-discarder@0.3.2: {}
 
+  stream-browserify@3.0.0:
+    dependencies:
+      inherits: 2.0.4
+      readable-stream: 3.6.2
+
   stream-buffers@2.2.0: {}
 
   stream-parser@0.3.1:
@@ -26222,6 +27053,8 @@ snapshots:
       debug: 2.6.9
     transitivePeerDependencies:
       - supports-color
+
+  streamsearch@1.1.0: {}
 
   streamx@2.28.1:
     dependencies:
@@ -26406,6 +27239,15 @@ snapshots:
       readable-stream: 3.6.2
     optional: true
 
+  tar-stream@3.1.7:
+    dependencies:
+      b4a: 1.8.1
+      fast-fifo: 1.3.2
+      streamx: 2.28.1
+    transitivePeerDependencies:
+      - bare-abort-controller
+      - react-native-b4a
+
   tar-stream@3.2.1:
     dependencies:
       b4a: 1.8.1
@@ -26416,14 +27258,6 @@ snapshots:
       - bare-abort-controller
       - bare-buffer
       - react-native-b4a
-
-  tar@7.5.16:
-    dependencies:
-      '@isaacs/fs-minipass': 4.0.1
-      chownr: 3.0.0
-      minipass: 7.1.3
-      minizlib: 3.1.0
-      yallist: 5.0.0
 
   tar@7.5.22:
     dependencies:
@@ -26615,6 +27449,11 @@ snapshots:
   undici@6.28.0: {}
 
   undici@7.27.1: {}
+
+  undici@7.29.0: {}
+
+  undici@8.10.0:
+    optional: true
 
   undici@8.9.0: {}
 
@@ -27120,7 +27959,7 @@ snapshots:
       deepmerge-ts: 7.1.6
       https-proxy-agent: 7.0.6
       undici: 6.28.0
-      ws: 8.21.0(bufferutil@4.1.0)(utf-8-validate@6.0.6)
+      ws: 8.21.3(bufferutil@4.1.0)(utf-8-validate@6.0.6)
     transitivePeerDependencies:
       - bare-abort-controller
       - bare-buffer
@@ -27267,6 +28106,14 @@ snapshots:
       simple-plist: 1.3.1
       uuid: 7.0.3
 
+  xdg-app-paths@5.1.0:
+    dependencies:
+      xdg-portable: 7.3.0
+
+  xdg-portable@7.3.0:
+    dependencies:
+      os-paths: 4.4.0
+
   xml-naming@0.1.0: {}
 
   xml2js@0.6.0:
@@ -27277,6 +28124,8 @@ snapshots:
   xmlbuilder@11.0.1: {}
 
   xmlbuilder@15.1.1: {}
+
+  xmlhttprequest-ssl@2.1.2: {}
 
   xtend@4.0.2: {}
 


### PR DESCRIPTION
## Why\nRemote bot workspaces had provider options but no provider-native lifecycle. A server restart could not reattach the same sandbox safely.\n\n## What changed\n- Add Local, E2B, Daytona, Vercel Sandbox, and Upstash Box workspace adapters.\n- Persist each remote provider ID and reattach it after server restart.\n- Sleep, wake, isolate, and destroy pooled workspaces without changing Local pooling.\n- Fail closed when credentials or a persisted workspace are unavailable. The error names the identity file to remove before an explicit replacement.\n- Remove the canceled Akeru Cloud option.\n\n## Testing\n- vp test run apps/server/src/provider/botWorkspace.test.ts apps/server/src/provider/botWorkspacePool.test.ts apps/server/src/provider/botWorkspaceFilesystem.test.ts apps/server/src/provider/AkeruSessionResources.test.ts apps/server/src/provider/Layers/AgentController.test.ts packages/contracts/src/botConfig.test.ts packages/contracts/src/provider.test.ts apps/web/src/components/roster/botSandbox.test.ts\n- vp run --filter akeru-bot typecheck\n- vp run --filter @t3tools/contracts typecheck\n\n## Related\n- https://linear.app/opencoredev/issue/LEO-278/drive-the-sandbox-browser-through-the-akeru-runtime\n- https://linear.app/opencoredev/issue/LEO-284/replace-sandbox-sdk-and-recover-bot-workspaces\n- https://linear.app/opencoredev/issue/LEO-294/own-launch-stacks-and-shared-file-integration\n- https://linear.app/opencoredev/issue/LEO-327/land-workspace-pooling-and-sandbox-browser\n\nRemote browser create and reconnect support follows as a dependent PR.\n\nModel: GPT-5.6 Sol\nHarness: Codex in T3 Code