### PR TITLE
fix(bots): queue rapid follow-up messages

### DIFF
--- a/apps/server/src/provider/Layers/AgentController.test.ts
+++ b/apps/server/src/provider/Layers/AgentController.test.ts
@@ -209,10 +209,12 @@ function makeMastraHarness() {
   let modeId = "build";
   let modelId = "openai/gpt-5.6-sol";
   let resolveSend: (() => void) | undefined;
+  const rejectSends: Array<(cause: unknown) => void> = [];
   const sendMessage = vi.fn(
     () =>
-      new Promise<void>((resolve) => {
+      new Promise<void>((resolve, reject) => {
         resolveSend = resolve;
+        rejectSends.push(reject);
       }),
   );
   const session = {
@@ -270,6 +272,7 @@ function makeMastraHarness() {
     sendMessage,
     emit,
     finishSend: () => resolveSend?.(),
+    rejectSend: (index: number, cause: unknown) => rejectSends[index]?.(cause),
   };
 }
 
@@ -867,6 +870,102 @@ describe("AgentControllerLive", () => {
         expect(mastra.sendMessage).toHaveBeenCalledWith({ content: "Reply once." });
         expect(bridge.startSession).not.toHaveBeenCalled();
         expect(bridge.sendTurn).not.toHaveBeenCalled();
+      }),
+      bridge.service,
+      mastra.factory,
+    );
+  });
+
+  it.effect("queues Mastra follow-ups while the current turn is active", () => {
+    const bridge = makeBridge();
+    const mastra = makeMastraHarness();
+    return provideController(
+      Effect.gen(function* () {
+        const controller = yield* AgentController;
+        yield* resolveCodex(controller);
+        yield* controller.startSession(codexThreadId, {
+          threadId: codexThreadId,
+          provider: ProviderDriverKind.make("codex"),
+          providerInstanceId: codexInstanceId,
+          modelSelection: codexSelection,
+          runtimeMode: "full-access",
+        });
+        const events: ProviderRuntimeEvent[] = [];
+        const eventsFiber = yield* controller.streamEvents.pipe(
+          Stream.runForEach((event) => Effect.sync(() => events.push(event))),
+          Effect.forkChild({ startImmediately: true }),
+        );
+        yield* Effect.yieldNow;
+
+        const first = yield* controller.sendTurn({
+          threadId: codexThreadId,
+          input: "First message",
+        });
+        const second = yield* controller.sendTurn({
+          threadId: codexThreadId,
+          input: "Queued follow-up",
+        });
+
+        expect(second.turnId).not.toBe(first.turnId);
+        expect(mastra.sendMessage).toHaveBeenCalledTimes(1);
+        mastra.finishSend();
+        yield* Effect.yieldNow;
+        yield* Effect.yieldNow;
+        expect(mastra.sendMessage).toHaveBeenNthCalledWith(2, { content: "Queued follow-up" });
+        expect(
+          events.filter((event) => event.type === "turn.started").map((event) => event.turnId),
+        ).toEqual([first.turnId, second.turnId]);
+        expect(
+          events
+            .filter((event) => event.type === "session.state.changed")
+            .map((event) => event.payload.state),
+        ).toEqual(["running", "running"]);
+        yield* Fiber.interrupt(eventsFiber);
+      }),
+      bridge.service,
+      mastra.factory,
+    );
+  });
+
+  it.effect("ignores a stale Mastra send failure after the next turn starts", () => {
+    const bridge = makeBridge();
+    const mastra = makeMastraHarness();
+    return provideController(
+      Effect.gen(function* () {
+        const controller = yield* AgentController;
+        yield* resolveCodex(controller);
+        yield* controller.startSession(codexThreadId, {
+          threadId: codexThreadId,
+          provider: ProviderDriverKind.make("codex"),
+          providerInstanceId: codexInstanceId,
+          modelSelection: codexSelection,
+          runtimeMode: "full-access",
+        });
+        const events: ProviderRuntimeEvent[] = [];
+        const eventsFiber = yield* controller.streamEvents.pipe(
+          Stream.runForEach((event) => Effect.sync(() => events.push(event))),
+          Effect.forkChild({ startImmediately: true }),
+        );
+        yield* Effect.yieldNow;
+
+        yield* controller.sendTurn({ threadId: codexThreadId, input: "First message" });
+        const second = yield* controller.sendTurn({
+          threadId: codexThreadId,
+          input: "Queued follow-up",
+        });
+        mastra.emit({ type: "agent_end", reason: "complete" } as AgentControllerEvent);
+        yield* Effect.yieldNow;
+        expect(mastra.sendMessage).toHaveBeenCalledTimes(2);
+
+        mastra.rejectSend(0, new Error("late failure"));
+        yield* Effect.yieldNow;
+        yield* Effect.yieldNow;
+
+        expect(events.some((event) => event.type === "runtime.error")).toBe(false);
+        expect(
+          events.find((event) => event.type === "turn.started" && event.turnId === second.turnId),
+        ).toBeDefined();
+        yield* Fiber.interrupt(eventsFiber);
       }),
       bridge.service,
       mastra.factory,

--- a/apps/server/src/provider/Layers/AgentController.ts
+++ b/apps/server/src/provider/Layers/AgentController.ts
@@ -114,7 +114,11 @@ import {
   botWorkspaceResourceKey,
 } from "../botWorkspacePool.ts";
 import { AgentControllerRuntimeError, AgentControllerUnsupportedEngineError } from "../Errors.ts";
-import { AgentController, type AgentControllerShape } from "../Services/AgentController.ts";
+import {
+  AgentController,
+  type AgentControllerSendTurnInput,
+  type AgentControllerShape,
+} from "../Services/AgentController.ts";
 import { LegacyProviderBridge } from "../Services/LegacyProviderBridge.ts";
 
 const DEFAULT_MODE_ID = "build";
@@ -152,6 +156,13 @@ interface ActiveTurn {
   assistantText: string;
 }
 
+interface PendingTurn {
+  readonly threadId: ThreadId;
+  readonly turnId: TurnId;
+  readonly message: Parameters<MastraSession["sendMessage"]>[0];
+  readonly botUsage: AgentControllerSendTurnInput["botUsage"];
+}
+
 interface ActiveSession {
   readonly session: MastraSession;
   readonly provider: ProviderDriverKind;
@@ -163,6 +174,7 @@ interface ActiveSession {
   model: string;
   status: ProviderSession["status"];
   activeTurn: ActiveTurn | null;
+  readonly pendingTurns: PendingTurn[];
   readonly toolNames: Map<string, string>;
   readonly approvalRequests: Map<string, { readonly name: string; readonly input: unknown }>;
   readonly connectorSessionApprovals: Set<string>;
@@ -840,6 +852,54 @@ const make = (options?: AgentControllerLiveOptions) =>
       toolRuntime.clearApprovals(String(threadId));
     };
 
+    const startPendingTurn = (
+      active: ActiveSession,
+      { threadId, turnId, message, botUsage }: PendingTurn,
+    ) => {
+      const key = String(threadId);
+      if (botUsage) {
+        memoryUsageByThread.set(key, { ...botUsage, turnId });
+      } else {
+        memoryUsageByThread.delete(key);
+      }
+      active.activeTurn = {
+        turnId,
+        assistantMessages: new Map(),
+        waiting: false,
+        finished: false,
+        inputTokens: 0,
+        outputTokens: 0,
+        reasoningTokens: 0,
+        memoryQueued: false,
+        assistantText: "",
+      };
+      active.status = "running";
+      publish({
+        ...baseEvent(threadId, active, turnId),
+        type: "turn.started",
+        payload: { model: active.model },
+      });
+      publishSessionState(threadId, active, "running");
+      void active.session
+        .sendMessage(message)
+        .then(() => {
+          const turn = active.activeTurn;
+          if (turn?.turnId === turnId && !turn.waiting) {
+            finishTurn(threadId, active, "completed");
+          }
+        })
+        .catch((cause: unknown) => {
+          if (active.activeTurn?.turnId !== turnId) return;
+          const detail = sessionFailureDetail(active, cause);
+          publish({
+            ...baseEvent(threadId, active, turnId),
+            type: "runtime.error",
+            payload: { message: detail, class: "provider_error" },
+          });
+          finishTurn(threadId, active, "failed", detail);
+        });
+    };
+
     const finishTurn = (
       threadId: ThreadId,
       active: ActiveSession,
@@ -880,7 +940,12 @@ const make = (options?: AgentControllerLiveOptions) =>
           });
       }
       active.activeTurn = null;
-      publishSessionState(threadId, active, "ready");
+      const nextTurn = active.pendingTurns.shift();
+      if (nextTurn) {
+        startPendingTurn(active, nextTurn);
+      } else {
+        publishSessionState(threadId, active, "ready");
+      }
     };
 
     const publishAssistantText = (
@@ -1619,6 +1684,7 @@ const make = (options?: AgentControllerLiveOptions) =>
           model: resolved.modelSelection.model,
           status: "ready" as const,
           activeTurn: null,
+          pendingTurns: [],
           toolNames: new Map<string, string>(),
           approvalRequests: new Map(),
           connectorSessionApprovals: new Set<string>(),
@@ -1664,12 +1730,6 @@ const make = (options?: AgentControllerLiveOptions) =>
               : providerInput,
           );
         }
-        if (active.activeTurn) {
-          return yield* new AgentControllerRuntimeError({
-            operation: "sendTurn",
-            detail: `Mastra session for thread '${input.threadId}' already has an active turn.`,
-          });
-        }
         const attachmentFiles = yield* Effect.forEach(input.attachments ?? [], (attachment) => {
           const path = resolveAttachmentPath({
             attachmentsDir: config.attachmentsDir,
@@ -1705,45 +1765,16 @@ const make = (options?: AgentControllerLiveOptions) =>
           .join("\n\n");
         const files = attachmentFiles.map(({ file }) => file);
         const turnId = TurnId.make(`mastra-turn-${NodeCrypto.randomUUID()}`);
-        if (input.botUsage) {
-          memoryUsageByThread.set(key, { ...input.botUsage, turnId });
-        } else {
-          memoryUsageByThread.delete(key);
-        }
-        active.activeTurn = {
+        active.pendingTurns.push({
+          threadId: input.threadId,
           turnId,
-          assistantMessages: new Map(),
-          waiting: false,
-          finished: false,
-          inputTokens: 0,
-          outputTokens: 0,
-          reasoningTokens: 0,
-          memoryQueued: false,
-          assistantText: "",
-        };
-        active.status = "running";
-        publish({
-          ...baseEvent(input.threadId, active, turnId),
-          type: "turn.started",
-          payload: { model: active.model },
+          message: { content, ...(files.length > 0 ? { files } : {}) },
+          botUsage: input.botUsage,
         });
-        publishSessionState(input.threadId, active, "running");
-        void active.session
-          .sendMessage({ content, ...(files.length > 0 ? { files } : {}) })
-          .then(() => {
-            if (!active.activeTurn?.waiting) {
-              finishTurn(input.threadId, active, "completed");
-            }
-          })
-          .catch((cause: unknown) => {
-            const detail = sessionFailureDetail(active, cause);
-            publish({
-              ...baseEvent(input.threadId, active, turnId),
-              type: "runtime.error",
-              payload: { message: detail, class: "provider_error" },
-            });
-            finishTurn(input.threadId, active, "failed", detail);
-          });
+        if (!active.activeTurn) {
+          const nextTurn = active.pendingTurns.shift();
+          if (nextTurn) startPendingTurn(active, nextTurn);
+        }
         return { threadId: input.threadId, turnId };
       },
     );
@@ -1761,6 +1792,7 @@ const make = (options?: AgentControllerLiveOptions) =>
         }
         return yield* legacyProviderBridge.interruptTurn(input);
       }
+      active.pendingTurns.length = 0;
       active.session.abort();
       finishTurn(input.threadId, active, "interrupted");
     });
@@ -1896,6 +1928,7 @@ const make = (options?: AgentControllerLiveOptions) =>
         }
         return yield* legacyProviderBridge.stopSession(input);
       }
+      active.pendingTurns.length = 0;
       active.session.abort();
       if (active.activeTurn) {
         finishTurn(input.threadId, active, "interrupted");
@@ -1942,6 +1975,7 @@ const make = (options?: AgentControllerLiveOptions) =>
     yield* Effect.addFinalizer(() =>
       Effect.gen(function* () {
         for (const [threadId, active] of sessions) {
+          active.pendingTurns.length = 0;
           active.session.abort();
           if (active.activeTurn) {
             finishTurn(ThreadId.make(threadId), active, "interrupted");

--- a/apps/web/src/components/roster/BotPromptComposer.test.tsx
+++ b/apps/web/src/components/roster/BotPromptComposer.test.tsx
@@ -12,9 +12,11 @@ import {
   type BotPromptAttachment,
 } from "./BotPromptAttachments";
 import {
+  appendBotMention,
   BotPromptComposer,
   canSubmitBotPrompt,
   findMentionedBotId,
+  isBotPromptSubmissionCurrent,
   isBotPromptExpanded,
   shouldFocusBotPromptForKey,
 } from "./BotPromptComposer";
@@ -32,6 +34,16 @@ describe("bot prompt composer", () => {
     expect(canSubmitBotPrompt(true, "Send this", 0)).toBe(false);
     expect(canSubmitBotPrompt(false, "Send this", 0)).toBe(true);
     expect(canSubmitBotPrompt(false, "", 1)).toBe(true);
+  });
+
+  it("restores a failed submission only while the composer remains unchanged", () => {
+    expect(isBotPromptSubmissionCurrent(3, 3)).toBe(true);
+    expect(isBotPromptSubmissionCurrent(3, 4)).toBe(false);
+  });
+
+  it("preserves new draft text when inserting a mention", () => {
+    expect(appendBotMention("new draft", "Mori")).toBe("new draft @Mori ");
+    expect(appendBotMention("", "Mori")).toBe("@Mori ");
   });
 
   it("expands for long or multiline prompts", () => {

--- a/apps/web/src/components/roster/BotPromptComposer.tsx
+++ b/apps/web/src/components/roster/BotPromptComposer.tsx
@@ -27,6 +27,17 @@ export function canSubmitBotPrompt(disabled: boolean, prompt: string, fileCount:
   return !disabled && (prompt.trim().length > 0 || fileCount > 0);
 }
 
+export function isBotPromptSubmissionCurrent(
+  submissionRevision: number,
+  currentRevision: number,
+): boolean {
+  return submissionRevision === currentRevision;
+}
+
+export function appendBotMention(draft: string, botName: string): string {
+  return `${draft}${draft && !/\s$/.test(draft) ? " " : ""}@${botName} `;
+}
+
 export function shouldFocusBotPromptForKey(input: {
   readonly altKey: boolean;
   readonly ctrlKey: boolean;
@@ -96,6 +107,7 @@ export function BotPromptComposer({
   const releasedPreviewUrlsRef = useRef(new Set<string>());
   const fileInputRef = useRef<HTMLInputElement>(null);
   const promptInputRef = useRef<HTMLTextAreaElement>(null);
+  const revisionRef = useRef(0);
   const releaseAttachments = (items: readonly BotPromptAttachment[]) => {
     const unreleased = items.filter((attachment) => {
       if (
@@ -110,6 +122,7 @@ export function BotPromptComposer({
     releaseBotPromptAttachments(unreleased);
   };
   const persistDraft = (next: string) => {
+    revisionRef.current += 1;
     setDraft(next);
     if (draftKey) writeBotDraft(draftKey, next);
   };
@@ -117,6 +130,7 @@ export function BotPromptComposer({
   persistDraftRef.current = persistDraft;
 
   useEffect(() => {
+    revisionRef.current += 1;
     setDraft(draftKey ? readBotDraft(draftKey) : "");
   }, [draftKey]);
   useEffect(
@@ -129,6 +143,7 @@ export function BotPromptComposer({
 
   const expanded = modelPicker !== null || attachments.length > 0 || isBotPromptExpanded(draft);
   const addFiles = (next: FileList | readonly File[]) => {
+    revisionRef.current += 1;
     const added = createBotPromptAttachments(Array.from(next));
     const updated = [...attachmentsRef.current, ...added];
     attachmentsRef.current = updated;
@@ -137,6 +152,7 @@ export function BotPromptComposer({
   const removeAttachment = (attachmentId: string) => {
     const removed = attachmentsRef.current.find((attachment) => attachment.id === attachmentId);
     if (!removed) return;
+    revisionRef.current += 1;
     const updated = attachmentsRef.current.filter((attachment) => attachment.id !== attachmentId);
     attachmentsRef.current = updated;
     setAttachments(updated);
@@ -196,31 +212,34 @@ export function BotPromptComposer({
         const prompt = draft.trim();
         const submittedAttachments = [...attachmentsRef.current];
         if (!canSubmitBotPrompt(disabled, prompt, submittedAttachments.length)) return;
-        const submittedIds = new Set(submittedAttachments.map((attachment) => attachment.id));
+        const submittedFailedIds = new Set(failedAttachmentIds);
+        persistDraft("");
+        if (draftKey) clearBotDraft(draftKey);
+        attachmentsRef.current = [];
+        setAttachments([]);
+        setFailedAttachmentIds(new Set());
+        setExpandedAttachmentId(null);
+        const submissionRevision = revisionRef.current;
         void onSubmit(
           prompt,
           submittedAttachments.map((attachment) => attachment.file),
           findMentionedBotId(prompt, mentionBots),
-        ).then(
-          (sent) => {
-            if (!sent) return;
-            persistDraft("");
-            if (draftKey) clearBotDraft(draftKey);
-            const remaining = attachmentsRef.current.filter(
-              (attachment) => !submittedIds.has(attachment.id),
-            );
-            attachmentsRef.current = remaining;
-            setAttachments(remaining);
-            setFailedAttachmentIds(
-              (current) => new Set([...current].filter((id) => !submittedIds.has(id))),
-            );
-            if (expandedAttachmentId && submittedIds.has(expandedAttachmentId)) {
-              setExpandedAttachmentId(null);
-            }
+        ).then((sent) => {
+          if (sent) {
             releaseAttachments(submittedAttachments);
-          },
-          () => undefined,
-        );
+            return;
+          }
+          if (!isBotPromptSubmissionCurrent(submissionRevision, revisionRef.current)) {
+            releaseAttachments(submittedAttachments);
+            return;
+          }
+          revisionRef.current += 1;
+          setDraft(prompt);
+          if (draftKey) writeBotDraft(draftKey, prompt);
+          attachmentsRef.current = submittedAttachments;
+          setAttachments(submittedAttachments);
+          setFailedAttachmentIds(submittedFailedIds);
+        });
       }}
     >
       <div
@@ -291,12 +310,7 @@ export function BotPromptComposer({
                 {mentionBots.map((bot) => (
                   <MenuItem
                     key={bot.id}
-                    onClick={() =>
-                      setDraft(
-                        (current) =>
-                          `${current}${current && !/\s$/.test(current) ? " " : ""}@${bot.name} `,
-                      )
-                    }
+                    onClick={() => persistDraft(appendBotMention(draft, bot.name))}
                   >
                     <AtSignIcon />
                     Mention {bot.name}

--- a/apps/web/src/components/roster/BotThreadLanding.tsx
+++ b/apps/web/src/components/roster/BotThreadLanding.tsx
@@ -237,7 +237,6 @@ export function BotThreadLanding({ botId }: { readonly botId: string }) {
             botName={bot.name}
             draftKey={bot.id}
             disabled={
-              runtime.sending ||
               pendingApproval !== null ||
               voiceCall.activeCall?.botId === bot.id ||
               voiceCall.startingBotId === bot.id ||

--- a/apps/web/src/components/roster/botThreadRuntime.logic.test.ts
+++ b/apps/web/src/components/roster/botThreadRuntime.logic.test.ts
@@ -1,151 +1,55 @@
-import {
-  BotId,
-  GroupId,
-  MessageId,
-  ProjectId,
-  ProviderInstanceId,
-  ThreadId,
-} from "@t3tools/contracts";
+import { BotId, GroupId, ProjectId, ProviderInstanceId, ThreadId } from "@t3tools/contracts";
 import { describe, expect, it } from "vite-plus/test";
 
 import {
-  acceptBotTurnSubmission,
   buildBotTurnStartInput,
   buildGroupTurnStartInput,
+  createBotTurnSubmissionQueue,
   findLatestBotThreadTarget,
   findLatestGroupThreadTarget,
   joinOrStartThreadCreate,
-  releaseBotTurnSubmissionAfterObservation,
-  reserveBotTurnSubmission,
-  reserveBotTurnSubmissionAfterObservation,
 } from "./botThreadRuntime.logic";
 
 describe("bot thread runtime", () => {
-  it("shares the turn submission lock across runtime instances", () => {
-    const release = reserveBotTurnSubmission("env-a:bot-akeru");
-    expect(release).not.toBeNull();
-    expect(reserveBotTurnSubmission("env-a:bot-akeru")).toBeNull();
-    release?.();
+  it("queues rapid submissions without waiting for the active reply", async () => {
+    const queue = createBotTurnSubmissionQueue();
+    const order: string[] = [];
+    let releaseFirst: (() => void) | undefined;
+    const firstBlocked = new Promise<void>((resolve) => {
+      releaseFirst = resolve;
+    });
+
+    const first = queue.enqueue(async () => {
+      order.push("first:start");
+      await firstBlocked;
+      order.push("first:end");
+      return true;
+    });
+    const second = queue.enqueue(async () => {
+      order.push("second");
+      return true;
+    });
+    const third = queue.enqueue(async () => {
+      order.push("third");
+      return true;
+    });
+
+    await Promise.resolve();
+    expect(order).toEqual(["first:start"]);
+    releaseFirst?.();
+    await expect(Promise.all([first, second, third])).resolves.toEqual([true, true, true]);
+    expect(order).toEqual(["first:start", "first:end", "second", "third"]);
   });
 
-  it("retains a reserved submission until the start command responds", () => {
-    const key = "env-a:bot-unaccepted";
-    const release = reserveBotTurnSubmission(key);
-    expect(release).not.toBeNull();
-    expect(
-      releaseBotTurnSubmissionAfterObservation(
-        key,
-        {
-          requestMessageId: MessageId.make("message-unrelated"),
-          state: "completed",
-        },
-        [
-          {
-            kind: "provider.turn.start.failed",
-            payload: { requestId: "message-unrelated" },
-          },
-        ],
-      ),
-    ).toBe(false);
-    expect(reserveBotTurnSubmission(key)).toBeNull();
-    release?.();
-  });
+  it("continues queued submissions after one fails", async () => {
+    const queue = createBotTurnSubmissionQueue();
+    const failed = queue.enqueue(async () => {
+      throw new Error("dispatch failed");
+    });
+    const followUp = queue.enqueue(async () => "sent");
 
-  it("retains an accepted submission until its exact turn settles", () => {
-    const key = "env-a:bot-settlement";
-    const requestMessageId = MessageId.make("message-request");
-    const release = reserveBotTurnSubmission(key);
-    expect(release).not.toBeNull();
-    acceptBotTurnSubmission(key, requestMessageId);
-
-    expect(
-      releaseBotTurnSubmissionAfterObservation(key, { requestMessageId, state: "running" }, []),
-    ).toBe(false);
-    expect(reserveBotTurnSubmission(key)).toBeNull();
-    expect(
-      releaseBotTurnSubmissionAfterObservation(key, { requestMessageId, state: "running" }, [
-        {
-          kind: "provider.turn.start.failed",
-          payload: { requestId: requestMessageId },
-        },
-      ]),
-    ).toBe(false);
-    expect(
-      releaseBotTurnSubmissionAfterObservation(
-        key,
-        { requestMessageId: MessageId.make("message-other"), state: "completed" },
-        [],
-      ),
-    ).toBe(false);
-
-    for (const state of ["completed", "interrupted", "error"] as const) {
-      expect(releaseBotTurnSubmissionAfterObservation(key, { requestMessageId, state }, [])).toBe(
-        true,
-      );
-      const nextRelease = reserveBotTurnSubmission(key);
-      expect(nextRelease).not.toBeNull();
-      if (state !== "error") acceptBotTurnSubmission(key, requestMessageId);
-      else nextRelease?.();
-    }
-  });
-
-  it("releases only for the exact provider start failure", () => {
-    const key = "env-a:bot-start-failure";
-    const requestMessageId = MessageId.make("message-request");
-    const release = reserveBotTurnSubmission(key);
-    expect(release).not.toBeNull();
-    acceptBotTurnSubmission(key, requestMessageId);
-
-    expect(
-      releaseBotTurnSubmissionAfterObservation(key, null, [
-        {
-          kind: "provider.turn.start.failed",
-          payload: { requestId: "message-other" },
-        },
-        { kind: "provider.turn.start.failed", payload: null },
-        { kind: "provider.turn.start.failed", payload: { requestId: 42 } },
-      ]),
-    ).toBe(false);
-    expect(reserveBotTurnSubmission(key)).toBeNull();
-    expect(
-      releaseBotTurnSubmissionAfterObservation(key, null, [
-        {
-          kind: "provider.turn.start.failed",
-          payload: { requestId: "message-request" },
-        },
-      ]),
-    ).toBe(true);
-  });
-
-  it("does not let stale cleanup release a newer submission", () => {
-    const key = "env-a:bot-replaced";
-    const staleRelease = reserveBotTurnSubmission(key);
-    expect(staleRelease).not.toBeNull();
-    staleRelease?.();
-
-    const nextRelease = reserveBotTurnSubmission(key);
-    expect(nextRelease).not.toBeNull();
-    staleRelease?.();
-    expect(reserveBotTurnSubmission(key)).toBeNull();
-    nextRelease?.();
-  });
-
-  it("reconciles a terminal turn received while the bot view was unmounted", () => {
-    const key = "env-a:bot-navigation";
-    const requestMessageId = MessageId.make("message-before-navigation");
-    const staleRelease = reserveBotTurnSubmission(key);
-    expect(staleRelease).not.toBeNull();
-    acceptBotTurnSubmission(key, requestMessageId);
-
-    const nextRelease = reserveBotTurnSubmissionAfterObservation(
-      key,
-      { requestMessageId, state: "completed" },
-      [],
-    );
-    expect(nextRelease).not.toBeNull();
-    staleRelease?.();
-    expect(reserveBotTurnSubmission(key)).toBeNull();
-    nextRelease?.();
+    await expect(failed).rejects.toThrow("dispatch failed");
+    await expect(followUp).resolves.toBe("sent");
   });
 
   it("shares concurrent initial thread creation", async () => {

--- a/apps/web/src/components/roster/botThreadRuntime.logic.ts
+++ b/apps/web/src/components/roster/botThreadRuntime.logic.ts
@@ -7,71 +7,23 @@ import type {
   ProviderInteractionMode,
   RuntimeMode,
   ThreadId,
-  OrchestrationLatestTurn,
-  OrchestrationThreadActivity,
 } from "@t3tools/contracts";
 
 import { parseChatPath } from "./roster.logic";
 
-const botTurnSubmissions = new Map<
-  string,
-  {
-    readonly requestMessageId: string | null;
-    readonly token: symbol;
-  }
->();
+export function createBotTurnSubmissionQueue() {
+  let tail: Promise<void> = Promise.resolve();
 
-export function reserveBotTurnSubmission(key: string): (() => void) | null {
-  if (botTurnSubmissions.has(key)) return null;
-  const token = Symbol(key);
-  botTurnSubmissions.set(key, { requestMessageId: null, token });
-  return () => {
-    if (botTurnSubmissions.get(key)?.token === token) botTurnSubmissions.delete(key);
+  return {
+    enqueue<T>(submission: () => Promise<T>): Promise<T> {
+      const result = tail.then(submission, submission);
+      tail = result.then(
+        () => undefined,
+        () => undefined,
+      );
+      return result;
+    },
   };
-}
-
-export function acceptBotTurnSubmission(key: string, requestMessageId: string): void {
-  const submission = botTurnSubmissions.get(key);
-  if (submission) botTurnSubmissions.set(key, { ...submission, requestMessageId });
-}
-
-export function releaseBotTurnSubmissionAfterObservation(
-  key: string,
-  latestTurn: Pick<OrchestrationLatestTurn, "requestMessageId" | "state"> | null | undefined,
-  activities: readonly Pick<OrchestrationThreadActivity, "kind" | "payload">[],
-): boolean {
-  const submission = botTurnSubmissions.get(key);
-  if (!submission?.requestMessageId) return false;
-
-  const matchingTurn = latestTurn?.requestMessageId === submission.requestMessageId;
-  if (matchingTurn && latestTurn.state === "running") return false;
-
-  const matchingTurnSettled = matchingTurn;
-  const providerStartFailed = activities.some((activity) => {
-    if (
-      activity.kind !== "provider.turn.start.failed" ||
-      typeof activity.payload !== "object" ||
-      activity.payload === null ||
-      !("requestId" in activity.payload) ||
-      typeof activity.payload.requestId !== "string"
-    ) {
-      return false;
-    }
-    return activity.payload.requestId === submission.requestMessageId;
-  });
-  if (!matchingTurnSettled && !providerStartFailed) return false;
-
-  botTurnSubmissions.delete(key);
-  return true;
-}
-
-export function reserveBotTurnSubmissionAfterObservation(
-  key: string,
-  latestTurn: Pick<OrchestrationLatestTurn, "requestMessageId" | "state"> | null | undefined,
-  activities: readonly Pick<OrchestrationThreadActivity, "kind" | "payload">[],
-): (() => void) | null {
-  releaseBotTurnSubmissionAfterObservation(key, latestTurn, activities);
-  return reserveBotTurnSubmission(key);
 }
 
 export async function joinOrStartThreadCreate<T>(input: {

--- a/apps/web/src/components/roster/useBotThreadRuntime.ts
+++ b/apps/web/src/components/roster/useBotThreadRuntime.ts
@@ -8,7 +8,7 @@ import {
   type ModelSelection,
   type ScopedThreadRef,
 } from "@t3tools/contracts";
-import { useCallback, useEffect, useMemo, useRef, useState } from "react";
+import { useCallback, useMemo, useRef, useState } from "react";
 
 import { usePrimarySettings } from "../../hooks/useSettings";
 import { DEFAULT_INTERACTION_MODE } from "../../types";
@@ -17,7 +17,6 @@ import { resolveAppModelSelectionState } from "../../modelSelection";
 import {
   useAllEnvironmentShellsBootstrapped,
   useProjects,
-  useThreadActivities,
   useThreadMessages,
   useThreadShell,
   useThreadShells,
@@ -30,12 +29,10 @@ import { useAtomCommand } from "../../state/use-atom-command";
 import { sortScopedProjectsForSidebar } from "../Sidebar.logic";
 import { resolveBotRuntimeMode } from "./botSandbox";
 import {
-  acceptBotTurnSubmission,
   buildBotTurnStartInput,
+  createBotTurnSubmissionQueue,
   joinOrStartThreadCreate,
-  releaseBotTurnSubmissionAfterObservation,
   resolveBotThreadTarget,
-  reserveBotTurnSubmissionAfterObservation,
 } from "./botThreadRuntime.logic";
 import { parseChatPath } from "./roster.logic";
 import { useRosterStore } from "./rosterStore";
@@ -110,7 +107,6 @@ export function useBotThreadRuntime(botId: string, effectiveModelSelection: Mode
     retainedThreadRef.current.threadRef = linkedThreadRef;
   }
   const messages = useThreadMessages(linkedThreadRef);
-  const activities = useThreadActivities(linkedThreadRef);
   const defaultProject = useMemo(
     () =>
       bootstrapped && primaryEnvironmentId
@@ -142,18 +138,10 @@ export function useBotThreadRuntime(botId: string, effectiveModelSelection: Mode
   const createThread = useAtomCommand(threadEnvironment.create, { reportFailure: false });
   const ensureThreadRef = useRef<Promise<ScopedThreadRef | null> | null>(null);
   const botReady = serverBots.some((candidate) => candidate.id === botId);
-  const sendInFlightRef = useRef(false);
+  const sendQueueRef = useRef(createBotTurnSubmissionQueue());
+  const queuedSendCountRef = useRef(0);
   const [sending, setSending] = useState(false);
   const [error, setError] = useState<string | null>(null);
-  useEffect(() => {
-    if (!primaryEnvironmentId) return;
-    const submissionKey = `${primaryEnvironmentId}:${botId}`;
-    releaseBotTurnSubmissionAfterObservation(
-      submissionKey,
-      rememberedThread?.latestTurn,
-      activities,
-    );
-  }, [activities, botId, primaryEnvironmentId, rememberedThread?.latestTurn]);
 
   const ensureTranscriptThread = useCallback(
     async (title = `Call with ${bot?.name ?? "bot"}`): Promise<ScopedThreadRef | null> => {
@@ -204,133 +192,117 @@ export function useBotThreadRuntime(botId: string, effectiveModelSelection: Mode
   );
 
   const send = useCallback(
-    async (prompt: string, files: readonly File[]): Promise<boolean> => {
-      if (sendInFlightRef.current) return false;
+    (prompt: string, files: readonly File[]): Promise<boolean> => {
       if (!botReady) {
         setError("The bot is still connecting.");
-        return false;
+        return Promise.resolve(false);
       }
       if (!activeProject) {
         setError("Add a project before you message a bot.");
-        return false;
-      }
-      if (rememberedThread?.latestTurn?.state === "running") {
-        setError("Wait for the current reply to finish.");
-        return false;
+        return Promise.resolve(false);
       }
       const unsupported = files.find((file) => !file.type.startsWith("image/"));
       if (unsupported) {
         setError("Bot attachments must be images.");
-        return false;
-      }
-      const submissionKey = `${activeProject.environmentId}:${botId}`;
-      const releaseSubmission = reserveBotTurnSubmissionAfterObservation(
-        submissionKey,
-        rememberedThread?.latestTurn,
-        activities,
-      );
-      if (!releaseSubmission) {
-        setError("Wait for the current reply to start.");
-        return false;
+        return Promise.resolve(false);
       }
 
-      sendInFlightRef.current = true;
+      queuedSendCountRef.current += 1;
       setSending(true);
       setError(null);
-      const createdAt = new Date().toISOString();
-      const modelSelection: ModelSelection =
-        effectiveModelSelection ?? activeProject.defaultModelSelection ?? appDefaultModelSelection;
-      const runtimeMode = resolveBotRuntimeMode(bot?.sandbox ?? null, settings.localExecutionMode);
-      const title = threadTitle(prompt, files);
-      const messageId = newMessageId();
-      let accepted = false;
-
-      try {
-        const attachments = await Promise.all(
-          files.map(async (file) => ({
-            type: "image" as const,
-            name: file.name,
-            mimeType: file.type,
-            sizeBytes: file.size,
-            dataUrl: await readFileAsDataUrl(file),
-          })),
+      return sendQueueRef.current.enqueue(async () => {
+        setError(null);
+        const createdAt = new Date().toISOString();
+        const modelSelection: ModelSelection =
+          effectiveModelSelection ??
+          activeProject.defaultModelSelection ??
+          appDefaultModelSelection;
+        const runtimeMode = resolveBotRuntimeMode(
+          bot?.sandbox ?? null,
+          settings.localExecutionMode,
         );
-        const currentThreadRef =
-          retainedThreadRef.current.threadRef ?? (await ensureTranscriptThread(title));
-        if (!currentThreadRef) {
-          setError("Could not send the message.");
-          return false;
-        }
-        if (rememberedThread && rememberedThread.runtimeMode !== runtimeMode) {
-          const modeResult = await setRuntimeMode({
-            environmentId: currentThreadRef.environmentId,
-            input: { threadId: currentThreadRef.threadId, runtimeMode },
-          });
-          if (modeResult._tag === "Failure") {
-            setError(errorMessage(modeResult));
+        const title = threadTitle(prompt, files);
+
+        try {
+          const attachments = await Promise.all(
+            files.map(async (file) => ({
+              type: "image" as const,
+              name: file.name,
+              mimeType: file.type,
+              sizeBytes: file.size,
+              dataUrl: await readFileAsDataUrl(file),
+            })),
+          );
+          const currentThreadRef =
+            retainedThreadRef.current.threadRef ?? (await ensureTranscriptThread(title));
+          if (!currentThreadRef) {
+            setError("Could not send the message.");
             return false;
           }
-        }
-        const startResult = await startTurn({
-          environmentId: currentThreadRef.environmentId,
-          input: buildBotTurnStartInput({
-            botId: BotId.make(botId),
-            threadId: currentThreadRef.threadId,
-            projectId: activeProject.id,
-            title,
-            message: {
-              messageId,
-              role: "user",
-              text: prompt,
-              attachments,
-            },
-            modelSelection,
-            runtimeMode,
-            interactionMode: DEFAULT_INTERACTION_MODE,
-            createdAt,
-            createThread: false,
-          }),
-        });
-        if (startResult._tag === "Failure") {
-          setError(errorMessage(startResult));
-          return false;
-        }
+          if (rememberedThread && rememberedThread.runtimeMode !== runtimeMode) {
+            const modeResult = await setRuntimeMode({
+              environmentId: currentThreadRef.environmentId,
+              input: { threadId: currentThreadRef.threadId, runtimeMode },
+            });
+            if (modeResult._tag === "Failure") {
+              setError(errorMessage(modeResult));
+              return false;
+            }
+          }
+          const startResult = await startTurn({
+            environmentId: currentThreadRef.environmentId,
+            input: buildBotTurnStartInput({
+              botId: BotId.make(botId),
+              threadId: currentThreadRef.threadId,
+              projectId: activeProject.id,
+              title,
+              message: {
+                messageId: newMessageId(),
+                role: "user",
+                text: prompt,
+                attachments,
+              },
+              modelSelection,
+              runtimeMode,
+              interactionMode: DEFAULT_INTERACTION_MODE,
+              createdAt,
+              createThread: false,
+            }),
+          });
+          if (startResult._tag === "Failure") {
+            setError(errorMessage(startResult));
+            return false;
+          }
 
-        accepted = true;
-        acceptBotTurnSubmission(submissionKey, messageId);
-        releaseBotTurnSubmissionAfterObservation(
-          submissionKey,
-          rememberedThread?.latestTurn,
-          activities,
-        );
-        retainedThreadRef.current.threadRef = currentThreadRef;
-        useRosterStore
-          .getState()
-          .recordChatPath(botId, `/${currentThreadRef.environmentId}/${currentThreadRef.threadId}`);
-        useRosterStore.getState().recordLastMessage(botId, {
-          text: prompt || (files.length === 1 ? "Sent an image" : "Sent images"),
-          at: createdAt,
-        });
-        return true;
-      } catch (cause) {
-        setError(cause instanceof Error ? cause.message : "Could not send the message.");
-        return false;
-      } finally {
-        if (!accepted) releaseSubmission();
-        sendInFlightRef.current = false;
-        setSending(false);
-      }
+          retainedThreadRef.current.threadRef = currentThreadRef;
+          useRosterStore
+            .getState()
+            .recordChatPath(
+              botId,
+              `/${currentThreadRef.environmentId}/${currentThreadRef.threadId}`,
+            );
+          useRosterStore.getState().recordLastMessage(botId, {
+            text: prompt || (files.length === 1 ? "Sent an image" : "Sent images"),
+            at: createdAt,
+          });
+          return true;
+        } catch (cause) {
+          setError(cause instanceof Error ? cause.message : "Could not send the message.");
+          return false;
+        } finally {
+          queuedSendCountRef.current -= 1;
+          if (queuedSendCountRef.current === 0) setSending(false);
+        }
+      });
     },
     [
       activeProject,
-      activities,
       appDefaultModelSelection,
       bot,
       botId,
       effectiveModelSelection,
       botReady,
       ensureTranscriptThread,
-      rememberedThread?.latestTurn,
       rememberedThread?.runtimeMode,
       settings.localExecutionMode,
       setRuntimeMode,

--- a/apps/web/src/routes/_chat.bots.$botId.tsx
+++ b/apps/web/src/routes/_chat.bots.$botId.tsx
@@ -21,7 +21,7 @@ function BotThreadRouteView() {
 
   return (
     <>
-      <BotThreadLanding botId={botId} />
+      <BotThreadLanding key={botId} botId={botId} />
       {bot ? (
         <BotDetailsPanel
           key={bot.id}


### PR DESCRIPTION
Rapid bot follow-up messages were blocked while a turn was active. Users could not queue a burst of prompts, and stale turn callbacks could leave the UI in the wrong working state.

This change adds a client FIFO for active-turn submissions and provider queues for Mastra Codex and Kimi. Stop clears pending work, and turn tokens prevent old completions from changing newer turns.

Verification:

- 66 focused server and web tests passed
- Web and server typechecks passed
- Five rapid browser submissions produced five user messages while the bot stayed working

[Before and after interaction test](https://github.com/user-attachments/assets/f8ebc770-e11a-41e6-a34d-bc009c23c83e)

Model: gpt-5.6-sol
Harness: Codex harness in T3 Code
