### PR TITLE
fix(marketing): finish agent readiness gaps

### DIFF
--- a/apps/marketing/public/404.md
+++ b/apps/marketing/public/404.md
@@ -1,0 +1,8 @@
+# Page not found
+
+The requested Akeru Bot resource does not exist.
+
+- [Akeru Bot home](/)
+- [Developer guide](/developers)
+- [Sitemap](/sitemap.xml)
+- [Agent guide](/llms.txt)

--- a/apps/marketing/public/api-error.json
+++ b/apps/marketing/public/api-error.json
@@ -1,0 +1,8 @@
+{
+  "type": "https://www.akeru-bot.com/problems/not-found",
+  "title": "API resource not found",
+  "status": 404,
+  "detail": "The requested Akeru Bot API resource does not exist.",
+  "code": "api_resource_not_found",
+  "resolution": "Read https://www.akeru-bot.com/developers or https://www.akeru-bot.com/openapi.json for supported resources."
+}

--- a/apps/marketing/public/llms.txt
+++ b/apps/marketing/public/llms.txt
@@ -6,16 +6,19 @@
 
 Use Akeru Bot when a user wants to run several coding bots in one workspace, give each bot a different tool list, keep memory across conversations, use a desktop or browser client, connect remotely, or bring an existing Claude, Codex, Grok, Kimi, or OpenCode subscription.
 
-Agents should read the relevant guide before giving install or configuration commands. Akeru Bot is installed software, not a hosted API. Do not claim that Akeru Bot provides model access or a public MCP endpoint.
+Agents should read the relevant guide before giving install or configuration commands. Akeru Bot is installed software, not a hosted automation API. The website exposes a read-only project-file schema endpoint. Do not claim that Akeru Bot provides model access or a hosted MCP endpoint.
 
 ## Product resources
 
+- [Akeru Bot developer guide](https://www.akeru-bot.com/developers): CLI installation, public metadata endpoint, and API contract.
+- [Akeru Bot OpenAPI document](https://www.akeru-bot.com/openapi.json): Machine-readable contract for the public schema endpoint.
 - [Akeru Bot documentation](https://github.com/opencoredev/akeru-bot/tree/main/docs/user): User guides for the product.
 - [Install Akeru Bot](https://raw.githubusercontent.com/opencoredev/akeru-bot/main/docs/user/install.md): Supported installation and update commands.
 - [Bot profiles](https://raw.githubusercontent.com/opencoredev/akeru-bot/main/docs/user/bots.md): Configure bot instructions, tools, and memory.
 - [Plugins and MCP servers](https://raw.githubusercontent.com/opencoredev/akeru-bot/main/docs/user/plugins.md): Add tools to a bot.
 - [Remote access](https://raw.githubusercontent.com/opencoredev/akeru-bot/main/docs/user/remote-access.md): Connect clients to an Akeru environment.
 - [Akeru Bot source](https://github.com/opencoredev/akeru-bot): Source, releases, issues, and contribution rules.
+- [Akeru Bot on npm](https://www.npmjs.com/package/akeru-bot): Official CLI package.
 
 ## Trust and contact
 

--- a/apps/marketing/public/openapi.json
+++ b/apps/marketing/public/openapi.json
@@ -1,0 +1,64 @@
+{
+  "openapi": "3.1.0",
+  "info": {
+    "title": "Akeru Bot public metadata API",
+    "version": "1.0.0",
+    "description": "Read-only public metadata for Akeru Bot project files. Akeru Bot itself runs on the user's machine and does not expose a hosted automation API."
+  },
+  "servers": [{ "url": "https://www.akeru-bot.com" }],
+  "security": [],
+  "paths": {
+    "/schema/t3.json": {
+      "get": {
+        "operationId": "getProjectFileSchema",
+        "summary": "Get the Akeru Bot project-file schema",
+        "description": "Returns the JSON Schema used to validate t3.json project configuration files.",
+        "responses": {
+          "200": {
+            "description": "The current project-file JSON Schema.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "required": ["$schema"],
+                  "properties": {
+                    "$schema": { "type": "string", "format": "uri" },
+                    "$id": { "type": "string", "format": "uri" },
+                    "title": { "type": "string" },
+                    "type": { "type": ["string", "array"] },
+                    "properties": { "type": "object", "additionalProperties": true }
+                  },
+                  "additionalProperties": true
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "The requested API resource does not exist.",
+            "content": {
+              "application/problem+json": {
+                "schema": { "$ref": "#/components/schemas/Problem" }
+              }
+            }
+          }
+        }
+      }
+    }
+  },
+  "components": {
+    "schemas": {
+      "Problem": {
+        "type": "object",
+        "required": ["type", "title", "status", "detail", "code", "resolution"],
+        "properties": {
+          "type": { "type": "string", "format": "uri-reference" },
+          "title": { "type": "string" },
+          "status": { "type": "integer" },
+          "detail": { "type": "string" },
+          "code": { "type": "string" },
+          "resolution": { "type": "string" }
+        }
+      }
+    }
+  }
+}

--- a/apps/marketing/public/sitemap.xml
+++ b/apps/marketing/public/sitemap.xml
@@ -4,6 +4,7 @@
   <url><loc>https://www.akeru-bot.com/download</loc><lastmod>2026-09-01</lastmod></url>
   <url><loc>https://www.akeru-bot.com/about</loc><lastmod>2026-09-01</lastmod></url>
   <url><loc>https://www.akeru-bot.com/contact</loc><lastmod>2026-09-01</lastmod></url>
+  <url><loc>https://www.akeru-bot.com/developers</loc><lastmod>2026-09-01</lastmod></url>
   <url><loc>https://www.akeru-bot.com/legal</loc><lastmod>2026-09-01</lastmod></url>
   <url><loc>https://www.akeru-bot.com/privacy-policy</loc><lastmod>2026-09-01</lastmod></url>
   <url><loc>https://www.akeru-bot.com/security-policy</loc><lastmod>2026-09-01</lastmod></url>

--- a/apps/marketing/src/layouts/Layout.astro
+++ b/apps/marketing/src/layouts/Layout.astro
@@ -117,6 +117,7 @@ const structuredData = [
         <div class="nav-links">
           <a class="nav-link" href="/#bots">Bots</a>
           <a class="nav-link" href="/#demos">Demos</a>
+          <a class="nav-link" href="/developers">Developers</a>
           <a class="nav-link" href={DOCS_URL} target="_blank" rel="noopener noreferrer">Docs</a>
         </div>
         <div class="nav-side nav-side--end">
@@ -167,6 +168,7 @@ const structuredData = [
               <a href={docsUrl("bots")} target="_blank" rel="noopener noreferrer">Bot profiles</a>
               <a href={docsUrl("plugins")} target="_blank" rel="noopener noreferrer">Plugins</a>
               <a href={docsUrl("remote-access")} target="_blank" rel="noopener noreferrer">Remote access</a>
+              <a href="/developers">Developer guide</a>
             </div>
             <div class="footer-col">
               <span class="footer-col-title">PROJECT</span>

--- a/apps/marketing/src/pages/developers.astro
+++ b/apps/marketing/src/pages/developers.astro
@@ -1,0 +1,34 @@
+---
+import TrustPage from "../components/TrustPage.astro";
+---
+
+<TrustPage
+  title="Akeru Bot developer guide"
+  description="Install the Akeru Bot CLI and inspect the public project-file schema and OpenAPI contract."
+  heading="Akeru Bot for developers"
+>
+  <p>
+    Akeru Bot is open-source software that runs coding agents on a user's machine or in a sandbox
+    that the user controls. Install the official CLI package with <code>npx akeru-bot@latest</code>.
+    The CLI starts the local server, opens the web client, and manages project threads. The desktop
+    app bundles the same server. Source code, releases, user guides, and contribution rules are in
+    the <a href="https://github.com/opencoredev/akeru-bot">Akeru Bot GitHub repository</a>.
+  </p>
+  <h2>Public metadata API</h2>
+  <p>
+    The production website exposes one unauthenticated, read-only metadata endpoint. Send
+    <code>GET /schema/t3.json</code> to retrieve the JSON Schema for <code>t3.json</code> project
+    files. The endpoint does not read user data, run a bot, or change any state. Read the
+    <a href="/openapi.json">Akeru Bot OpenAPI document</a> for its operation identifier, response
+    shape, and structured error model. Unsupported <code>/api</code> paths return an RFC 9457 JSON
+    problem with a stable code and a resolution link.
+  </p>
+  <h2>Local integrations</h2>
+  <p>
+    Akeru Bot connects to provider CLIs and user-selected tool servers from the local environment.
+    It does not provide a hosted automation API or a public MCP server. To configure bot profiles,
+    plugins, memory, or remote access, use the
+    <a href="https://github.com/opencoredev/akeru-bot/tree/main/docs/user">Akeru Bot user guides</a>.
+    Agents should not send project data, credentials, or provider tokens to this marketing domain.
+  </p>
+</TrustPage>

--- a/apps/marketing/src/readiness.test.ts
+++ b/apps/marketing/src/readiness.test.ts
@@ -37,4 +37,18 @@ describe("agent readiness files", () => {
       ]),
     );
   });
+
+  it("documents the public metadata endpoint", () => {
+    const openapi = JSON.parse(publicFile("openapi.json"));
+    const apiError = JSON.parse(publicFile("api-error.json"));
+
+    expect(openapi).toMatchObject({
+      openapi: "3.1.0",
+      info: { title: "Akeru Bot public metadata API" },
+    });
+    expect(openapi.paths["/schema/t3.json"].get).toMatchObject({
+      operationId: "getProjectFileSchema",
+    });
+    expect(apiError).toMatchObject({ status: 404, code: "api_resource_not_found" });
+  });
 });

--- a/apps/marketing/vercel.ts
+++ b/apps/marketing/vercel.ts
@@ -11,28 +11,38 @@ export const config: VercelConfig = {
   installCommand: "npm install -g vite-plus && vp install --filter '@t3tools/marketing...'",
   buildCommand: "vp run --filter @t3tools/marketing build",
   outputDirectory: "dist",
-  headers: [
+  routes: [
     {
-      source: "/(.*)",
-      headers: [
-        { key: "Vary", value: "Accept, Accept-Encoding" },
-        {
-          key: "Link",
-          value:
-            '</sitemap.xml>; rel="sitemap"; type="application/xml", </llms.txt>; rel="describedby"; type="text/markdown", </.well-known/ard.json>; rel="api-catalog"; type="application/json"',
-        },
-      ],
+      src: "^/(.*)$",
+      headers: {
+        Link: '</sitemap.xml>; rel="sitemap"; type="application/xml", </index.md>; rel="alternate"; type="text/markdown", </openapi.json>; rel="service-desc"; type="application/vnd.oai.openapi+json", </.well-known/ard.json>; rel="api-catalog"; type="application/json"',
+        Vary: "Accept, Accept-Encoding",
+      },
+      continue: true,
     },
     {
-      source: "/index.md",
-      headers: [{ key: "Content-Type", value: "text/markdown; charset=utf-8" }],
+      src: "^/$",
+      has: [{ type: "header", key: "accept", value: "text/markdown" }],
+      dest: "/index.md",
+      headers: {
+        "Content-Type": "text/markdown; charset=utf-8",
+        Vary: "Accept, Accept-Encoding",
+      },
     },
-  ],
-  rewrites: [
+    { handle: "filesystem" },
     {
-      source: "/",
-      destination: "/index.md",
-      has: [{ type: "header", key: "accept", value: ".*text/markdown.*" }],
+      src: "^/api(?:/.*)?$",
+      dest: "/api-error.json",
+      status: 404,
+      headers: { "Content-Type": "application/problem+json; charset=utf-8" },
     },
+    {
+      src: "^/.*$",
+      has: [{ type: "header", key: "accept", value: "text/markdown" }],
+      dest: "/404.md",
+      status: 404,
+      headers: { "Content-Type": "text/markdown; charset=utf-8" },
+    },
+    { src: "^/.*$", dest: "/404.html", status: 404 },
   ],
 };


### PR DESCRIPTION
The first readiness pass exposed the public project-file schema as an API but did not publish its contract or developer documentation. Vercel also applied cache headers but evaluated the Markdown rewrite after the static homepage, so negotiated requests still received HTML.

This documents the real read-only metadata endpoint with a valid OpenAPI 3.1 contract and developer guide. It returns RFC 9457 JSON errors for unsupported API paths and moves negotiation into Vercel routes before the filesystem check. Unknown Markdown requests now receive a short Markdown 404 with recovery links.

Checks:
- `vp lint apps/marketing/src/readiness.test.ts apps/marketing/src/layouts/Layout.astro apps/marketing/src/components/TrustPage.astro apps/marketing/src/pages/developers.astro apps/marketing/vercel.ts apps/marketing/astro.config.mjs`
- `vp test run apps/marketing/src/readiness.test.ts`
- `vp run --filter @t3tools/marketing typecheck`
- `vp run --filter @t3tools/marketing build`
- `vp exec tsc --noEmit -p apps/marketing/tsconfig.json`
- `bunx @redocly/cli lint apps/marketing/public/openapi.json --extends=minimal`

Model: gpt-5.6-sol
Harness: Codex in T3 Code