### PR TITLE
fix(agent): keep recent context across restarts

### DIFF
--- a/apps/server/src/provider/AkeruMastraHarness.test.ts
+++ b/apps/server/src/provider/AkeruMastraHarness.test.ts
@@ -18,6 +18,7 @@ import { assert, describe, expect, it, vi } from "vite-plus/test";
 
 import { AKERU_AGENT_INSTRUCTIONS, AKERU_BOT_INSTRUCTIONS } from "./AkeruAgentInstructions.ts";
 import {
+  AKERU_RECENT_MESSAGE_LIMIT,
   AkeruPassiveObservationalMemoryProcessor,
   akeruActionNeedsApproval,
   createAkeruObserveHooks,
@@ -143,6 +144,114 @@ describe("AkeruMastraHarness", () => {
     } finally {
       NodeFS.rmSync(directory, { recursive: true, force: true });
     }
+  });
+
+  it("restores a bounded recent message window after reopening", async () => {
+    const directory = NodeFS.mkdtempSync(NodePath.join(NodeOS.tmpdir(), "akeru-message-store-"));
+    const options = {
+      authStorage: new AuthStorage(NodePath.join(directory, "auth.json")),
+      memoryDbPath: NodePath.join(directory, "observational-memory.sqlite"),
+    };
+    try {
+      const first = await createAkeruMastraMemory(options);
+      await first.memory.createThread({
+        threadId: "thread-history",
+        resourceId: "thread-history",
+      });
+      const messages = Array.from({ length: AKERU_RECENT_MESSAGE_LIMIT + 4 }, (_, index) => ({
+        id: `message-${index}`,
+        role: index % 2 === 0 ? ("user" as const) : ("assistant" as const),
+        createdAt: DateTime.toDate(
+          DateTime.makeUnsafe(`2026-08-30T20:${String(index).padStart(2, "0")}:00.000Z`),
+        ),
+        content: { format: 2 as const, parts: [{ type: "text" as const, text: `Turn ${index}` }] },
+        threadId: "thread-history",
+        resourceId: "thread-history",
+      }));
+      await first.memory.persistMessages(messages);
+      await first.close();
+
+      const reopened = await createAkeruMastraMemory(options);
+      const engine = {
+        getThreadContext: vi.fn(() => ({
+          threadId: "thread-history",
+          resourceId: "thread-history",
+        })),
+        getOrCreateRecord: vi.fn(async () => ({ activeObservations: "Older observations." })),
+        buildContextSystemMessages: vi.fn(async () => ["Older context from observations."]),
+      } as unknown as ObservationalMemory;
+      const processor = new AkeruPassiveObservationalMemoryProcessor(engine, reopened.memory);
+      const messageList = new MessageList({
+        threadId: "thread-history",
+        resourceId: "thread-history",
+      });
+      messageList.add(
+        {
+          id: "current-message",
+          role: "user",
+          createdAt: DateTime.toDate(DateTime.makeUnsafe("2026-08-31T20:00:00.000Z")),
+          content: { format: 2, parts: [{ type: "text", text: "What did we discuss?" }] },
+          threadId: "thread-history",
+          resourceId: "thread-history",
+        },
+        "input",
+      );
+
+      await processor.processInputStep({ stepNumber: 0, messageList } as never);
+
+      const recalled = messageList.get.remembered.db();
+      assert.equal(recalled.length, AKERU_RECENT_MESSAGE_LIMIT);
+      assert.deepEqual(
+        recalled.map((message) => message.id),
+        messages.slice(-AKERU_RECENT_MESSAGE_LIMIT).map((message) => message.id),
+      );
+      assert.deepEqual(
+        messageList.getSystemMessages("observational-memory").map((message) => message.content),
+        ["Older context from observations."],
+      );
+      assert.equal(messageList.get.input.db()[0]?.id, "current-message");
+      await reopened.close();
+    } finally {
+      NodeFS.rmSync(directory, { recursive: true, force: true });
+    }
+  });
+
+  it("adds older observational context beside the recent message window", async () => {
+    const engine = {
+      getThreadContext: vi.fn(() => ({ threadId: "thread-context", resourceId: "thread-context" })),
+      getOrCreateRecord: vi.fn(async () => ({
+        activeObservations: "The user prefers short replies.",
+      })),
+      buildContextSystemMessages: vi.fn(async () => ["Older context: short replies."]),
+    } as unknown as ObservationalMemory;
+    const processor = new AkeruPassiveObservationalMemoryProcessor(engine, {
+      recall: vi.fn(async () => ({ messages: [] })),
+      persistMessages: vi.fn(async () => undefined),
+    } as unknown as Memory);
+    const messageList = new MessageList({
+      threadId: "thread-context",
+      resourceId: "thread-context",
+    });
+    messageList.add(
+      {
+        id: "recent-message",
+        role: "user",
+        createdAt: DateTime.toDate(DateTime.makeUnsafe("2026-08-31T20:00:00.000Z")),
+        content: { format: 2, parts: [{ type: "text", text: "Use the context you remember." }] },
+        threadId: "thread-context",
+        resourceId: "thread-context",
+      },
+      "input",
+    );
+
+    await processor.processInputStep({ stepNumber: 0, messageList } as never);
+
+    assert.deepEqual(
+      messageList.getSystemMessages("observational-memory").map((message) => message.content),
+      ["Older context: short replies."],
+    );
+    assert.lengthOf(messageList.get.input.db(), 1);
+    assert.equal(messageList.get.input.db()[0]?.id, "recent-message");
   });
 
   it("persists only messages created by the current turn", async () => {

--- a/apps/server/src/provider/AkeruMastraHarness.ts
+++ b/apps/server/src/provider/AkeruMastraHarness.ts
@@ -43,6 +43,7 @@ import type { AkeruToolRuntime } from "./AkeruToolRuntime.ts";
 import { isCodexComputerUseTool } from "./CodexComputerUse.ts";
 
 const DEFAULT_MODEL_ID = "openai/gpt-5.6-sol";
+export const AKERU_RECENT_MESSAGE_LIMIT = 10;
 const decodeProductFeedbackToolDraft = Schema.decodeUnknownExit(ProductFeedbackToolDraft, {
   onExcessProperty: "error",
 });
@@ -213,6 +214,10 @@ export class AkeruPassiveObservationalMemoryProcessor implements Processor<"obse
     if (args.stepNumber !== 0) return args.messageList;
     const context = this.engine.getThreadContext(args.requestContext, args.messageList);
     if (!context) return args.messageList;
+    const recent = await this.memory.recall({ threadId: context.threadId });
+    for (const message of recent.messages) {
+      if (message.role !== "system") args.messageList.add(message, "memory");
+    }
     const record = await this.engine.getOrCreateRecord(context.threadId, context.resourceId);
     const chunks = await this.engine.buildContextSystemMessages({ ...context, record });
     args.messageList.clearSystemMessages("observational-memory");
@@ -255,7 +260,7 @@ export async function createAkeruMastraMemory(
   const memory = new Memory({
     storage,
     options: {
-      lastMessages: 10,
+      lastMessages: AKERU_RECENT_MESSAGE_LIMIT,
       semanticRecall: false,
       workingMemory: { enabled: false },
       observationalMemory: false,


### PR DESCRIPTION
## What changed

Akeru now reloads the latest 10 persisted thread messages before each agent turn. Older context still comes from Mastra Observational Memory. The memory store remains LibSQL-backed across server restarts.

## Why

The custom observational-memory processor disabled Mastra's built-in message-history processor but did not load persisted messages itself. New agent sessions could therefore see the current prompt and observational summary, but not the recent chat.

## Verification

- `vp test run apps/server/src/provider/AkeruMastraHarness.test.ts`
- `vp run --filter akeru-bot typecheck`
- Regression test writes 14 messages, reopens storage, and proves only the latest 10 messages plus older observational context reach the model.

Model: gpt-5.6-sol
Harness: Codex harness in T3 Code