### PR TITLE
fix(web): keep group avatars during search

### DIFF
--- a/apps/web/src/components/roster/BotRosterSidebar.tsx
+++ b/apps/web/src/components/roster/BotRosterSidebar.tsx
@@ -369,8 +369,8 @@ export default function BotRosterSidebar() {
   const pinnedBots = visibleBots.filter((bot) => bot.pinned);
   const unpinnedBots = visibleBots.filter((bot) => !bot.pinned);
   const groupSections = useMemo(
-    () => buildGroupedRosterSections(visibleBots, groups),
-    [groups, visibleBots],
+    () => buildGroupedRosterSections(dragLayout ?? bots, groups, query),
+    [bots, dragLayout, groups, query],
   );
   const activeBot =
     activeBotId === null

--- a/apps/web/src/components/roster/roster.logic.test.ts
+++ b/apps/web/src/components/roster/roster.logic.test.ts
@@ -115,6 +115,76 @@ describe("buildGroupedRosterSections", () => {
     expect(sections[0]?.bots.map((entry) => entry.id)).toEqual(["assigned"]);
     expect(sections[1]?.bots.map((entry) => entry.id)).toEqual(["free"]);
   });
+
+  it("keeps every group member when the group name matches a search", () => {
+    const sections = buildGroupedRosterSections(
+      [
+        bot({ id: "atlas", name: "Atlas", groupId: group.id }),
+        bot({ id: "mori", name: "Mori", groupId: group.id }),
+        bot({ id: "free", name: "Free" }),
+      ],
+      [group],
+      "product",
+    );
+
+    expect(sections.map((section) => section.name)).toEqual(["Product"]);
+    expect(sections[0]?.bots.map((entry) => entry.id)).toEqual(["atlas", "mori"]);
+  });
+
+  it("keeps every group member when one member matches a search", () => {
+    const sections = buildGroupedRosterSections(
+      [
+        bot({ id: "atlas", name: "Atlas", groupId: group.id }),
+        bot({ id: "mori", name: "Mori", groupId: group.id }),
+      ],
+      [group],
+      "atlas",
+    );
+
+    expect(sections[0]?.bots.map((entry) => entry.id)).toEqual(["atlas", "mori"]);
+  });
+
+  it("hides a name-matching group when every member is pinned or archived", () => {
+    const sections = buildGroupedRosterSections(
+      [
+        bot({ id: "atlas", name: "Atlas", groupId: group.id, pinned: true }),
+        bot({
+          id: "gone",
+          name: "Gone",
+          groupId: group.id,
+          archivedAt: "2026-08-20T00:00:00.000Z",
+        }),
+      ],
+      [group],
+      "product",
+    );
+
+    expect(sections).toEqual([]);
+  });
+
+  it("hides groups whose name and members miss the search", () => {
+    const sections = buildGroupedRosterSections(
+      [bot({ id: "atlas", name: "Atlas", groupId: group.id }), bot({ id: "free", name: "Free" })],
+      [group],
+      "asdfasdf",
+    );
+
+    expect(sections).toEqual([]);
+  });
+
+  it("keeps only matching unassigned bots", () => {
+    const sections = buildGroupedRosterSections(
+      [
+        bot({ id: "1", name: "Akeru", label: "Research" }),
+        bot({ id: "2", name: "Mori", label: "Design" }),
+      ],
+      [],
+      "research",
+    );
+
+    expect(sections.map((section) => section.name)).toEqual(["Unassigned"]);
+    expect(sections[0]?.bots.map((entry) => entry.id)).toEqual(["1"]);
+  });
 });
 
 describe("buildRosterStrip", () => {

--- a/apps/web/src/components/roster/roster.logic.ts
+++ b/apps/web/src/components/roster/roster.logic.ts
@@ -237,20 +237,34 @@ export interface RosterGroupSection {
   readonly bots: ReadonlyArray<Bot>;
 }
 
-/** Assigned groups first, then every bot without a group under Unassigned. */
+/**
+ * Assigned groups first, then every bot without a group under Unassigned.
+ * A matching group keeps every member so stacked avatars stay visible.
+ */
 export function buildGroupedRosterSections(
   bots: ReadonlyArray<Bot>,
   groups: ReadonlyArray<Group>,
+  query = "",
 ): ReadonlyArray<RosterGroupSection> {
+  const needle = query.trim().toLowerCase();
   const active = bots.filter((bot) => bot.archivedAt === null && bot.pinned === false);
   const assigned = groups.flatMap((group) => {
     const groupBots = active.filter((bot) => bot.groupId === group.id);
-    return groupBots.length > 0 ? [{ id: group.id, name: group.name, bots: groupBots }] : [];
+    const matchesQuery =
+      needle.length === 0 ||
+      group.name.toLowerCase().includes(needle) ||
+      filterRosterBots(groupBots, query).length > 0;
+    return groupBots.length > 0 && matchesQuery
+      ? [{ id: group.id, name: group.name, bots: groupBots }]
+      : [];
   });
   const unassigned = active.filter((bot) => bot.groupId === null);
+  const visibleUnassigned = needle.length === 0 ? unassigned : filterRosterBots(unassigned, query);
   return [
     ...assigned,
-    ...(unassigned.length > 0 ? [{ id: "unassigned", name: "Unassigned", bots: unassigned }] : []),
+    ...(visibleUnassigned.length > 0
+      ? [{ id: "unassigned", name: "Unassigned", bots: visibleUnassigned }]
+      : []),
   ];
 }
 


### PR DESCRIPTION
## What Changed

- Pass the full active roster into group search.
- Keep every group member when the group name or one member matches.
- Hide groups with no active matching member and filter Unassigned to matching bots.

## Why

Filtering bots before group construction removed nonmatching members from avatar stacks. PR #4 cannot merge cleanly because its branch and current main have different Git roots, so this replaces it from current main.

## UI Changes

No screenshots. This changes search filtering without changing layout. Browser control was not authorized for this run.

## Testing

- `vp test run apps/web/src/components/roster/roster.logic.test.ts` (35 passed)
- `vp fmt --check apps/web/src/components/roster/BotRosterSidebar.tsx apps/web/src/components/roster/roster.logic.ts apps/web/src/components/roster/roster.logic.test.ts`
- `vp lint apps/web/src/components/roster/BotRosterSidebar.tsx apps/web/src/components/roster/roster.logic.ts apps/web/src/components/roster/roster.logic.test.ts`
- `vp run --filter @t3tools/web typecheck`

## Checklist

- [x] This PR is small and focused
- [x] I explained what changed and why
- [x] I linked the accepted plugin or provider proposal in **Why**, or this PR does not add one
- [ ] I included before/after screenshots for any UI changes
- [ ] I included a video for animation/interaction changes

Model: gpt-5.6-sol
Harness: Codex in T3 Code