### PR TITLE
fix(marketing): preload launch demos

### DIFF
--- a/apps/marketing/src/lib/demoPlayback.test.ts
+++ b/apps/marketing/src/lib/demoPlayback.test.ts
@@ -12,4 +12,8 @@ describe("landing demo playback", () => {
   it("keeps the first demo when visibility is tied", () => {
     NodeAssert.equal(pickMostVisibleDemo([0.6, 0.6, 0.2]), 0);
   });
+
+  it("selects a demo as soon as any part enters the viewport", () => {
+    NodeAssert.equal(pickMostVisibleDemo([0, Number.MIN_VALUE, 0]), 1);
+  });
 });

--- a/apps/marketing/src/pages/index.astro
+++ b/apps/marketing/src/pages/index.astro
@@ -147,7 +147,7 @@ const DOWNLOAD_GLYPH = `<path d="M7 11.5L12 17.5L17 11.5H14L14 3H10L10 11.5H7Z" 
               muted
               loop
               playsinline
-              preload="none"
+              preload="auto"
             />
           </div>
         </div>
@@ -258,6 +258,13 @@ const DOWNLOAD_GLYPH = `<path d="M7 11.5L12 17.5L17 11.5H14L14 3H10L10 11.5H7Z" 
 
     const reduceMotion = window.matchMedia("(prefers-reduced-motion: reduce)").matches;
     const visibility = new Map<HTMLVideoElement, number>();
+    const preloadVideos = () => {
+      videos.forEach((video) => {
+        if (video.src) return;
+        const source = video.dataset.src;
+        if (source) video.src = source;
+      });
+    };
 
     const updatePlayback = () => {
       if (document.hidden || reduceMotion) {
@@ -280,18 +287,16 @@ const DOWNLOAD_GLYPH = `<path d="M7 11.5L12 17.5L17 11.5H14L14 3H10L10 11.5H7Z" 
         entries.forEach((entry) => {
           const video = entry.target as HTMLVideoElement;
           visibility.set(video, entry.intersectionRatio);
-          if (entry.isIntersecting && !video.src) {
-            const source = video.dataset.src;
-            if (source) video.src = source;
-          }
         });
         updatePlayback();
       },
-      { rootMargin: "320px 0px", threshold: [0, 0.25, 0.5, 0.75, 1] },
+      { threshold: [0, 0.25, 0.5, 0.75, 1] },
     );
 
     videos.forEach((video) => observer.observe(video));
     document.addEventListener("visibilitychange", updatePlayback);
+    if (document.readyState === "complete") preloadVideos();
+    else window.addEventListener("load", preloadVideos, { once: true });
   }
 
   init();


### PR DESCRIPTION
The demo sources loaded too late, which left blank frames during normal scrolling. This preloads all three clips after the page load event and starts playback as soon as a clip enters the viewport. Only the most visible clip plays.

Model: GPT-5.6 Sol
Harness: Codex in T3 Code