### PR TITLE
fix(web): widen rich bot output

### DIFF
--- a/apps/web/src/components/ChatMarkdown.test.tsx
+++ b/apps/web/src/components/ChatMarkdown.test.tsx
@@ -201,6 +201,39 @@ describe("orderedListGutterStyle", () => {
 });
 
 describe("ChatMarkdown rich formatting", () => {
+  it("renders bot assistant artifacts", () => {
+    const html = renderToStaticMarkup(
+      <ChatMarkdown
+        cwd="/tmp/project"
+        text={[
+          "| File | State |",
+          "| --- | --- |",
+          "| src/output.ts | Ready |",
+          "",
+          "- [x] Render table",
+          "- [ ] Review diff",
+          "",
+          "```diff",
+          "-const state = 'plain';",
+          "+const state = 'rich';",
+          "```",
+          "",
+          '```ts title="src/generated.ts"',
+          "export const ready = true;",
+          "```",
+        ].join("\n")}
+      />,
+    );
+
+    expect(html).toContain("chat-markdown-table-container");
+    expect(html.match(/type="checkbox"/g)).toHaveLength(2);
+    expect(html.match(/disabled=""/g)).toHaveLength(2);
+    expect(html.match(/readOnly=""/g)).toHaveLength(2);
+    expect(html).toContain('data-language="diff"');
+    expect(html).toContain('data-language="ts"');
+    expect(html).toContain("src/generated.ts");
+  });
+
   it("renders inline and display math", () => {
     const html = renderToStaticMarkup(
       <ChatMarkdown

--- a/apps/web/src/components/roster/BotThreadLanding.markdown.test.ts
+++ b/apps/web/src/components/roster/BotThreadLanding.markdown.test.ts
@@ -5,18 +5,25 @@ import { describe, expect, it } from "vite-plus/test";
 
 describe("BotThreadLanding message formatting", () => {
   it("renders assistant messages with the shared rich markdown component", () => {
-    const sources = ["BotThreadLanding.tsx", "GroupThreadLanding.tsx"].map((file) =>
-      NodeFS.readFileSync(new URL(`./${file}`, import.meta.url), "utf8"),
-    );
+    const entries = [
+      ["BotThreadLanding.tsx", "bot-provider-message", "bot-user-message"],
+      ["GroupThreadLanding.tsx", "group-provider-message", "group-user-message"],
+    ] as const;
 
-    for (const source of sources) {
-      expect(source).toContain('import ChatMarkdown from "../ChatMarkdown"');
-      expect(source).toContain("<ChatMarkdown");
-      expect(source).toContain("cwd={runtime.defaultProject?.workspaceRoot}");
-      expect(source).toContain("threadRef={runtime.linkedThreadRef ?? undefined}");
-      expect(source).toContain('className="min-w-0 flex-1"');
-      expect(source).toContain('className="whitespace-pre-wrap"');
-      expect(source).not.toContain("onTaskListChange");
+    for (const [file, assistantTestId, userTestId] of entries) {
+      const source = NodeFS.readFileSync(new URL(`./${file}`, import.meta.url), "utf8");
+      const assistantStart = source.indexOf(`data-testid="${assistantTestId}"`);
+      const userStart = source.indexOf(`data-testid="${userTestId}"`, assistantStart);
+      const assistantSource = source.slice(assistantStart, userStart);
+
+      expect(assistantStart).toBeGreaterThan(-1);
+      expect(userStart).toBeGreaterThan(assistantStart);
+      expect(assistantSource).toContain("<ChatMarkdown");
+      expect(assistantSource).toContain("cwd={runtime.defaultProject?.workspaceRoot}");
+      expect(assistantSource).toContain("threadRef={runtime.linkedThreadRef ?? undefined}");
+      expect(assistantSource).toContain('className="min-w-0 flex-1"');
+      expect(assistantSource).not.toContain("onTaskListChange");
+      expect(source.slice(userStart)).toContain('className="whitespace-pre-wrap"');
     }
   });
 

--- a/apps/web/src/components/roster/BotThreadLanding.markdown.test.ts
+++ b/apps/web/src/components/roster/BotThreadLanding.markdown.test.ts
@@ -14,6 +14,9 @@ describe("BotThreadLanding message formatting", () => {
       expect(source).toContain("<ChatMarkdown");
       expect(source).toContain("cwd={runtime.defaultProject?.workspaceRoot}");
       expect(source).toContain("threadRef={runtime.linkedThreadRef ?? undefined}");
+      expect(source).toContain('className="min-w-0 flex-1"');
+      expect(source).toContain('className="whitespace-pre-wrap"');
+      expect(source).not.toContain("onTaskListChange");
     }
   });
 

--- a/apps/web/src/components/roster/BotThreadLanding.tsx
+++ b/apps/web/src/components/roster/BotThreadLanding.tsx
@@ -150,7 +150,7 @@ export function BotThreadLanding({ botId }: { readonly botId: string }) {
                       name={bot.name}
                       className="mt-0.5 size-7 shrink-0"
                     />
-                    <div className="min-w-0 max-w-[85%]">
+                    <div className="min-w-0 flex-1">
                       <div className="text-sm font-medium">{bot.name}</div>
                       <ChatMarkdown
                         className="mt-1"

--- a/apps/web/src/components/roster/GroupThreadLanding.tsx
+++ b/apps/web/src/components/roster/GroupThreadLanding.tsx
@@ -104,7 +104,7 @@ export function GroupThreadLanding({ groupId }: { readonly groupId: string }) {
                       name={respondingBot.name}
                       className="mt-0.5 size-7 shrink-0"
                     />
-                    <div className="min-w-0 max-w-[85%]">
+                    <div className="min-w-0 flex-1">
                       <div className="text-sm font-medium">{respondingBot.name}</div>
                       <ChatMarkdown
                         className="mt-1"


### PR DESCRIPTION
Bot and group assistant replies use the shared Markdown renderer, but the message column caps tables, diffs, and titled file blocks at 85% width. The behavior also lacked focused coverage.

This gives assistant output the available conversation width in individual and group threads. User messages stay plain, and task lists stay read-only. Focused assertions cover GFM tables, disabled checklists, diff fences, and titled file blocks.

Tests:
- `vp test run apps/web/src/components/ChatMarkdown.test.tsx apps/web/src/components/roster/BotThreadLanding.markdown.test.ts`
- `vp exec tsgo --noEmit --project apps/web/tsconfig.json --pretty false`
- Targeted type-aware lint for the four changed files

Replaces #5.

Model: GPT-5.6 Sol
Harness: Codex in T3 Code