### PR TITLE
feat(bots): show sensitive approval cards

### DIFF
--- a/apps/server/src/provider/Layers/AgentController.test.ts
+++ b/apps/server/src/provider/Layers/AgentController.test.ts
@@ -1013,7 +1013,7 @@ describe("AgentControllerLive", () => {
     );
   });
 
-  it.effect("grants one exact Akeru tool call without persisting acceptAlways", () => {
+  it.effect("keeps a pending approval across reconnect and grants one exact tool call", () => {
     const bridge = makeBridge();
     const mastra = makeMastraHarness();
     return provideController(
@@ -1035,6 +1035,14 @@ describe("AgentControllerLive", () => {
           toolName: "Shell",
           args: { command: "pwd" },
         } as AgentControllerEvent);
+        yield* controller.startSession(codexThreadId, {
+          threadId: codexThreadId,
+          provider: ProviderDriverKind.make("codex"),
+          providerInstanceId: codexInstanceId,
+          cwd: process.cwd(),
+          modelSelection: codexSelection,
+          runtimeMode: "full-access",
+        });
         yield* controller.respondToRequest({
           threadId: codexThreadId,
           requestId: ApprovalRequestId.make("shell-tool-1"),
@@ -1064,6 +1072,27 @@ describe("AgentControllerLive", () => {
         });
         mastra.emit({
           type: "tool_approval_required",
+          toolCallId: "send-tool-1",
+          toolName: "gmail_send_message",
+          args: { to: "user@example.com" },
+        } as AgentControllerEvent);
+        yield* controller.respondToRequest({
+          threadId: codexThreadId,
+          requestId: ApprovalRequestId.make("send-tool-1"),
+          decision: "decline",
+        });
+        yield* controller.respondToRequest({
+          threadId: codexThreadId,
+          requestId: ApprovalRequestId.make("send-tool-1"),
+          decision: "accept",
+        });
+        expect(mastra.session.respondToToolApproval).toHaveBeenCalledTimes(2);
+        expect(mastra.session.respondToToolApproval).toHaveBeenLastCalledWith({
+          toolCallId: "send-tool-1",
+          decision: "decline",
+        });
+        mastra.emit({
+          type: "tool_approval_required",
           toolCallId: "shell-tool-stale",
           toolName: "Shell",
           args: { command: "pwd" },
@@ -1080,6 +1109,94 @@ describe("AgentControllerLive", () => {
           ),
         );
         mastra.finishSend();
+      }),
+      bridge.service,
+      mastra.factory,
+    );
+  });
+
+  it.effect("cancels pending approvals when the turn or session ends", () => {
+    const bridge = makeBridge();
+    const mastra = makeMastraHarness();
+    return provideController(
+      Effect.gen(function* () {
+        const controller = yield* AgentController;
+        yield* resolveCodex(controller);
+        yield* controller.startSession(codexThreadId, {
+          threadId: codexThreadId,
+          provider: ProviderDriverKind.make("codex"),
+          providerInstanceId: codexInstanceId,
+          cwd: process.cwd(),
+          modelSelection: codexSelection,
+          runtimeMode: "full-access",
+        });
+        const events: ProviderRuntimeEvent[] = [];
+        const expectCancelledOnce = (requestId: string) =>
+          expect(
+            events.filter(
+              (event) => event.type === "request.resolved" && event.requestId === requestId,
+            ),
+          ).toEqual([
+            expect.objectContaining({
+              payload: { requestType: "dynamic_tool_call", decision: "cancel" },
+            }),
+          ]);
+        const eventsFiber = yield* controller.streamEvents.pipe(
+          Stream.runForEach((event) => Effect.sync(() => events.push(event))),
+          Effect.forkChild({ startImmediately: true }),
+        );
+        yield* Effect.yieldNow;
+
+        yield* controller.sendTurn({ threadId: codexThreadId, input: "Run pwd." });
+        mastra.emit({
+          type: "tool_approval_required",
+          toolCallId: "turn-expiry",
+          toolName: "Shell",
+          args: { command: "pwd" },
+        } as AgentControllerEvent);
+        mastra.emit({ type: "agent_end", reason: "complete" } as AgentControllerEvent);
+        mastra.finishSend();
+        yield* Effect.yieldNow;
+        yield* Effect.yieldNow;
+
+        expectCancelledOnce("turn-expiry");
+        yield* controller.respondToRequest({
+          threadId: codexThreadId,
+          requestId: ApprovalRequestId.make("turn-expiry"),
+          decision: "accept",
+        });
+        expect(mastra.session.respondToToolApproval).not.toHaveBeenCalled();
+
+        yield* controller.sendTurn({ threadId: codexThreadId, input: "Run pwd again." });
+        mastra.emit({
+          type: "tool_approval_required",
+          toolCallId: "tool-end-expiry",
+          toolName: "Shell",
+          args: { command: "pwd" },
+        } as AgentControllerEvent);
+        mastra.emit({
+          type: "tool_end",
+          toolCallId: "tool-end-expiry",
+          result: "cancelled",
+          isError: false,
+          denied: true,
+        } as AgentControllerEvent);
+        yield* Effect.yieldNow;
+        yield* Effect.yieldNow;
+        expectCancelledOnce("tool-end-expiry");
+
+        mastra.emit({
+          type: "tool_approval_required",
+          toolCallId: "session-expiry",
+          toolName: "Shell",
+          args: { command: "pwd" },
+        } as AgentControllerEvent);
+        yield* controller.stopSession({ threadId: codexThreadId });
+        yield* Effect.yieldNow;
+        yield* Effect.yieldNow;
+
+        expectCancelledOnce("session-expiry");
+        yield* Fiber.interrupt(eventsFiber);
       }),
       bridge.service,
       mastra.factory,

--- a/apps/server/src/provider/Layers/AgentController.ts
+++ b/apps/server/src/provider/Layers/AgentController.ts
@@ -498,6 +498,19 @@ const make = (options?: AgentControllerLiveOptions) =>
       }
     };
 
+    const cancelPendingApprovals = (threadId: ThreadId, active: ActiveSession) => {
+      for (const requestId of active.approvalRequests.keys()) {
+        publish({
+          ...baseEvent(threadId, active, active.activeTurn?.turnId),
+          requestId: RuntimeRequestId.make(requestId),
+          type: "request.resolved",
+          payload: { requestType: "dynamic_tool_call", decision: "cancel" },
+        });
+      }
+      active.approvalRequests.clear();
+      toolRuntime.clearApprovals(String(threadId));
+    };
+
     const finishTurn = (
       threadId: ThreadId,
       active: ActiveSession,
@@ -509,6 +522,7 @@ const make = (options?: AgentControllerLiveOptions) =>
       queueTurnMemory(threadId, active, turn);
       turn.finished = true;
       completeAssistantMessages(threadId, active, turn);
+      cancelPendingApprovals(threadId, active);
       publish({
         ...baseEvent(threadId, active, turn.turnId),
         type: "turn.completed",
@@ -524,8 +538,6 @@ const make = (options?: AgentControllerLiveOptions) =>
           : { error: errorMessage ?? `The delegated turn ${state}.` }),
         usage: { inputTokens: turn.inputTokens, outputTokens: turn.outputTokens },
       });
-      active.approvalRequests.clear();
-      toolRuntime.clearApprovals(String(threadId));
       active.activeTurn = null;
       publishSessionState(threadId, active, "ready");
     };
@@ -603,7 +615,14 @@ const make = (options?: AgentControllerLiveOptions) =>
         case "tool_end": {
           if (!turn) return;
           const toolName = active.toolNames.get(event.toolCallId) ?? "tool";
-          active.approvalRequests.delete(event.toolCallId);
+          if (active.approvalRequests.delete(event.toolCallId)) {
+            publish({
+              ...baseEvent(threadId, active, turn.turnId),
+              requestId: RuntimeRequestId.make(event.toolCallId),
+              type: "request.resolved",
+              payload: { requestType: "dynamic_tool_call", decision: "cancel" },
+            });
+          }
           const mcpServerId = mcpServerIdForToolName(active.mcpServerIds, toolName);
           if (mcpServerId && !event.denied) {
             if (event.isError) {
@@ -1259,6 +1278,7 @@ const make = (options?: AgentControllerLiveOptions) =>
         }
         return yield* legacyProviderBridge.stopSession(input);
       }
+      cancelPendingApprovals(input.threadId, active);
       active.session.abort();
       active.unsubscribe();
       publishSessionState(input.threadId, active, "stopped");

--- a/apps/web/src/components/roster/BotApprovalPrompt.test.tsx
+++ b/apps/web/src/components/roster/BotApprovalPrompt.test.tsx
@@ -1,0 +1,38 @@
+import { ApprovalRequestId } from "@t3tools/contracts";
+import { renderToStaticMarkup } from "react-dom/server";
+import { describe, expect, it, vi } from "vite-plus/test";
+
+import { BotApprovalPrompt } from "./BotApprovalPrompt";
+
+describe("BotApprovalPrompt", () => {
+  it("renders a one-use warning and only the hub-provided decisions", () => {
+    const markup = renderToStaticMarkup(
+      <BotApprovalPrompt
+        approval={{
+          requestId: ApprovalRequestId.make("send-call"),
+          requestKind: "command",
+          createdAt: "2026-08-27T00:00:00.000Z",
+          detail: "Allow gmail_send_message?",
+          options: [
+            { decision: "decline", label: "Decline" },
+            { decision: "accept", label: "Allow" },
+          ],
+        }}
+        pendingCount={1}
+        responding
+        error="Could not answer approval."
+        onRespond={vi.fn()}
+      />,
+    );
+
+    expect(markup).toContain('data-testid="bot-approval-prompt"');
+    expect(markup).toContain("This approval applies only to this action.");
+    expect(markup).toContain("It cannot undo completed work.");
+    expect(markup).toContain(">Decline<");
+    expect(markup).toContain(">Allow<");
+    expect(markup).not.toContain("Always allow");
+    expect(markup.match(/disabled=""/g)).toHaveLength(2);
+    expect(markup).toContain('role="alert"');
+    expect(markup).toContain("Could not answer approval.");
+  });
+});

--- a/apps/web/src/components/roster/BotApprovalPrompt.tsx
+++ b/apps/web/src/components/roster/BotApprovalPrompt.tsx
@@ -1,0 +1,57 @@
+import type { ProviderApprovalDecision } from "@t3tools/contracts";
+
+import type { PendingApproval } from "../../session-logic";
+import { ComposerPendingApprovalActions } from "../chat/ComposerPendingApprovalActions";
+import { ComposerPendingApprovalPanel } from "../chat/ComposerPendingApprovalPanel";
+
+export function BotApprovalPrompt({
+  approval,
+  pendingCount,
+  responding,
+  error,
+  onRespond,
+}: {
+  readonly approval: PendingApproval;
+  readonly pendingCount: number;
+  readonly responding: boolean;
+  readonly error: string | null;
+  readonly onRespond: (decision: ProviderApprovalDecision) => Promise<unknown>;
+}) {
+  const oneUse =
+    approval.options?.every(
+      (option) => option.decision !== "acceptForSession" && option.decision !== "acceptAlways",
+    ) ?? false;
+
+  return (
+    <section
+      aria-label="Approval required"
+      className="w-full max-w-2xl rounded-2xl border border-border bg-foreground/5 p-3"
+      data-testid="bot-approval-prompt"
+    >
+      <p className="text-sm font-medium">Approval required</p>
+      {oneUse ? (
+        <p className="mt-1 text-xs text-muted-foreground">
+          This approval applies only to this action. It cannot undo completed work.
+        </p>
+      ) : null}
+      <ComposerPendingApprovalPanel
+        approval={approval}
+        pendingCount={pendingCount}
+        className="mt-2"
+      />
+      <div className="mt-3 flex justify-end gap-1">
+        <ComposerPendingApprovalActions
+          requestId={approval.requestId}
+          isResponding={responding}
+          options={approval.options}
+          onRespondToApproval={(_requestId, decision) => onRespond(decision)}
+        />
+      </div>
+      {error ? (
+        <p role="alert" className="mt-2 text-xs text-destructive">
+          {error}
+        </p>
+      ) : null}
+    </section>
+  );
+}

--- a/apps/web/src/components/roster/BotPromptComposer.test.tsx
+++ b/apps/web/src/components/roster/BotPromptComposer.test.tsx
@@ -5,12 +5,19 @@ import { deriveProviderInstanceEntries } from "../../providerInstances";
 import { composerTestInstanceId, makeComposerTestProvider } from "../../test/chatComposerProps";
 import {
   BotPromptComposer,
+  canSubmitBotPrompt,
   findMentionedBotId,
   isBotPromptExpanded,
   shouldFocusBotPromptForKey,
 } from "./BotPromptComposer";
 
 describe("bot prompt composer", () => {
+  it("does not submit while disabled", () => {
+    expect(canSubmitBotPrompt(true, "Send this", 0)).toBe(false);
+    expect(canSubmitBotPrompt(false, "Send this", 0)).toBe(true);
+    expect(canSubmitBotPrompt(false, "", 1)).toBe(true);
+  });
+
   it("expands for long or multiline prompts", () => {
     expect(isBotPromptExpanded("Short prompt")).toBe(false);
     expect(isBotPromptExpanded("Line one\nLine two")).toBe(true);

--- a/apps/web/src/components/roster/BotPromptComposer.tsx
+++ b/apps/web/src/components/roster/BotPromptComposer.tsx
@@ -15,6 +15,10 @@ export function isBotPromptExpanded(prompt: string): boolean {
   return prompt.includes("\n") || prompt.length > 80;
 }
 
+export function canSubmitBotPrompt(disabled: boolean, prompt: string, fileCount: number): boolean {
+  return !disabled && (prompt.trim().length > 0 || fileCount > 0);
+}
+
 export function shouldFocusBotPromptForKey(input: {
   readonly altKey: boolean;
   readonly ctrlKey: boolean;
@@ -130,6 +134,7 @@ export function BotPromptComposer({
       onSubmit={(event) => {
         event.preventDefault();
         const prompt = draft.trim();
+        if (!canSubmitBotPrompt(disabled, prompt, files.length)) return;
         void onSubmit(prompt, files, findMentionedBotId(prompt, mentionBots)).then((sent) => {
           if (sent) {
             persistDraft("");
@@ -244,7 +249,7 @@ export function BotPromptComposer({
           <button
             type="submit"
             aria-label="Send message"
-            disabled={disabled || (draft.trim().length === 0 && files.length === 0)}
+            disabled={!canSubmitBotPrompt(disabled, draft, files.length)}
             className="pointer-events-auto flex size-9 items-center justify-center rounded-full bg-foreground text-background disabled:opacity-25"
           >
             <ArrowUpIcon className="size-5" />

--- a/apps/web/src/components/roster/BotThreadLanding.markdown.test.ts
+++ b/apps/web/src/components/roster/BotThreadLanding.markdown.test.ts
@@ -33,6 +33,18 @@ describe("BotThreadLanding message formatting", () => {
     expect(groupSource).not.toContain("justify-end gap-4");
   });
 
+  it("renders the shared approval card in bot and group threads", () => {
+    const sources = ["BotThreadLanding.tsx", "GroupThreadLanding.tsx"].map((file) =>
+      NodeFS.readFileSync(new URL(`./${file}`, import.meta.url), "utf8"),
+    );
+
+    for (const source of sources) {
+      expect(source).toContain("<BotApprovalPrompt");
+      expect(source).toContain("useRosterPendingApproval(runtime.linkedThreadRef)");
+      expect(source).toContain("pendingApproval !== null ||");
+    }
+  });
+
   it("mounts the voice action in the live bot chat header", () => {
     const source = NodeFS.readFileSync(new URL("./BotThreadLanding.tsx", import.meta.url), "utf8");
 

--- a/apps/web/src/components/roster/BotThreadLanding.tsx
+++ b/apps/web/src/components/roster/BotThreadLanding.tsx
@@ -25,6 +25,7 @@ import { toastManager } from "../ui/toast";
 import ChatMarkdown from "../ChatMarkdown";
 import { WorkspacePageHeader } from "../WorkspacePageHeader";
 import { BotActivityStatus } from "./BotActivityStatus";
+import { BotApprovalPrompt } from "./BotApprovalPrompt";
 import { BotInboxAlertStack } from "./BotInboxAlertStack";
 import { BotAvatarView } from "./BotAvatarView";
 import { BotConversationScrollArea } from "./BotConversationScrollArea";
@@ -36,6 +37,7 @@ import { BotVoiceCallButton, useVoiceCall } from "../voice/VoiceCall";
 import { useBotPresence } from "./botPresence";
 import { useRosterStore } from "./rosterStore";
 import { useBotThreadRuntime } from "./useBotThreadRuntime";
+import { useRosterPendingApproval } from "./useRosterPendingApproval";
 
 export function BotThreadLanding({ botId }: { readonly botId: string }) {
   const navigate = useNavigate();
@@ -80,6 +82,7 @@ export function BotThreadLanding({ botId }: { readonly botId: string }) {
   );
   const effectiveModelSelection = stickyEngine;
   const runtime = useBotThreadRuntime(botId, effectiveModelSelection);
+  const approvalState = useRosterPendingApproval(runtime.linkedThreadRef);
   const voiceCall = useVoiceCall();
   const presence = useBotPresence(botId);
   const inboxQuery = useEnvironmentQuery(
@@ -109,6 +112,7 @@ export function BotThreadLanding({ botId }: { readonly botId: string }) {
   if (!bot || bot.archivedAt !== null) return null;
   const working = runtime.sending || presence === "working";
   const messages = visibleBotChatMessages(runtime.messages);
+  const pendingApproval = approvalState.pendingApproval;
   const inboxItems = selectOpenBotInboxItems(inboxQuery.data?.inbox ?? [], new Set([bot.id]));
 
   return (
@@ -181,6 +185,15 @@ export function BotThreadLanding({ botId }: { readonly botId: string }) {
                 ),
               )
             )}
+            {pendingApproval ? (
+              <BotApprovalPrompt
+                approval={pendingApproval}
+                pendingCount={approvalState.pendingCount}
+                responding={approvalState.responding}
+                error={approvalState.responseError}
+                onRespond={(decision) => approvalState.respond(pendingApproval.requestId, decision)}
+              />
+            ) : null}
             {working ? <BotActivityStatus avatar={bot.avatar} name={bot.name} /> : null}
           </BotConversationScrollArea>
           <BotInboxAlertStack
@@ -197,6 +210,7 @@ export function BotThreadLanding({ botId }: { readonly botId: string }) {
             draftKey={bot.id}
             disabled={
               runtime.sending ||
+              pendingApproval !== null ||
               voiceCall.activeCall?.botId === bot.id ||
               voiceCall.startingBotId === bot.id ||
               modelUpdatePending ||

--- a/apps/web/src/components/roster/GroupThreadLanding.tsx
+++ b/apps/web/src/components/roster/GroupThreadLanding.tsx
@@ -11,6 +11,7 @@ import ChatMarkdown from "../ChatMarkdown";
 import { WorkspacePageHeader } from "../WorkspacePageHeader";
 import { ThreadErrorBanner } from "../chat/ThreadErrorBanner";
 import { BotActivityStatus } from "./BotActivityStatus";
+import { BotApprovalPrompt } from "./BotApprovalPrompt";
 import { BotInboxAlertStack } from "./BotInboxAlertStack";
 import { BotAvatarView } from "./BotAvatarView";
 import { BotConversationScrollArea } from "./BotConversationScrollArea";
@@ -19,6 +20,7 @@ import { BotPromptComposer } from "./BotPromptComposer";
 import { useGroupPresence } from "./botPresence";
 import { useRosterStore } from "./rosterStore";
 import { useGroupThreadRuntime } from "./useGroupThreadRuntime";
+import { useRosterPendingApproval } from "./useRosterPendingApproval";
 
 export function GroupThreadLanding({ groupId }: { readonly groupId: string }) {
   const navigate = useNavigate();
@@ -28,6 +30,7 @@ export function GroupThreadLanding({ groupId }: { readonly groupId: string }) {
   );
   const bots = useRosterStore((state) => state.bots);
   const runtime = useGroupThreadRuntime(groupId);
+  const approvalState = useRosterPendingApproval(runtime.linkedThreadRef);
   const presence = useGroupPresence(groupId);
   const inboxQuery = useEnvironmentQuery(
     environmentId === null
@@ -45,6 +48,7 @@ export function GroupThreadLanding({ groupId }: { readonly groupId: string }) {
   if (!boss) return null;
   const working = runtime.sending || presence === "working";
   const messages = visibleBotChatMessages(runtime.messages);
+  const pendingApproval = approvalState.pendingApproval;
   const activeBot = members.find((bot) => bot.id === runtime.respondingBotId) ?? boss;
   const inboxItems = selectOpenBotInboxItems(
     inboxQuery.data?.inbox ?? [],
@@ -125,6 +129,15 @@ export function GroupThreadLanding({ groupId }: { readonly groupId: string }) {
               );
             })
           )}
+          {pendingApproval ? (
+            <BotApprovalPrompt
+              approval={pendingApproval}
+              pendingCount={approvalState.pendingCount}
+              responding={approvalState.responding}
+              error={approvalState.responseError}
+              onRespond={(decision) => approvalState.respond(pendingApproval.requestId, decision)}
+            />
+          ) : null}
           {working ? <BotActivityStatus avatar={activeBot.avatar} name={activeBot.name} /> : null}
         </BotConversationScrollArea>
         <BotInboxAlertStack
@@ -141,6 +154,7 @@ export function GroupThreadLanding({ groupId }: { readonly groupId: string }) {
           draftKey={`group:${group.id}`}
           disabled={
             runtime.sending ||
+            pendingApproval !== null ||
             !runtime.groupReady ||
             !runtime.bootstrapped ||
             runtime.defaultProject === null

--- a/apps/web/src/components/roster/useRosterPendingApproval.test.ts
+++ b/apps/web/src/components/roster/useRosterPendingApproval.test.ts
@@ -1,0 +1,26 @@
+import { ApprovalRequestId, type ScopedThreadRef } from "@t3tools/contracts";
+import { describe, expect, it } from "vite-plus/test";
+
+import { rosterApprovalResponseKey } from "./useRosterPendingApproval";
+
+describe("roster approval response state", () => {
+  it("is scoped by environment, thread, and request", () => {
+    const thread = {
+      environmentId: "local",
+      threadId: "thread-a",
+    } as ScopedThreadRef;
+    const requestId = ApprovalRequestId.make("request-a");
+    const key = rosterApprovalResponseKey(thread, requestId);
+
+    expect(
+      rosterApprovalResponseKey({ ...thread, threadId: "thread-b" } as ScopedThreadRef, requestId),
+    ).not.toBe(key);
+    expect(
+      rosterApprovalResponseKey(
+        { ...thread, environmentId: "remote" } as ScopedThreadRef,
+        requestId,
+      ),
+    ).not.toBe(key);
+    expect(rosterApprovalResponseKey(thread, ApprovalRequestId.make("request-b"))).not.toBe(key);
+  });
+});

--- a/apps/web/src/components/roster/useRosterPendingApproval.ts
+++ b/apps/web/src/components/roster/useRosterPendingApproval.ts
@@ -1,0 +1,56 @@
+import { squashAtomCommandFailure } from "@t3tools/client-runtime/state/runtime";
+import type {
+  ApprovalRequestId,
+  ProviderApprovalDecision,
+  ScopedThreadRef,
+} from "@t3tools/contracts";
+import { useCallback, useMemo, useRef, useState } from "react";
+
+import { derivePendingApprovals } from "../../session-logic";
+import { useThreadActivities } from "../../state/entities";
+import { threadEnvironment } from "../../state/threads";
+import { useAtomCommand } from "../../state/use-atom-command";
+
+export function useRosterPendingApproval(threadRef: ScopedThreadRef | null) {
+  const activities = useThreadActivities(threadRef);
+  const pendingApprovals = useMemo(() => derivePendingApprovals(activities), [activities]);
+  const respondToApproval = useAtomCommand(threadEnvironment.respondToApproval, {
+    reportFailure: false,
+  });
+  const respondingRef = useRef(false);
+  const [responding, setResponding] = useState(false);
+  const [responseError, setResponseError] = useState<string | null>(null);
+
+  const respond = useCallback(
+    async (requestId: ApprovalRequestId, decision: ProviderApprovalDecision): Promise<boolean> => {
+      if (!threadRef || respondingRef.current) return false;
+      respondingRef.current = true;
+      setResponding(true);
+      setResponseError(null);
+      try {
+        const result = await respondToApproval({
+          environmentId: threadRef.environmentId,
+          input: { threadId: threadRef.threadId, requestId, decision },
+        });
+        if (result._tag === "Failure") {
+          const cause = squashAtomCommandFailure(result);
+          setResponseError(cause instanceof Error ? cause.message : "Could not answer approval.");
+          return false;
+        }
+        return true;
+      } finally {
+        respondingRef.current = false;
+        setResponding(false);
+      }
+    },
+    [respondToApproval, threadRef],
+  );
+
+  return {
+    pendingApproval: pendingApprovals[0] ?? null,
+    pendingCount: pendingApprovals.length,
+    respond,
+    responding,
+    responseError,
+  };
+}

--- a/apps/web/src/components/roster/useRosterPendingApproval.ts
+++ b/apps/web/src/components/roster/useRosterPendingApproval.ts
@@ -11,22 +11,34 @@ import { useThreadActivities } from "../../state/entities";
 import { threadEnvironment } from "../../state/threads";
 import { useAtomCommand } from "../../state/use-atom-command";
 
+export function rosterApprovalResponseKey(
+  threadRef: ScopedThreadRef,
+  requestId: ApprovalRequestId,
+): string {
+  return JSON.stringify([threadRef.environmentId, threadRef.threadId, requestId]);
+}
+
 export function useRosterPendingApproval(threadRef: ScopedThreadRef | null) {
   const activities = useThreadActivities(threadRef);
   const pendingApprovals = useMemo(() => derivePendingApprovals(activities), [activities]);
   const respondToApproval = useAtomCommand(threadEnvironment.respondToApproval, {
     reportFailure: false,
   });
-  const respondingRef = useRef(false);
-  const [responding, setResponding] = useState(false);
-  const [responseError, setResponseError] = useState<string | null>(null);
+  const respondingRef = useRef(new Set<string>());
+  const [responses, setResponses] = useState<
+    ReadonlyMap<string, { readonly responding: boolean; readonly error: string | null }>
+  >(() => new Map());
 
   const respond = useCallback(
     async (requestId: ApprovalRequestId, decision: ProviderApprovalDecision): Promise<boolean> => {
-      if (!threadRef || respondingRef.current) return false;
-      respondingRef.current = true;
-      setResponding(true);
-      setResponseError(null);
+      if (!threadRef) return false;
+      const responseKey = rosterApprovalResponseKey(threadRef, requestId);
+      if (respondingRef.current.has(responseKey)) return false;
+      respondingRef.current.add(responseKey);
+      setResponses((current) =>
+        new Map(current).set(responseKey, { responding: true, error: null }),
+      );
+      let error: string | null = null;
       try {
         const result = await respondToApproval({
           environmentId: threadRef.environmentId,
@@ -34,23 +46,34 @@ export function useRosterPendingApproval(threadRef: ScopedThreadRef | null) {
         });
         if (result._tag === "Failure") {
           const cause = squashAtomCommandFailure(result);
-          setResponseError(cause instanceof Error ? cause.message : "Could not answer approval.");
+          error = cause instanceof Error ? cause.message : "Could not answer approval.";
           return false;
         }
         return true;
       } finally {
-        respondingRef.current = false;
-        setResponding(false);
+        respondingRef.current.delete(responseKey);
+        setResponses((current) => {
+          const next = new Map(current);
+          if (error) next.set(responseKey, { responding: false, error });
+          else next.delete(responseKey);
+          return next;
+        });
       }
     },
     [respondToApproval, threadRef],
   );
 
+  const pendingApproval = pendingApprovals[0] ?? null;
+  const response =
+    threadRef && pendingApproval
+      ? responses.get(rosterApprovalResponseKey(threadRef, pendingApproval.requestId))
+      : undefined;
+
   return {
-    pendingApproval: pendingApprovals[0] ?? null,
+    pendingApproval,
     pendingCount: pendingApprovals.length,
     respond,
-    responding,
-    responseError,
+    responding: response?.responding ?? false,
+    responseError: response?.error ?? null,
   };
 }


### PR DESCRIPTION
Bot and group threads did not render approval requests from the existing server approval hub. Pending cards could remain after a tool, turn, or session ended.

This adds the shared approval panel and actions to both thread types. Sensitive requests show one-use scope, reject duplicate responses, keep pending state across reconnects, and resolve cancelled requests at lifecycle boundaries.

Tests:
- vp test run apps/server/src/provider/Layers/AgentController.test.ts apps/server/src/provider/AkeruToolRuntime.test.ts apps/web/src/components/roster/BotApprovalPrompt.test.tsx apps/web/src/components/roster/BotPromptComposer.test.tsx apps/web/src/components/roster/BotThreadLanding.markdown.test.ts
- vp run --filter akeru-bot typecheck
- vp run --filter @t3tools/web typecheck
- targeted vp lint
- git diff --check

Model: GPT-5.6 Sol
Harness: Codex in T3 Code