### PR TITLE
fix(server): preserve rewritten Mastra replies

### DIFF
--- a/apps/server/src/provider/Layers/AgentController.test.ts
+++ b/apps/server/src/provider/Layers/AgentController.test.ts
@@ -690,12 +690,11 @@ describe("AgentControllerLive", () => {
         yield* Fiber.interrupt(eventsFiber);
 
         assert.deepEqual(
-          events.slice(0, 7).map((event) => event.type),
+          events.slice(0, 6).map((event) => event.type),
           [
             "turn.started",
             "session.state.changed",
             "item.started",
-            "content.delta",
             "content.delta",
             "item.completed",
             "turn.completed",
@@ -711,6 +710,54 @@ describe("AgentControllerLive", () => {
         expect(mastra.sendMessage).toHaveBeenCalledWith({ content: "Reply once." });
         expect(bridge.startSession).not.toHaveBeenCalled();
         expect(bridge.sendTurn).not.toHaveBeenCalled();
+      }),
+      bridge.service,
+      mastra.factory,
+    );
+  });
+
+  it.effect("publishes the final text when Mastra rewrites a message snapshot", () => {
+    const bridge = makeBridge();
+    const mastra = makeMastraHarness();
+    return provideController(
+      Effect.gen(function* () {
+        const controller = yield* AgentController;
+        yield* resolveCodex(controller);
+        yield* controller.startSession(codexThreadId, {
+          threadId: codexThreadId,
+          provider: ProviderDriverKind.make("codex"),
+          providerInstanceId: codexInstanceId,
+          cwd: process.cwd(),
+          modelSelection: codexSelection,
+          runtimeMode: "full-access",
+        });
+
+        const eventsFiber = yield* controller.streamEvents.pipe(
+          Stream.takeUntil((event) => event.type === "turn.completed"),
+          Stream.runCollect,
+          Effect.forkChild({ startImmediately: true }),
+        );
+        yield* Effect.yieldNow;
+        yield* controller.sendTurn({ threadId: codexThreadId, input: "Say hello." });
+        mastra.emit({
+          type: "message_update",
+          message: assistantMessage("Hello world"),
+        } as AgentControllerEvent);
+        mastra.emit({
+          type: "message_end",
+          message: assistantMessage("Hi there!"),
+        } as AgentControllerEvent);
+        mastra.emit({ type: "agent_end", reason: "complete" } as AgentControllerEvent);
+        mastra.finishSend();
+
+        const events = Array.from(yield* Fiber.join(eventsFiber));
+        assert.equal(
+          events
+            .filter((event) => event.type === "content.delta")
+            .map((event) => event.payload.delta)
+            .join(""),
+          "Hi there!",
+        );
       }),
       bridge.service,
       mastra.factory,

--- a/apps/server/src/provider/Layers/AgentController.test.ts
+++ b/apps/server/src/provider/Layers/AgentController.test.ts
@@ -764,6 +764,65 @@ describe("AgentControllerLive", () => {
     );
   });
 
+  it.effect("publishes a same-id rewrite after a tool boundary", () => {
+    const bridge = makeBridge();
+    const mastra = makeMastraHarness();
+    return provideController(
+      Effect.gen(function* () {
+        const controller = yield* AgentController;
+        yield* resolveCodex(controller);
+        yield* controller.startSession(codexThreadId, {
+          threadId: codexThreadId,
+          provider: ProviderDriverKind.make("codex"),
+          providerInstanceId: codexInstanceId,
+          cwd: process.cwd(),
+          modelSelection: codexSelection,
+          runtimeMode: "full-access",
+        });
+
+        const eventsFiber = yield* controller.streamEvents.pipe(
+          Stream.takeUntil((event) => event.type === "turn.completed"),
+          Stream.runCollect,
+          Effect.forkChild({ startImmediately: true }),
+        );
+        yield* Effect.yieldNow;
+        yield* controller.sendTurn({ threadId: codexThreadId, input: "Check the project." });
+        mastra.emit({
+          type: "message_update",
+          message: assistantMessage("draft", "same"),
+        } as AgentControllerEvent);
+        mastra.emit({
+          type: "tool_start",
+          toolCallId: "view-1",
+          toolName: "view",
+          args: { path: "package.json" },
+        } as AgentControllerEvent);
+        mastra.emit({
+          type: "tool_end",
+          toolCallId: "view-1",
+          result: "{}",
+          isError: false,
+        } as AgentControllerEvent);
+        mastra.emit({
+          type: "message_end",
+          message: assistantMessage("final revised", "same"),
+        } as AgentControllerEvent);
+        mastra.emit({ type: "agent_end", reason: "complete" } as AgentControllerEvent);
+        mastra.finishSend();
+
+        const events = Array.from(yield* Fiber.join(eventsFiber));
+        assert.deepEqual(
+          events
+            .filter((event) => event.type === "content.delta")
+            .map((event) => event.payload.delta),
+          ["draft", "final revised"],
+        );
+      }),
+      bridge.service,
+      mastra.factory,
+    );
+  });
+
   it.effect("keeps replies and status beats as separate completed messages", () => {
     const bridge = makeBridge();
     const mastra = makeMastraHarness();

--- a/apps/server/src/provider/Layers/AgentController.ts
+++ b/apps/server/src/provider/Layers/AgentController.ts
@@ -93,9 +93,10 @@ interface ResolvedEngine {
 }
 
 interface ActiveAssistantMessage {
-  readonly itemId: RuntimeItemId;
+  readonly messageId: string;
   text: string;
-  completed: boolean;
+  publishedText: string;
+  revision: number;
 }
 
 interface ActiveTurn {
@@ -441,26 +442,33 @@ const make = (options?: AgentControllerLiveOptions) =>
       turn: ActiveTurn,
       message: ActiveAssistantMessage,
     ) => {
-      if (message.completed || message.text.length === 0) return;
+      const text = message.text.startsWith(message.publishedText)
+        ? message.text.slice(message.publishedText.length)
+        : message.text;
+      if (text.length === 0) return;
+      const itemId = RuntimeItemId.make(
+        `mastra-answer-${message.messageId}${message.revision === 0 ? "" : `-${message.revision}`}`,
+      );
       publish({
         ...baseEvent(threadId, active, turn.turnId),
-        itemId: message.itemId,
+        itemId,
         type: "item.started",
         payload: { itemType: "assistant_message", status: "inProgress" },
       });
       publish({
         ...baseEvent(threadId, active, turn.turnId),
-        itemId: message.itemId,
+        itemId,
         type: "content.delta",
-        payload: { streamKind: "assistant_text", delta: message.text },
+        payload: { streamKind: "assistant_text", delta: text },
       });
-      message.completed = true;
       publish({
         ...baseEvent(threadId, active, turn.turnId),
-        itemId: message.itemId,
+        itemId,
         type: "item.completed",
         payload: { itemType: "assistant_message", status: "completed" },
       });
+      message.publishedText = message.text;
+      message.revision += 1;
     };
 
     const completeAssistantMessages = (
@@ -513,13 +521,13 @@ const make = (options?: AgentControllerLiveOptions) =>
       if (!activeMessage) {
         completeAssistantMessages(threadId, active, turn);
         activeMessage = {
-          itemId: RuntimeItemId.make(`mastra-answer-${messageKey}`),
+          messageId: messageKey,
           text: "",
-          completed: false,
+          publishedText: "",
+          revision: 0,
         };
         turn.assistantMessages.set(messageKey, activeMessage);
       }
-      if (activeMessage.completed) return;
       activeMessage.text = text;
       if (complete) completeAssistantMessage(threadId, active, turn, activeMessage);
     };

--- a/apps/server/src/provider/Layers/AgentController.ts
+++ b/apps/server/src/provider/Layers/AgentController.ts
@@ -94,8 +94,7 @@ interface ResolvedEngine {
 
 interface ActiveAssistantMessage {
   readonly itemId: RuntimeItemId;
-  length: number;
-  started: boolean;
+  text: string;
   completed: boolean;
 }
 
@@ -436,20 +435,41 @@ const make = (options?: AgentControllerLiveOptions) =>
       });
     };
 
+    const completeAssistantMessage = (
+      threadId: ThreadId,
+      active: ActiveSession,
+      turn: ActiveTurn,
+      message: ActiveAssistantMessage,
+    ) => {
+      if (message.completed || message.text.length === 0) return;
+      publish({
+        ...baseEvent(threadId, active, turn.turnId),
+        itemId: message.itemId,
+        type: "item.started",
+        payload: { itemType: "assistant_message", status: "inProgress" },
+      });
+      publish({
+        ...baseEvent(threadId, active, turn.turnId),
+        itemId: message.itemId,
+        type: "content.delta",
+        payload: { streamKind: "assistant_text", delta: message.text },
+      });
+      message.completed = true;
+      publish({
+        ...baseEvent(threadId, active, turn.turnId),
+        itemId: message.itemId,
+        type: "item.completed",
+        payload: { itemType: "assistant_message", status: "completed" },
+      });
+    };
+
     const completeAssistantMessages = (
       threadId: ThreadId,
       active: ActiveSession,
       turn: ActiveTurn,
     ) => {
       for (const message of turn.assistantMessages.values()) {
-        if (!message.started || message.completed) continue;
-        message.completed = true;
-        publish({
-          ...baseEvent(threadId, active, turn.turnId),
-          itemId: message.itemId,
-          type: "item.completed",
-          payload: { itemType: "assistant_message", status: "completed" },
-        });
+        completeAssistantMessage(threadId, active, turn, message);
       }
     };
 
@@ -491,43 +511,17 @@ const make = (options?: AgentControllerLiveOptions) =>
       const messageKey = String(message.id);
       let activeMessage = turn.assistantMessages.get(messageKey);
       if (!activeMessage) {
+        completeAssistantMessages(threadId, active, turn);
         activeMessage = {
           itemId: RuntimeItemId.make(`mastra-answer-${messageKey}`),
-          length: 0,
-          started: false,
+          text: "",
           completed: false,
         };
         turn.assistantMessages.set(messageKey, activeMessage);
       }
       if (activeMessage.completed) return;
-      if (!activeMessage.started && text.length > 0) {
-        activeMessage.started = true;
-        publish({
-          ...baseEvent(threadId, active, turn.turnId),
-          itemId: activeMessage.itemId,
-          type: "item.started",
-          payload: { itemType: "assistant_message", status: "inProgress" },
-        });
-      }
-      if (text.length > activeMessage.length) {
-        const delta = text.slice(activeMessage.length);
-        activeMessage.length = text.length;
-        publish({
-          ...baseEvent(threadId, active, turn.turnId),
-          itemId: activeMessage.itemId,
-          type: "content.delta",
-          payload: { streamKind: "assistant_text", delta },
-        });
-      }
-      if (complete && activeMessage.started && !activeMessage.completed) {
-        activeMessage.completed = true;
-        publish({
-          ...baseEvent(threadId, active, turn.turnId),
-          itemId: activeMessage.itemId,
-          type: "item.completed",
-          payload: { itemType: "assistant_message", status: "completed" },
-        });
-      }
+      activeMessage.text = text;
+      if (complete) completeAssistantMessage(threadId, active, turn, activeMessage);
     };
 
     const handleControllerEvent = (


### PR DESCRIPTION
Mastra emits complete message snapshots that can rewrite earlier text. The server treated each snapshot as append-only, so users received scrambled replies.

Buffer the latest snapshot and publish it at a message, tool, or turn boundary. A focused regression test covers a shorter rewritten final snapshot.

Tests: `vp test run apps/server/src/provider/Layers/AgentController.test.ts`
Typecheck: `vp run --filter akeru-bot typecheck`

Model: gpt-5.6-sol
Harness: Codex harness in T3 Code