### PR TITLE
fix(analytics): report opt-out deletion failures

### DIFF
--- a/apps/server/src/serverSettings.test.ts
+++ b/apps/server/src/serverSettings.test.ts
@@ -135,6 +135,61 @@ it.layer(NodeServices.layer)("server settings", (it) => {
     }).pipe(Effect.provide(makeServerSettingsLayer())),
   );
 
+  it.effect("reports an analytics opt-out deletion failure", () =>
+    Effect.gen(function* () {
+      const fileSystem = yield* FileSystem.FileSystem;
+      const baseDir = yield* fileSystem.makeTempDirectoryScoped({
+        prefix: "t3code-server-settings-analytics-opt-out-",
+      });
+      const configLayer = ServerConfig.layerTest(process.cwd(), baseDir);
+      const config = yield* ServerConfig.ServerConfig.pipe(Effect.provide(configLayer));
+      const cause = PlatformError.systemError({
+        _tag: "PermissionDenied",
+        module: "FileSystem",
+        method: "remove",
+        pathOrDescriptor: config.analyticsStatePath,
+      });
+      let failAnalyticsStateRemoval = true;
+      const failingFileSystem = FileSystem.FileSystem.of({
+        ...fileSystem,
+        remove: (path, options) =>
+          failAnalyticsStateRemoval && path === config.analyticsStatePath
+            ? Effect.fail(cause)
+            : fileSystem.remove(path, options),
+      });
+      const settingsLayer = ServerSettingsModule.layer.pipe(
+        Layer.provide(ServerSecretStore.layer),
+        Layer.provideMerge(Layer.fresh(SqlitePersistenceMemory)),
+        Layer.provideMerge(configLayer),
+        Layer.provide(Layer.succeed(FileSystem.FileSystem, failingFileSystem)),
+      );
+      yield* fileSystem.writeFileString(config.analyticsStatePath, "queued analytics");
+      yield* fileSystem.writeFileString(config.anonymousIdPath, "legacy identity");
+
+      const { error, stateRemained, analyticsEnabled } = yield* Effect.gen(function* () {
+        const serverSettings = yield* ServerSettingsModule.ServerSettingsService;
+        const error = yield* Effect.flip(
+          serverSettings.updateSettings({ analyticsEnabled: false }),
+        );
+        const stateRemained = yield* fileSystem.exists(config.analyticsStatePath);
+        failAnalyticsStateRemoval = false;
+        const settings = yield* serverSettings.updateSettings({ analyticsEnabled: false });
+        return { error, stateRemained, analyticsEnabled: settings.analyticsEnabled };
+      }).pipe(Effect.provide(settingsLayer));
+
+      assert.deepInclude(error, {
+        _tag: "ServerSettingsError",
+        operation: "remove-analytics-state",
+        settingsPath: config.analyticsStatePath,
+      });
+      assert.strictEqual(error.cause, cause);
+      assert.isTrue(stateRemained);
+      assert.isFalse(analyticsEnabled);
+      assert.isFalse(yield* fileSystem.exists(config.analyticsStatePath));
+      assert.isFalse(yield* fileSystem.exists(config.anonymousIdPath));
+    }),
+  );
+
   it.effect("decodes nested settings patches", () =>
     Effect.gen(function* () {
       assert.deepEqual(

--- a/apps/server/src/serverSettings.ts
+++ b/apps/server/src/serverSettings.ts
@@ -377,7 +377,7 @@ function stripDefaultServerSettings(current: unknown, defaults: unknown): unknow
 }
 
 const make = Effect.gen(function* () {
-  const { settingsPath } = yield* ServerConfig.ServerConfig;
+  const { analyticsStatePath, anonymousIdPath, settingsPath } = yield* ServerConfig.ServerConfig;
   const fs = yield* FileSystem.FileSystem;
   const pathService = yield* Path.Path;
   const secretStore = yield* ServerSecretStore.ServerSecretStore;
@@ -752,6 +752,23 @@ const make = Effect.gen(function* () {
           yield* writeSettingsAtomically(next);
           yield* Cache.set(settingsCache, cacheKey, next);
           yield* emitChange(next);
+          if (patch.analyticsEnabled === false) {
+            yield* Effect.all(
+              [analyticsStatePath, anonymousIdPath].map((filePath) =>
+                fs.remove(filePath, { force: true }).pipe(
+                  Effect.mapError(
+                    (cause) =>
+                      new ServerSettingsError({
+                        settingsPath: filePath,
+                        operation: "remove-analytics-state",
+                        cause,
+                      }),
+                  ),
+                ),
+              ),
+              { concurrency: "unbounded", discard: true },
+            );
+          }
           const materialized = yield* materializeProviderEnvironmentSecrets(next);
           return resolveTextGenerationProvider(materialized);
         }),

--- a/packages/contracts/src/settings.ts
+++ b/packages/contracts/src/settings.ts
@@ -814,6 +814,7 @@ export const ServerSettingsOperation = Schema.Literals([
   "read-secret",
   "remove-secret",
   "remove-stale-secret",
+  "remove-analytics-state",
   "write-secret",
   "write-file",
   "prepare-directory",


### PR DESCRIPTION
PR #60 could report a successful analytics opt-out even when filesystem deletion failed. The disabled setting persisted, but local analytics state remained and the deletion error was swallowed.

This change makes the settings update delete analytics.json and the legacy anonymous ID before it returns. It returns a typed ServerSettingsError when deletion fails. A focused test proves the failure, the persisted disabled setting, and successful retry cleanup.

Tests:
- vp test run packages/contracts/src/settings.test.ts apps/server/src/serverSettings.test.ts apps/server/src/telemetry/AnalyticsService.test.ts
- vp run --filter @t3tools/contracts typecheck
- vp run --filter akeru-bot typecheck
- vp lint packages/contracts/src/settings.ts apps/server/src/serverSettings.ts apps/server/src/serverSettings.test.ts

Model: GPT-5.6 Sol
Harness: Codex in T3 Code