### PR TITLE
fix(providers): make subscription connections reliable

### DIFF
--- a/apps/server/src/provider/AkeruMastraTools.test.ts
+++ b/apps/server/src/provider/AkeruMastraTools.test.ts
@@ -5,6 +5,18 @@ import { createAkeruToolRuntime, type AkeruToolRuntime } from "./AkeruToolRuntim
 import { createAkeruMastraTools } from "./AkeruMastraTools.ts";
 
 describe("createAkeruMastraTools", () => {
+  it("builds every registered Akeru tool schema", () => {
+    const runtime = {
+      toolsForThread: () => AKERU_TOOL_CATALOG,
+      requiresApproval: vi.fn(async () => false),
+      execute: vi.fn(async () => ({ ok: true })),
+    } as unknown as AkeruToolRuntime;
+
+    const tools = createAkeruMastraTools("thread-all-tools", runtime);
+
+    expect(Object.keys(tools)).toEqual(AKERU_TOOL_CATALOG.map((definition) => definition.id));
+  });
+
   it("passes an exact call identity and approval mode to the runtime", async () => {
     const execute = vi.fn(async () => ({ ok: true }));
     const runtime = {

--- a/apps/server/src/provider/AkeruMastraTools.ts
+++ b/apps/server/src/provider/AkeruMastraTools.ts
@@ -28,6 +28,7 @@ export function createAkeruMastraTools(threadId: string, runtime: AkeruToolRunti
         description: definition.description,
         inputSchema: z.fromJSONSchema(
           standardSchema["~standard"].jsonSchema.input({ target: "draft-07" }),
+          { defaultTarget: "draft-7" },
         ),
         requireApproval: approval,
         execute: (input, context) => {

--- a/apps/web/src/components/settings/ProvidersPanel.test.tsx
+++ b/apps/web/src/components/settings/ProvidersPanel.test.tsx
@@ -1,70 +1,44 @@
 import { renderToStaticMarkup } from "react-dom/server";
-import { BotId, type ProviderAccessStatus } from "@t3tools/contracts";
+import type { SubscriptionProviderStatus } from "@t3tools/contracts";
 import { describe, expect, it } from "vite-plus/test";
 
-import {
-  ProviderAccessSection,
-  selectVisibleProviderAccess,
-  SUBSCRIPTION_PROVIDERS,
-} from "./ProvidersPanel";
+import { ProviderLoginCard, SUBSCRIPTION_PROVIDERS } from "./ProvidersPanel";
 
-function access(overrides: Partial<ProviderAccessStatus>): ProviderAccessStatus {
-  return {
-    id: "api-key-custom",
-    label: "Custom API key",
-    accessMethod: "api-key",
-    health: "detected",
-    apiAccess: "included",
-    nextAction: "Send a provider request to verify the key.",
-    dependentBots: [],
-    dependentRoutines: [],
-    ...overrides,
-  };
-}
-
-describe("provider access rows", () => {
+describe("subscription providers", () => {
   it("offers Kimi subscription login without Cursor", () => {
     const providers = SUBSCRIPTION_PROVIDERS.map((provider) => provider.id);
     expect(providers).toContain("kimi-for-coding");
     expect(providers).not.toContain("cursor");
   });
 
-  it("keeps non-subscription access and unsupported plan rows", () => {
-    const visible = selectVisibleProviderAccess([
-      access({ id: "chatgpt", accessMethod: "subscription-oauth" }),
-      access({ id: "supergrok", accessMethod: "subscription-oauth", health: "unsupported" }),
-      access({ id: "cursor-acp", accessMethod: "acp-cli" }),
-      access({ id: "builtin-exa", accessMethod: "mcp" }),
-      access({ id: "email-browser", accessMethod: "browser", health: "unsupported" }),
-    ]);
-
-    expect(visible.map((item) => item.id)).toEqual([
-      "supergrok",
-      "cursor-acp",
-      "builtin-exa",
-      "email-browser",
-    ]);
-  });
-
-  it("renders repair instructions and dependent bots", () => {
+  it("keeps connected providers compact", () => {
+    const status: SubscriptionProviderStatus = {
+      provider: "openai-codex",
+      connected: true,
+      health: "failed-first-request",
+      lastSuccessfulRequestAt: "2026-09-01T10:00:00.000Z",
+      lastFailedRequest: {
+        at: "2026-09-01T10:01:00.000Z",
+        message: "Provider request failed.",
+      },
+      dependentBots: [],
+      dependentRoutines: [],
+    };
     const markup = renderToStaticMarkup(
-      <ProviderAccessSection
-        access={[
-          access({
-            id: "email-browser",
-            label: "Email browser session",
-            accessMethod: "browser",
-            health: "unsupported",
-            repairAction: "Add an email connector.",
-            dependentBots: [{ id: BotId.make("bot-1"), name: "Research bot" }],
-          }),
-        ]}
+      <ProviderLoginCard
+        definition={SUBSCRIPTION_PROVIDERS[0]!}
+        status={status}
+        busy={false}
+        onConnect={() => undefined}
+        onDisconnect={() => undefined}
+        onTest={() => undefined}
       />,
     );
 
-    expect(markup).toContain("Email browser session");
-    expect(markup).toContain("Unsupported");
-    expect(markup).toContain("Add an email connector.");
-    expect(markup).toContain("Research bot");
+    expect(markup).toContain("ChatGPT");
+    expect(markup).toContain("Reconnect");
+    expect(markup).not.toContain("Last successful request");
+    expect(markup).not.toContain("Last failed request");
+    expect(markup).not.toContain("Provider request failed.");
   });
 });

--- a/apps/web/src/components/settings/ProvidersPanel.tsx
+++ b/apps/web/src/components/settings/ProvidersPanel.tsx
@@ -1,16 +1,8 @@
-import {
-  CheckIcon,
-  CopyIcon,
-  ExternalLinkIcon,
-  LoaderIcon,
-  LogOutIcon,
-  RefreshCwIcon,
-} from "lucide-react";
+import { CopyIcon, ExternalLinkIcon, LoaderIcon, LogOutIcon, RefreshCwIcon } from "lucide-react";
 import { useCallback, useEffect, useMemo, useState } from "react";
 import type {
   SubscriptionAuthLoginProgress,
   SubscriptionAuthStartResult,
-  ProviderAccessStatus,
   SubscriptionProviderId,
   SubscriptionProviderStatus,
 } from "@t3tools/contracts";
@@ -88,9 +80,7 @@ const healthLabels: Readonly<Record<NonNullable<SubscriptionProviderStatus["heal
   recovered: "Recovered",
 };
 
-function healthBadgeVariant(
-  health: SubscriptionProviderStatus["health"] | ProviderAccessStatus["health"] | undefined,
-) {
+function healthBadgeVariant(health: SubscriptionProviderStatus["health"] | undefined) {
   if (health === "healthy" || health === "recovered") return "success" as const;
   if (
     health === "expired" ||
@@ -104,89 +94,13 @@ function healthBadgeVariant(
   return "secondary" as const;
 }
 
-const accessMethodLabels: Readonly<Record<ProviderAccessStatus["accessMethod"], string>> = {
-  "subscription-oauth": "Subscription plan",
-  "api-key": "API key",
-  "acp-cli": "CLI",
-  browser: "Browser",
-  mcp: "MCP",
-};
-
-export function selectVisibleProviderAccess(
-  access: ReadonlyArray<ProviderAccessStatus>,
-): ReadonlyArray<ProviderAccessStatus> {
-  return access.filter(
-    (item) => item.accessMethod !== "subscription-oauth" || item.health === "unsupported",
-  );
-}
-
-export function ProviderAccessSection({
-  access,
-}: {
-  readonly access: ReadonlyArray<ProviderAccessStatus>;
-}) {
-  const rows = selectVisibleProviderAccess(access);
-  if (rows.length === 0) return null;
-
-  return (
-    <SettingsSection title="Provider access">
-      {rows.map((item) => (
-        <SettingsRow
-          key={item.id}
-          title={
-            <span className="flex items-center gap-2">
-              {item.label}
-              <Badge variant={healthBadgeVariant(item.health)} className="h-4 px-1.5 text-[10px]">
-                {healthLabels[item.health]}
-              </Badge>
-            </span>
-          }
-          description={item.nextAction}
-          status={accessMethodLabels[item.accessMethod]}
-        >
-          {item.repairAction || item.lastFailedRequest || item.dependentBots.length > 0 ? (
-            <dl className="grid gap-x-6 gap-y-2 border-t border-border/50 py-3 text-xs sm:grid-cols-2">
-              {item.repairAction ? (
-                <div>
-                  <dt className="text-muted-foreground">Repair</dt>
-                  <dd>{item.repairAction}</dd>
-                </div>
-              ) : null}
-              {item.lastFailedRequest ? (
-                <div>
-                  <dt className="text-muted-foreground">Last failed request</dt>
-                  <dd>
-                    {formatTimestamp(item.lastFailedRequest.at)} · {item.lastFailedRequest.message}
-                  </dd>
-                </div>
-              ) : null}
-              {item.dependentBots.length > 0 ? (
-                <div>
-                  <dt className="text-muted-foreground">Dependent bots</dt>
-                  <dd>{item.dependentBots.map((bot) => bot.name).join(", ")}</dd>
-                </div>
-              ) : null}
-            </dl>
-          ) : null}
-        </SettingsRow>
-      ))}
-    </SettingsSection>
-  );
-}
-
-function formatTimestamp(value: string | number | undefined): string {
-  if (value === undefined) return "Never";
-  const date = new Date(value);
-  return Number.isNaN(date.getTime()) ? "Never" : date.toLocaleString();
-}
-
 function commandError(result: AtomCommandResult<unknown, unknown>): string {
   if (result._tag !== "Failure") return "The request failed.";
   const error = squashAtomCommandFailure(result);
   return error instanceof Error ? error.message : "The request failed.";
 }
 
-function ProviderLoginCard({
+export function ProviderLoginCard({
   definition,
   status,
   busy,
@@ -256,50 +170,7 @@ function ProviderLoginCard({
           </Button>
         )
       }
-    >
-      {connected ? (
-        <dl className="grid gap-x-6 gap-y-2 border-t border-border/50 py-3 text-xs sm:grid-cols-2">
-          <div>
-            <dt className="text-muted-foreground">Last successful request</dt>
-            <dd>{formatTimestamp(status?.lastSuccessfulRequestAt)}</dd>
-          </div>
-          <div>
-            <dt className="text-muted-foreground">Last failed request</dt>
-            <dd>
-              {status?.lastFailedRequest
-                ? `${formatTimestamp(status.lastFailedRequest.at)} · ${status.lastFailedRequest.message}`
-                : "Never"}
-            </dd>
-          </div>
-          <div>
-            <dt className="text-muted-foreground">OAuth expiry</dt>
-            <dd>{formatTimestamp(status?.expiresAt)}</dd>
-          </div>
-          <div>
-            <dt className="text-muted-foreground">Next retry</dt>
-            <dd>
-              {status?.nextRetryAt ? formatTimestamp(status.nextRetryAt) : "No automatic retry"}
-            </dd>
-          </div>
-          <div>
-            <dt className="text-muted-foreground">OAuth check</dt>
-            <dd>
-              {!status?.oauthCheck
-                ? "Not run"
-                : `${status.oauthCheck.status === "passed" ? "Passed" : "Failed"} · ${formatTimestamp(status.oauthCheck.checkedAt)}`}
-            </dd>
-          </div>
-          <div>
-            <dt className="text-muted-foreground">Dependent bots</dt>
-            <dd>{status?.dependentBots.map((bot) => bot.name).join(", ") || "None"}</dd>
-          </div>
-          <div>
-            <dt className="text-muted-foreground">Dependent routines</dt>
-            <dd>{status?.dependentRoutines.join(", ") || "Unavailable until routines ship"}</dd>
-          </div>
-        </dl>
-      ) : null}
-    </SettingsRow>
+    />
   );
 }
 
@@ -418,8 +289,6 @@ export function ProvidersPanel() {
     () => new Map(statusQuery.data?.providers.map((status) => [status.provider, status]) ?? []),
     [statusQuery.data],
   );
-  const providerAccess = statusQuery.data?.access ?? [];
-
   const settleLogin = useCallback(
     (progress: SubscriptionAuthLoginProgress) => {
       if (progress.status === "connected") {
@@ -570,20 +439,6 @@ export function ProvidersPanel() {
             onTest={() => void testHealth(definition.id)}
           />
         ))}
-      </SettingsSection>
-
-      <ProviderAccessSection access={providerAccess} />
-
-      <SettingsSection title="How credentials are used">
-        <SettingsRow
-          title={
-            <span className="flex items-center gap-2">
-              <CheckIcon className="size-4 text-success" />
-              Stored on your Akeru server
-            </span>
-          }
-          description="Refresh tokens never enter a project or sandbox. A run receives only the short-lived access token it needs."
-        />
       </SettingsSection>
     </SettingsPageContainer>
   );


### PR DESCRIPTION
## Problem

Subscription OAuth could connect successfully and then fail before the first provider request. The Akeru tool schema used draft-07 references, but Zod interpreted it as draft 2020-12 and rejected `UpdateBotProfileInput`.

The Providers page exposed request history, retry state, provider access, and credential internals that did not help users connect an account.

## Fix

- Parse the generated tool schema as draft-07 so every registered Akeru tool loads before the first agent request.
- Lock the complete tool catalog behind a regression test that reproduced the failure.
- Keep the Providers page focused on subscriptions and connection controls.

## Verification

- 108 focused server tests passed.
- 2 focused web tests passed.
- Server and web typechecks passed.

## Screenshots

### Before

![Providers before](https://github.com/user-attachments/assets/bb39be8f-de65-4166-bba0-80fbb0ee9ecf)

### After

![Providers after](https://github.com/user-attachments/assets/264be0f1-a5c4-46b0-97c9-cb2f383eeba4)

The after image uses a local connected-state fixture. It does not use account credentials.

Model: gpt-5.6-sol
Harness: Codex harness in T3 Code
