### PR TITLE
feat(server): run browsers in remote sandboxes

### DIFF
--- a/apps/server/src/provider/AkeruSessionResources.test.ts
+++ b/apps/server/src/provider/AkeruSessionResources.test.ts
@@ -322,6 +322,7 @@ describe("AkeruSessionResources", () => {
         providerId: providerId ?? "provider-1",
         inspect: async () => "running",
         run: async () => ({ exitCode: 0, stdout: "", stderr: "" }),
+        browserEndpoint: async () => ({ url: "https://browser.example", requestHeaders: {} }),
         wake: async () => undefined,
         sleep,
         destroy,

--- a/apps/server/src/provider/AkeruSessionResources.test.ts
+++ b/apps/server/src/provider/AkeruSessionResources.test.ts
@@ -385,12 +385,17 @@ describe("AkeruSessionResources", () => {
     await resources.shutdown();
   });
 
-  it("does not create or attach a browser for remote workspaces", async () => {
+  it("creates and attaches a browser for remote workspaces", async () => {
+    const browserEndpoint = vi.fn(async () => ({
+      url: "https://browser.example",
+      requestHeaders: { authorization: "Bearer token" },
+    }));
     const remote: AkeruBotWorkspace = {
       id: "akeru-shared",
       provider: "vercel",
       providerId: "vercel-native-id",
       workspace: workspace(),
+      browserEndpoint,
       inspect: async () => "running",
       wake: vi.fn(async () => undefined),
       sleep: vi.fn(async () => undefined),
@@ -402,7 +407,8 @@ describe("AkeruSessionResources", () => {
       getTools: vi.fn(() => ({ exa_search: {} })),
       getServerStatuses: vi.fn(() => []),
     };
-    const makeBotBrowser = vi.fn(() => browser());
+    const remoteBrowser = browser();
+    const makeBotBrowser = vi.fn(() => remoteBrowser);
     const toMcpServerConfigs = vi.fn(() => ({}));
     const resources = new AkeruSessionResources({
       stateDir: stateDir(),
@@ -428,7 +434,10 @@ describe("AkeruSessionResources", () => {
       ],
     });
 
-    expect(makeBotBrowser).not.toHaveBeenCalled();
+    expect(makeBotBrowser).toHaveBeenCalledWith(
+      expect.objectContaining({ browserEndpoint, workspace: remote.workspace }),
+    );
+    expect(remoteBrowser.attachment).toHaveBeenCalledOnce();
     expect(toMcpServerConfigs).toHaveBeenCalledWith(expect.any(Array), undefined);
     expect(resources.getConnectorTools("remote-mcp")).toEqual({ exa_search: {} });
     await resources.shutdown();

--- a/apps/server/src/provider/AkeruSessionResources.ts
+++ b/apps/server/src/provider/AkeruSessionResources.ts
@@ -146,42 +146,42 @@ export class AkeruSessionResources {
         this.userComputerWorkspaceLeases.set(key, userComputerWorkspaceLease);
       }
 
-      let browser: BotBrowser | undefined;
-      if (workspaceLease.workspace.provider === "local") {
-        const existingBrowser = this.resourceBrowsers.get(input.workspaceResourceKey);
-        browser =
-          existingBrowser ??
-          (this.options.makeBotBrowser ?? createBotBrowser)({
-            threadId: input.resourceScope,
-            workspace: workspaceLease.workspace.workspace,
-            cacheDir: NodePath.join(this.options.stateDir, "bot-browser-runtime"),
-          });
+      const existingBrowser = this.resourceBrowsers.get(input.workspaceResourceKey);
+      const browser =
+        existingBrowser ??
+        (this.options.makeBotBrowser ?? createBotBrowser)({
+          threadId: input.resourceScope,
+          workspace: workspaceLease.workspace.workspace,
+          cacheDir: NodePath.join(this.options.stateDir, "bot-browser-runtime"),
+          ...(workspaceLease.workspace.browserEndpoint
+            ? { browserEndpoint: workspaceLease.workspace.browserEndpoint }
+            : {}),
+        });
 
-        this.resourceBrowsers.set(input.workspaceResourceKey, browser);
-        this.threadBrowsers.set(key, browser);
-        this.browserResourceKeys.set(key, input.workspaceResourceKey);
-        this.browserReferences.set(
-          input.workspaceResourceKey,
-          (this.browserReferences.get(input.workspaceResourceKey) ?? 0) + 1,
-        );
+      this.resourceBrowsers.set(input.workspaceResourceKey, browser);
+      this.threadBrowsers.set(key, browser);
+      this.browserResourceKeys.set(key, input.workspaceResourceKey);
+      this.browserReferences.set(
+        input.workspaceResourceKey,
+        (this.browserReferences.get(input.workspaceResourceKey) ?? 0) + 1,
+      );
 
-        let reconnect = this.browserReconnects.get(input.workspaceResourceKey);
-        if (existingBrowser && workspaceLease.wokeFromSleep && !reconnect) {
-          reconnect = browser.reconnect().finally(() => {
-            this.browserReconnects.delete(input.workspaceResourceKey);
-          });
-          this.browserReconnects.set(input.workspaceResourceKey, reconnect);
-        }
-        try {
-          await reconnect;
-        } catch (cause) {
-          await this.invalidateBrowser(input.workspaceResourceKey, browser);
-          throw cause;
-        }
+      let reconnect = this.browserReconnects.get(input.workspaceResourceKey);
+      if (existingBrowser && workspaceLease.wokeFromSleep && !reconnect) {
+        reconnect = browser.reconnect().finally(() => {
+          this.browserReconnects.delete(input.workspaceResourceKey);
+        });
+        this.browserReconnects.set(input.workspaceResourceKey, reconnect);
+      }
+      try {
+        await reconnect;
+      } catch (cause) {
+        await this.invalidateBrowser(input.workspaceResourceKey, browser);
+        throw cause;
       }
 
       if (input.mcpServers.length > 0) {
-        const attachment = await browser?.attachment();
+        const attachment = await browser.attachment();
         const manager = (this.options.makeMcpManager ?? createMcpManager)(
           NodePath.join(this.options.stateDir, "bot-mcp-runtime"),
           ".akeru-runtime",

--- a/apps/server/src/provider/Layers/AgentController.test.ts
+++ b/apps/server/src/provider/Layers/AgentController.test.ts
@@ -1369,7 +1369,7 @@ describe("AgentControllerLive", () => {
         }),
       );
       expect(mastra.createSession.mock.calls[0]?.[0]).toMatchObject({ workspace: remote });
-      expect(makeBotBrowser).not.toHaveBeenCalled();
+      expect(makeBotBrowser).toHaveBeenCalledOnce();
       yield* controller.stopSession({ threadId: codexThreadId });
     }).pipe(Effect.provide(layer), Effect.orDie);
   });
@@ -1475,7 +1475,12 @@ describe("AgentControllerLive", () => {
     });
     const destroy = vi.spyOn(remote, "destroy");
     const makeRemoteWorkspace = vi.fn(async () => remote);
-    const makeBotBrowser = vi.fn();
+    const makeBotBrowser = vi.fn(() => ({
+      tools: {},
+      attachment: vi.fn(async () => undefined),
+      reconnect: vi.fn(async () => undefined),
+      close: vi.fn(async () => undefined),
+    }));
     const layer = makeAgentControllerLive({
       makeMastraHarness: mastra.factory,
       makeRemoteWorkspace,
@@ -1507,7 +1512,7 @@ describe("AgentControllerLive", () => {
 
       expect(makeRemoteWorkspace).toHaveBeenCalledOnce();
       expect(destroy).not.toHaveBeenCalled();
-      expect(makeBotBrowser).not.toHaveBeenCalled();
+      expect(makeBotBrowser).toHaveBeenCalledOnce();
     }).pipe(Effect.provide(layer), Effect.orDie);
   });
 

--- a/apps/server/src/provider/botBrowser.test.ts
+++ b/apps/server/src/provider/botBrowser.test.ts
@@ -1,4 +1,9 @@
-import { LocalFilesystem, LocalSandbox, Workspace } from "@mastra/core/workspace";
+import {
+  LocalFilesystem,
+  LocalSandbox,
+  Workspace,
+  type WorkspaceSandbox,
+} from "@mastra/core/workspace";
 import { describe, expect, it, vi } from "vite-plus/test";
 
 import {
@@ -129,5 +134,111 @@ describe("sandbox bot browser", () => {
     expect(browserRpc.reconnect).toHaveBeenCalledOnce();
     expect(browserRpc.close).toHaveBeenCalledOnce();
     await workspace.destroy();
+  });
+
+  it("creates and reconnects one remote browser while preserving its current URL", async () => {
+    const executeCommand = vi.fn(async (command: string, args: string[] = []) => ({
+      exitCode: 0,
+      stdout:
+        command === "uname"
+          ? args[0] === "-s"
+            ? "Linux\n"
+            : "x86_64\n"
+          : command === "sh"
+            ? "4242\n"
+            : "",
+      stderr: "",
+      success: true,
+      executionTimeMs: 1,
+    }));
+    const workspace = new Workspace({
+      filesystem: new LocalFilesystem({ basePath: process.cwd() }),
+      sandbox: {
+        id: "remote-workspace",
+        provider: "e2b",
+        executeCommand,
+      } as unknown as WorkspaceSandbox,
+    });
+    const browserEndpoint = vi.fn(async () => ({
+      url: "https://9223-e2b.example",
+      requestHeaders: { "e2b-traffic-access-token": "traffic-token" },
+    }));
+    const messages: Array<{ method?: string; params?: { name?: string } }> = [];
+    let session = 0;
+    const fetchMock = vi.fn(async (_url: string | URL | Request, init?: RequestInit) => {
+      if (init?.method === "DELETE") return new Response("", { status: 204 });
+      const message = JSON.parse(String(init?.body)) as {
+        method?: string;
+        params?: { name?: string };
+      };
+      messages.push(message);
+      const sessionId =
+        message.method === "initialize" ? `browser-session-${++session}` : undefined;
+      const text =
+        message.params?.name === "session_list"
+          ? JSON.stringify([{ url: "https://example.com/bottom-edge" }])
+          : "ok";
+      return new Response(JSON.stringify({ result: { content: [{ text }] } }), {
+        status: 200,
+        headers: sessionId ? { "mcp-session-id": sessionId } : {},
+      });
+    });
+    vi.stubGlobal("fetch", fetchMock);
+    const browser = createBotBrowser({
+      threadId: "remote-browser",
+      workspace,
+      cacheDir: "/tmp/unused-remote-browser-cache",
+      browserEndpoint,
+    });
+
+    try {
+      await expect(browser.attachment()).resolves.toMatchObject({
+        browserUrl: "https://9223-e2b.example",
+        requestHeaders: { "e2b-traffic-access-token": "traffic-token" },
+        localRequestHeaders: { "e2b-traffic-access-token": "traffic-token" },
+        availableToHostedPlugins: true,
+      });
+      await executeTool(browser.tools.browser_click, { selector: "#bottom-target" });
+      await browser.reconnect();
+      await expect(browser.attachment()).resolves.toMatchObject({
+        mcpSessionId: "browser-session-2",
+      });
+
+      expect(browserEndpoint).toHaveBeenNthCalledWith(1, 9223);
+      expect(browserEndpoint).toHaveBeenNthCalledWith(2, 9223);
+      expect(executeCommand.mock.calls.filter(([command]) => command === "sh")).toHaveLength(2);
+      expect(messages).toContainEqual(
+        expect.objectContaining({
+          method: "tools/call",
+          params: expect.objectContaining({ name: "goto" }),
+        }),
+      );
+      for (const [, init] of fetchMock.mock.calls) {
+        expect(init?.headers).toMatchObject({
+          "e2b-traffic-access-token": "traffic-token",
+        });
+      }
+    } finally {
+      await browser.close();
+      vi.unstubAllGlobals();
+    }
+  });
+
+  it("fails closed when a remote workspace has no browser endpoint", async () => {
+    const browser = createBotBrowser({
+      threadId: "unsupported-remote-browser",
+      workspace: new Workspace({
+        filesystem: new LocalFilesystem({ basePath: process.cwd() }),
+        sandbox: {
+          id: "unsupported-remote-workspace",
+          provider: "remote",
+          executeCommand: vi.fn(),
+        } as unknown as WorkspaceSandbox,
+      }),
+      cacheDir: "/tmp/unused-remote-browser-cache",
+    });
+
+    await expect(browser.attachment()).rejects.toThrow("has no Akeru browser adapter");
+    await browser.close();
   });
 });

--- a/apps/server/src/provider/botBrowser.ts
+++ b/apps/server/src/provider/botBrowser.ts
@@ -9,11 +9,13 @@ import type { ProcessHandle, Workspace, WorkspaceSandbox } from "@mastra/core/wo
 import { z } from "zod";
 
 import { redactSensitiveText } from "../mcp/SensitiveDataRedaction.ts";
+import type { AkeruBrowserEndpoint } from "./botWorkspace.ts";
 
 const LIGHTPANDA_VERSION = "0.3.7";
 const MAX_SNAPSHOT_LENGTH = 50 * 1_024;
 const MCP_PROTOCOL_VERSION = "2024-11-05";
 const BROWSER_REQUEST_TIMEOUT_MS = 30_000;
+const REMOTE_BROWSER_PORT = 9_223;
 
 interface LightpandaRelease {
   readonly url: string;
@@ -63,17 +65,15 @@ export interface BotBrowserRpc {
   readonly close: () => Promise<void>;
 }
 
-export interface CreateBotBrowserInput {
-  readonly threadId: string;
-  readonly workspace: Workspace;
-  readonly cacheDir: string;
-  readonly makeRpc?: (input: BotBrowserProcessInput) => BotBrowserRpc;
-}
-
 export interface BotBrowserProcessInput {
   readonly threadId: string;
   readonly workspace: Workspace;
   readonly cacheDir: string;
+  readonly browserEndpoint?: (port: number) => Promise<AkeruBrowserEndpoint>;
+}
+
+export interface CreateBotBrowserInput extends BotBrowserProcessInput {
+  readonly makeRpc?: (input: BotBrowserProcessInput) => BotBrowserRpc;
 }
 
 interface JsonRpcResponse {
@@ -206,13 +206,17 @@ function availableLocalPort(): Promise<number> {
   });
 }
 
-function browserRequestTransport(url: string): BrowserRequestTransport {
+function browserRequestTransport(
+  url: string,
+  requestHeaders: Readonly<Record<string, string>> = {},
+): BrowserRequestTransport {
   return async (request) => {
     // This runtime is owned by Mastra's promise-based workspace API, not an Effect layer.
     // @effect-diagnostics-next-line globalFetch:off
     const response = await fetch(url, {
       method: request.method,
       headers: {
+        ...requestHeaders,
         accept: "application/json, text/event-stream",
         ...(request.method === "POST" ? { "content-type": "application/json" } : {}),
         ...(request.sessionId ? { "mcp-session-id": request.sessionId } : {}),
@@ -226,6 +230,28 @@ function browserRequestTransport(url: string): BrowserRequestTransport {
       body: await response.text(),
       ...(sessionId ? { sessionId } : {}),
     };
+  };
+}
+
+type BrowserProcess = Pick<ProcessHandle, "kill">;
+
+async function spawnRemoteBrowser(
+  sandbox: WorkspaceSandbox,
+  binaryPath: string,
+  port: number,
+): Promise<BrowserProcess> {
+  const command = lightpandaMcpCommand(binaryPath, port);
+  const output = await execute(sandbox, "sh", [
+    "-lc",
+    `nohup ${command} >${shellQuote(`/tmp/akeru-browser-${port}.log`)} 2>&1 </dev/null & echo $!`,
+  ]);
+  const pid = output.trim();
+  if (!/^[1-9]\d*$/.test(pid)) {
+    throw new Error(`Sandbox '${sandbox.provider}' did not return a browser process id.`);
+  }
+  return {
+    kill: async () =>
+      (await sandbox.executeCommand?.("kill", [pid], { timeout: 5_000 }))?.success ?? false,
   };
 }
 
@@ -246,7 +272,7 @@ function rpcResultText(value: unknown): string {
 class LightpandaRpc implements BotBrowserRpc {
   private readonly input: BotBrowserProcessInput;
   private nextId = 1;
-  private processes: ProcessHandle[] = [];
+  private processes: BrowserProcess[] = [];
   private startPromise: Promise<void> | undefined;
   private requestTransport: BrowserRequestTransport | undefined;
   private attachmentValue: BotBrowserAttachment | undefined;
@@ -293,40 +319,47 @@ class LightpandaRpc implements BotBrowserRpc {
 
   private async start(): Promise<void> {
     const sandbox = this.input.workspace.sandbox;
-    if (!sandbox?.processes) {
+    if (!sandbox?.executeCommand) {
       throw new Error(`Workspace '${this.input.workspace.id}' cannot host a sandbox browser.`);
     }
-    if (sandbox.provider !== "local") {
+    const local = sandbox.provider === "local";
+    if (local && !sandbox.processes) {
+      throw new Error(`Workspace '${this.input.workspace.id}' cannot host a sandbox browser.`);
+    }
+    if (!local && !this.input.browserEndpoint) {
       throw new Error(`Sandbox '${sandbox.provider}' has no Akeru browser adapter.`);
     }
     const binaryPath = await installLightpanda(sandbox, this.input.cacheDir);
     if (this.closed) throw new Error(`Sandbox browser for '${this.input.threadId}' is closed.`);
-    const browserPort = await availableLocalPort();
-    const browserHandle = await sandbox.processes.spawn(
-      lightpandaMcpCommand(binaryPath, browserPort, "127.0.0.1"),
-      { maxRetainedBytes: 64 * 1_024 },
-    );
+    const browserPort = local ? await availableLocalPort() : REMOTE_BROWSER_PORT;
+    const endpoint = local
+      ? { url: `http://127.0.0.1:${browserPort}`, requestHeaders: {} }
+      : await this.input.browserEndpoint!(browserPort);
+    const browserHandle = local
+      ? await sandbox.processes!.spawn(lightpandaMcpCommand(binaryPath, browserPort, "127.0.0.1"), {
+          maxRetainedBytes: 64 * 1_024,
+        })
+      : await spawnRemoteBrowser(sandbox, binaryPath, browserPort);
     const processes = [browserHandle];
     if (this.closed) {
       await Promise.all(processes.map((process) => process.kill().catch(() => false)));
       throw new Error(`Sandbox browser for '${this.input.threadId}' is closed.`);
     }
     this.processes = processes;
-    for (const process of processes) {
-      void process.wait().then(() => this.processStopped(process));
+    if (local) {
+      void (browserHandle as ProcessHandle).wait().then(() => this.processStopped(browserHandle));
     }
 
     try {
-      const browserUrl = `http://127.0.0.1:${browserPort}`;
-      this.requestTransport = browserRequestTransport(browserUrl);
+      this.requestTransport = browserRequestTransport(endpoint.url, endpoint.requestHeaders);
       await this.initialize();
       await this.restoreCurrentUrl();
       this.attachmentValue = {
-        browserUrl,
+        browserUrl: endpoint.url,
         mcpSessionId: this.sessionId!,
-        requestHeaders: {},
-        localRequestHeaders: {},
-        availableToHostedPlugins: false,
+        requestHeaders: endpoint.requestHeaders,
+        localRequestHeaders: endpoint.requestHeaders,
+        availableToHostedPlugins: !local,
       };
     } catch (cause) {
       this.processes = [];
@@ -338,7 +371,7 @@ class LightpandaRpc implements BotBrowserRpc {
     }
   }
 
-  private processStopped(process: ProcessHandle): void {
+  private processStopped(process: BrowserProcess): void {
     if (this.closed || !this.processes.includes(process)) return;
     const remaining = this.processes.filter((candidate) => candidate !== process);
     this.processes = [];

--- a/apps/server/src/provider/botWorkspace.test.ts
+++ b/apps/server/src/provider/botWorkspace.test.ts
@@ -10,10 +10,12 @@ import {
   createBotWorkspace,
   createRemoteBotWorkspace,
   daytona,
+  e2b,
   type AkeruRemoteSession,
   isRemoteBotSandbox,
   upstash,
   upstashWorkspaceState,
+  vercel,
   vercelWorkspaceState,
 } from "./botWorkspace.ts";
 
@@ -22,6 +24,7 @@ function remoteSession(providerId: string): AkeruRemoteSession {
     providerId,
     inspect: async () => "running",
     run: async () => ({ exitCode: 0, stdout: "", stderr: "" }),
+    browserEndpoint: async () => ({ url: "https://browser.example", requestHeaders: {} }),
     wake: async () => undefined,
     sleep: async () => undefined,
     destroy: async () => undefined,
@@ -153,6 +156,10 @@ describe("createBotWorkspace", () => {
       pause,
       start,
       delete: vi.fn(async () => undefined),
+      getPreviewLink: vi.fn(async () => ({
+        url: "https://9223-daytona.example",
+        token: "daytona-token",
+      })),
       process: { executeCommand: vi.fn() },
     } as unknown as import("@daytona/sdk").Sandbox;
     const client = {
@@ -167,6 +174,46 @@ describe("createBotWorkspace", () => {
     expect(pause).toHaveBeenCalledOnce();
     expect(start).toHaveBeenCalledOnce();
     expect(await session.inspect()).toBe("running");
+    await expect(session.browserEndpoint(9223)).resolves.toEqual({
+      url: "https://9223-daytona.example/?DAYTONA_SANDBOX_AUTH_KEY=daytona-token",
+      requestHeaders: {},
+    });
+  });
+
+  it("keeps E2B browser ingress private", async () => {
+    const session = e2b({
+      sandboxId: "e2b-id",
+      trafficAccessToken: "e2b-token",
+      getHost: (port: number) => `${port}-e2b.example`,
+      commands: { run: vi.fn() },
+      pause: vi.fn(),
+      kill: vi.fn(),
+    } as unknown as import("e2b").Sandbox);
+
+    await expect(session.browserEndpoint(9223)).resolves.toEqual({
+      url: "https://9223-e2b.example",
+      requestHeaders: { "e2b-traffic-access-token": "e2b-token" },
+    });
+  });
+
+  it("adds the Vercel browser port without removing existing routes", async () => {
+    const update = vi.fn(async () => undefined);
+    const session = vercel({
+      name: "vercel-id",
+      status: "running",
+      routes: [{ port: 3000 }],
+      update,
+      domain: (port: number) => `https://${port}-vercel.example`,
+      runCommand: vi.fn(),
+      stop: vi.fn(),
+      delete: vi.fn(),
+    } as unknown as import("@vercel/sandbox").Sandbox);
+
+    await expect(session.browserEndpoint(9223)).resolves.toEqual({
+      url: "https://9223-vercel.example",
+      requestHeaders: {},
+    });
+    expect(update).toHaveBeenCalledWith({ ports: [3000, 9223] });
   });
 
   it("resumes a paused Upstash workspace after reattach", async () => {
@@ -180,6 +227,11 @@ describe("createBotWorkspace", () => {
       resume,
       pause: vi.fn(async () => undefined),
       delete: vi.fn(async () => undefined),
+      getPublicURL: vi.fn(async () => ({
+        url: "https://9223-upstash.example",
+        port: 9223,
+        token: "upstash-token",
+      })),
       exec: { command: vi.fn() },
     } as unknown as import("@upstash/box").Box;
     const session = upstash(box);
@@ -188,6 +240,42 @@ describe("createBotWorkspace", () => {
 
     expect(resume).toHaveBeenCalledOnce();
     expect(await session.inspect()).toBe("running");
+    await expect(session.browserEndpoint(9223)).resolves.toEqual({
+      url: "https://9223-upstash.example",
+      requestHeaders: { authorization: "Bearer upstash-token" },
+    });
+  });
+
+  it("fails closed when a remote provider omits browser credentials", async () => {
+    const e2bSession = e2b({
+      sandboxId: "e2b-id",
+      getHost: vi.fn(),
+      commands: { run: vi.fn() },
+      pause: vi.fn(),
+      kill: vi.fn(),
+    } as unknown as import("e2b").Sandbox);
+    const upstashSession = upstash({
+      id: "upstash-id",
+      getPublicURL: vi.fn(async () => ({ url: "https://upstash.example", port: 9223 })),
+    } as unknown as import("@upstash/box").Box);
+    const daytonaSession = daytona(
+      {} as import("@daytona/sdk").Daytona,
+      {
+        id: "daytona-id",
+        getPreviewLink: vi.fn(async () => ({
+          url: "https://daytona.example",
+          token: "",
+        })),
+      } as unknown as import("@daytona/sdk").Sandbox,
+    );
+
+    await expect(e2bSession.browserEndpoint(9223)).rejects.toThrow("no traffic access token");
+    await expect(daytonaSession.browserEndpoint(9223)).rejects.toThrow(
+      "no authenticated preview URL",
+    );
+    await expect(upstashSession.browserEndpoint(9223)).rejects.toThrow(
+      "no authenticated public URL",
+    );
   });
 
   it("does not classify unavailable provider states as running", () => {

--- a/apps/server/src/provider/botWorkspace.ts
+++ b/apps/server/src/provider/botWorkspace.ts
@@ -19,11 +19,17 @@ export const REMOTE_BOT_SANDBOXES = ["e2b", "daytona", "vercel", "upstash"] as c
 export type RemoteBotSandbox = (typeof REMOTE_BOT_SANDBOXES)[number];
 export type AkeruWorkspaceState = "running" | "sleeping" | "missing";
 
+export interface AkeruBrowserEndpoint {
+  readonly url: string;
+  readonly requestHeaders: Readonly<Record<string, string>>;
+}
+
 export interface AkeruBotWorkspace {
   readonly id: string;
   readonly provider: BotSandbox;
   readonly providerId?: string;
   readonly workspace: Workspace;
+  readonly browserEndpoint?: (port: number) => Promise<AkeruBrowserEndpoint>;
   readonly inspect: () => Promise<AkeruWorkspaceState>;
   readonly wake: () => Promise<void>;
   readonly sleep: () => Promise<void>;
@@ -38,6 +44,7 @@ export interface AkeruRemoteSession {
     args: readonly string[],
     options?: { cwd?: string; env?: Record<string, string>; timeout?: number },
   ) => Promise<{ exitCode: number; stdout: string; stderr: string }>;
+  readonly browserEndpoint: (port: number) => Promise<AkeruBrowserEndpoint>;
   readonly wake: () => Promise<void>;
   readonly sleep: () => Promise<void>;
   readonly destroy: () => Promise<void>;
@@ -142,6 +149,7 @@ export async function createRemoteBotWorkspace(
     provider: input.sandbox,
     providerId: session.providerId,
     workspace,
+    browserEndpoint: session.browserEndpoint,
     inspect: session.inspect,
     wake: () => workspace.init(),
     sleep: () => workspace.stop(),
@@ -254,7 +262,12 @@ const commandLine = (command: string, args: readonly string[]) =>
 async function create(provider: RemoteBotSandbox, id: string): Promise<AkeruRemoteSession> {
   if (provider === "e2b") {
     const { Sandbox } = await import("e2b");
-    return e2b(await Sandbox.create({ lifecycle: { onTimeout: "pause" } }));
+    return e2b(
+      await Sandbox.create({
+        lifecycle: { onTimeout: "pause" },
+        network: { allowPublicTraffic: false },
+      }),
+    );
   }
   if (provider === "daytona") {
     const { Daytona } = await import("@daytona/sdk");
@@ -287,7 +300,7 @@ async function open(provider: RemoteBotSandbox, id: string): Promise<AkeruRemote
   return upstash(await Box.get(id));
 }
 
-function e2b(initial: import("e2b").Sandbox): AkeruRemoteSession {
+export function e2b(initial: import("e2b").Sandbox): AkeruRemoteSession {
   let sandbox = initial;
   const providerId = sandbox.sandboxId;
   return {
@@ -304,6 +317,14 @@ function e2b(initial: import("e2b").Sandbox): AkeruRemoteSession {
         ...(options?.timeout ? { timeoutMs: options.timeout } : {}),
       });
       return { exitCode: result.exitCode, stdout: result.stdout, stderr: result.stderr };
+    },
+    browserEndpoint: async (port) => {
+      const token = sandbox.trafficAccessToken?.trim();
+      if (!token) throw new Error(`E2B workspace '${providerId}' has no traffic access token.`);
+      return {
+        url: `https://${sandbox.getHost(port)}`,
+        requestHeaders: { "e2b-traffic-access-token": token },
+      };
     },
     wake: async () => {
       const { Sandbox } = await import("e2b");
@@ -338,6 +359,16 @@ export function daytona(
       );
       return { exitCode: result.exitCode, stdout: result.result, stderr: "" };
     },
+    browserEndpoint: async (port) => {
+      const preview = await sandbox.getPreviewLink(port);
+      const token = preview.token?.trim();
+      if (!preview.url || !token) {
+        throw new Error(`Daytona workspace '${sandbox.id}' has no authenticated preview URL.`);
+      }
+      const url = new URL(preview.url);
+      url.searchParams.set("DAYTONA_SANDBOX_AUTH_KEY", token);
+      return { url: url.toString(), requestHeaders: {} };
+    },
     wake: async () => {
       if ((await sandbox.refreshData(), String(sandbox.state)) !== "started") {
         await sandbox.start();
@@ -359,7 +390,7 @@ export function vercelWorkspaceState(
   return "sleeping";
 }
 
-function vercel(initial: import("@vercel/sandbox").Sandbox): AkeruRemoteSession {
+export function vercel(initial: import("@vercel/sandbox").Sandbox): AkeruRemoteSession {
   let sandbox = initial;
   return {
     providerId: sandbox.name,
@@ -381,6 +412,12 @@ function vercel(initial: import("@vercel/sandbox").Sandbox): AkeruRemoteSession 
         stdout: await result.stdout(),
         stderr: await result.stderr(),
       };
+    },
+    browserEndpoint: async (port) => {
+      if (!sandbox.routes.some((route) => route.port === port)) {
+        await sandbox.update({ ports: [...sandbox.routes.map((route) => route.port), port] });
+      }
+      return { url: sandbox.domain(port), requestHeaders: {} };
     },
     wake: async () => {
       const { Sandbox } = await import("@vercel/sandbox");
@@ -418,6 +455,17 @@ export function upstash(box: import("@upstash/box").Box): AkeruRemoteSession {
         `${options?.cwd ? `cd ${quote(options.cwd)} && ` : ""}${line}`,
       );
       return { exitCode: result.exitCode ?? 1, stdout: result.result, stderr: "" };
+    },
+    browserEndpoint: async (port) => {
+      const preview = await box.getPublicURL(port, { bearerToken: true });
+      const token = preview.token?.trim();
+      if (!preview.url || !token) {
+        throw new Error(`Upstash workspace '${box.id}' has no authenticated public URL.`);
+      }
+      return {
+        url: preview.url,
+        requestHeaders: { authorization: `Bearer ${token}` },
+      };
     },
     wake: async () => {
       const current = await inspect();


### PR DESCRIPTION
## What changed

Run the Akeru-owned browser inside Local, E2B, Daytona, Vercel Sandbox, and Upstash Box workspaces. Preserve the browser URL across remote workspace reconnects and pass authenticated endpoints to browser-aware MCP plugins.

## Why

Bots need one browser implementation across every sandbox provider. The runtime now owns browser startup, authenticated ingress, reconnect, and cleanup through the existing workspace lifecycle.

## Verification

- 32 focused provider tests passed
- Server typecheck passed
- Targeted lint and format checks passed

## Related issues

- [LEO-278](https://linear.app/opencoredev/issue/LEO-278/drive-the-sandbox-browser-through-the-akeru-runtime)
- [LEO-284](https://linear.app/opencoredev/issue/LEO-284/replace-sandbox-sdk-and-recover-bot-workspaces)
- [LEO-294](https://linear.app/opencoredev/issue/LEO-294/own-launch-stacks-and-shared-file-integration)
- [LEO-327](https://linear.app/opencoredev/issue/LEO-327/land-workspace-pooling-and-sandbox-browser)

Model: GPT-5.6 Sol
Harness: Codex in T3 Code