### PR TITLE
fix(bots): stop creating default bot

### DIFF
--- a/apps/web/src/components/roster/useServerRoster.ts
+++ b/apps/web/src/components/roster/useServerRoster.ts
@@ -1,5 +1,5 @@
 import { useAtomValue } from "@effect/atom-react";
-import { BotId, type EnvironmentId } from "@t3tools/contracts";
+import type { EnvironmentId } from "@t3tools/contracts";
 import { useCallback, useEffect } from "react";
 
 import {
@@ -10,7 +10,6 @@ import {
 } from "../../state/bots";
 import { usePrimaryEnvironmentId } from "../../state/environments";
 import { useAtomCommand } from "../../state/use-atom-command";
-import { DEFAULT_BOT_RUNTIME_MODE } from "./botSandbox";
 import { useRosterStore } from "./rosterStore";
 import type { BotAvatar } from "./types";
 
@@ -23,29 +22,9 @@ export function useServerRosterSync(): void {
   const loaded = useAtomValue(environmentRosterLoadedAtom(atomKey));
   const bots = useAtomValue(environmentBotsAtom(atomKey));
   const groups = useAtomValue(environmentGroupsAtom(atomKey));
-  const createBot = useAtomCommand(botEnvironment.create, { reportFailure: false });
 
   useEffect(() => {
     if (environmentId === null || !loaded) return;
-    if (bots.length === 0) {
-      void createBot({
-        environmentId,
-        input: {
-          botId: BotId.make("bot-akeru"),
-          name: "Akeru",
-          title: "Generalist",
-          label: null,
-          description: null,
-          avatar: { kind: "blob", shape: "circle", color: "#5B7FD4" },
-          engine: null,
-          sandbox: null,
-          runtimeMode: DEFAULT_BOT_RUNTIME_MODE,
-          usageCap: null,
-          groupId: null,
-        },
-      });
-      return;
-    }
     useRosterStore.getState().replaceRoster({
       bots: bots.map((bot) => ({
         ...bot,
@@ -54,7 +33,7 @@ export function useServerRosterSync(): void {
       })),
       groups: groups.map((group) => ({ ...group })),
     });
-  }, [bots, createBot, environmentId, groups, loaded]);
+  }, [bots, environmentId, groups, loaded]);
 }
 
 export function useSaveBotAvatar(): (botId: string, avatar: BotAvatar) => Promise<boolean> {

--- a/apps/web/src/components/sidebar/SidebarChrome.test.ts
+++ b/apps/web/src/components/sidebar/SidebarChrome.test.ts
@@ -139,7 +139,7 @@ describe("sidebar footer", () => {
     expect(source).not.toContain('openSettings("inbox")');
   });
 
-  it("creates manual and first-run bots with approval required", () => {
+  it("creates manual bots with approval required without adding a first-run bot", () => {
     const rosterSource = NodeFS.readFileSync(
       new URL("../roster/BotRosterSidebar.tsx", import.meta.url),
       "utf8",
@@ -150,9 +150,9 @@ describe("sidebar footer", () => {
     );
 
     expect(rosterSource).toContain("runtimeMode: DEFAULT_BOT_RUNTIME_MODE");
-    expect(syncSource).toContain("runtimeMode: DEFAULT_BOT_RUNTIME_MODE");
     expect(rosterSource).not.toContain('runtimeMode: "full-access"');
-    expect(syncSource).not.toContain('runtimeMode: "full-access"');
+    expect(syncSource).not.toContain('BotId.make("bot-akeru")');
+    expect(syncSource).not.toContain("botEnvironment.create");
   });
 
   it("updates existing bot and group threads before starting the next turn", () => {


### PR DESCRIPTION
New installations create an Akeru bot as soon as the web roster loads an empty server roster. This leaves every instance with a bot that the user did not request.

Remove the first-run create command from roster sync. Empty rosters now stay empty, while the manual bot flow still uses the default approval-required runtime mode. Add a regression guard for the empty-roster behavior.

Tests: `vp test run apps/web/src/components/sidebar/SidebarChrome.test.ts`
Typecheck: `vp run --filter @t3tools/web typecheck`

Model: gpt-5.6-sol
Harness: Codex in T3 Code