### PR TITLE
feat(marketing): add PostHog web analytics

### DIFF
--- a/apps/marketing/src/components/PostHog.astro
+++ b/apps/marketing/src/components/PostHog.astro
@@ -1,0 +1,21 @@
+---
+const enabled = import.meta.env.PROD;
+---
+
+{
+  enabled && (
+    <script is:inline>
+      !function(t,e){var o,n,p,r;e.__SV||(window.posthog=e,e._i=[],e.init=function(i,s,a){function g(t,e){var o=e.split(".");2==o.length&&(t=t[o[0]],e=o[1]),t[e]=function(){t.push([e].concat(Array.prototype.slice.call(arguments,0)))}}(p=t.createElement("script")).type="text/javascript",p.crossOrigin="anonymous",p.async=!0,p.src=s.api_host.replace(".i.posthog.com","-assets.i.posthog.com")+"/static/array.js",(r=t.getElementsByTagName("script")[0]).parentNode.insertBefore(p,r);var u=e;for(void 0!==a?u=e[a]=[]:a="posthog",u.people=u.people||[],u.toString=function(t){var e="posthog";return"posthog"!==a&&(e+="."+a),t||(e+=" (stub)"),e},u.people.toString=function(){return u.toString(1)+".people (stub)"},o="init capture register register_once register_for_session unregister unregister_for_session getFeatureFlag getFeatureFlagPayload isFeatureEnabled reloadFeatureFlags updateEarlyAccessFeatureEnrollment getEarlyAccessFeatures on onFeatureFlags onSessionId getSurveys getActiveMatchingSurveys renderSurvey canRenderSurvey getNextSurveyStep identify setPersonProperties group resetGroups setPersonPropertiesForFlags resetPersonPropertiesForFlags setGroupPropertiesForFlags resetGroupPropertiesForFlags reset get_distinct_id getGroups get_session_id get_session_replay_url alias set_config startSessionRecording stopSessionRecording sessionRecordingStarted captureException loadToolbar get_property getSessionProperty createPersonProfile opt_in_capturing opt_out_capturing has_opted_in_capturing has_opted_out_capturing clear_opt_in_out_capturing debug getPageViewId captureTraceFeedback captureTraceMetric".split(" "),n=0;n<o.length;n++)g(u,o[n]);e._i.push([i,s,a])},e.__SV=1)}(document,window.posthog||[]);
+      posthog.init("phc_yuXg3geGrykvtEkQdeG6jWf2jvdA2WSZnQdrKVnMKUa7", {
+        api_host: "https://us.i.posthog.com",
+        ui_host: "https://us.posthog.com",
+        defaults: "2025-05-24",
+        person_profiles: "identified_only",
+        capture_pageview: true,
+        capture_pageleave: true,
+        disable_session_recording: true,
+        autocapture: false
+      });
+    </script>
+  )
+}

--- a/apps/marketing/src/layouts/Layout.astro
+++ b/apps/marketing/src/layouts/Layout.astro
@@ -1,6 +1,7 @@
 ---
 import { GITHUB_REPOSITORY_URL, UPSTREAM_REPOSITORY_URL, DOCS_URL, docsUrl } from "../lib/site";
 import { RELEASES_URL } from "../lib/releases";
+import PostHog from "../components/PostHog.astro";
 
 interface Props {
   title?: string;
@@ -62,6 +63,7 @@ const year = new Date().getFullYear();
     <link rel="icon" type="image/png" href="/favicon-16x16.png" sizes="16x16" />
     <link rel="apple-touch-icon" href="/apple-touch-icon.png" />
     <title>{title}</title>
+    <PostHog />
   </head>
   <body>
     <div class:list={["page", pageClass]}>

--- a/apps/marketing/src/pages/privacy-policy.astro
+++ b/apps/marketing/src/pages/privacy-policy.astro
@@ -248,6 +248,13 @@ const sections = [
               >.
             </li>
             <li>
+              <strong>PostHog</strong> <em>(PostHog, Inc.)</em>.<br />
+              We use PostHog to measure visits to the Site.<br />
+              You can view PostHog's privacy policy here:{" "}<a
+                href="https://posthog.com/privacy">https://posthog.com/privacy</a
+              >.
+            </li>
+            <li>
               <strong>Expo</strong> <em>(650 Industries, Inc.)</em>.<br />
               We use Expo for application updates and related mobile-app services.<br />
               You can view Expo's privacy policy here:{" "}<a href="https://expo.dev/privacy"


### PR DESCRIPTION
The marketing site did not send pageviews to PostHog, so its Web Analytics dashboard stayed empty.

This adds production-only pageview and page-leave tracking to the shared Astro layout. It disables autocapture and session recording, uses identified-only person profiles, and adds PostHog to the privacy policy.

Verification:
- `vp run --filter @t3tools/marketing typecheck`
- `vp run --filter @t3tools/marketing build`
- Confirmed the built HTML contains the analytics loader on marketing routes

Model: gpt-5.6-sol
Harness: Codex in T3 Code