### PR TITLE
feat(marketing): explain unsigned macOS downloads

### DIFF
--- a/apps/marketing/src/components/InstallPromptDialog.astro
+++ b/apps/marketing/src/components/InstallPromptDialog.astro
@@ -1,0 +1,174 @@
+---
+import {
+  MAC_DOWNLOAD_DIALOG_BODY,
+  MAC_DOWNLOAD_DIALOG_TITLE,
+} from "../lib/downloadInstallPrompt";
+---
+
+<dialog
+  id="install-prompt-dialog"
+  class="install-dialog"
+  aria-labelledby="install-prompt-title"
+  aria-describedby="install-prompt-description"
+>
+  <div class="install-dialog-panel">
+    <form method="dialog" class="install-dialog-close-row">
+      <button class="install-dialog-close" type="submit">Close</button>
+    </form>
+    <div class="install-dialog-copy">
+      <h2 id="install-prompt-title">{MAC_DOWNLOAD_DIALOG_TITLE}</h2>
+      <p id="install-prompt-description">{MAC_DOWNLOAD_DIALOG_BODY}</p>
+    </div>
+    <button class="install-dialog-action" type="button" data-copy-install-prompt>
+      Copy prompt
+    </button>
+  </div>
+</dialog>
+
+<script>
+  import { installPromptForPlatform } from "../lib/installPrompt";
+
+  const dialog = document.getElementById("install-prompt-dialog") as HTMLDialogElement | null;
+  const copyButton = dialog?.querySelector<HTMLButtonElement>("[data-copy-install-prompt]");
+  let platform: string | null = null;
+  let trigger: HTMLAnchorElement | null = null;
+
+  document.addEventListener("click", (event) => {
+    const link = (event.target as Element | null)?.closest<HTMLAnchorElement>(
+      "a[data-install-prompt]",
+    );
+    if (!link || !dialog || event.defaultPrevented) return;
+
+    platform = link.dataset.installPrompt ?? null;
+    trigger = link;
+    if (copyButton) copyButton.textContent = "Copy prompt";
+    dialog.showModal();
+  });
+
+  copyButton?.addEventListener("click", async () => {
+    const prompt = platform ? installPromptForPlatform(platform) : null;
+    if (!prompt) return;
+    try {
+      await navigator.clipboard.writeText(prompt);
+      copyButton.textContent = "Copied";
+    } catch {
+      copyButton.textContent = "Copy prompt";
+    }
+  });
+
+  dialog?.addEventListener("click", (event) => {
+    if (event.target === dialog) dialog.close();
+  });
+
+  dialog?.addEventListener("close", () => {
+    platform = null;
+    if (copyButton) copyButton.textContent = "Copy prompt";
+    trigger?.focus();
+    trigger = null;
+  });
+</script>
+
+<style>
+  .install-dialog {
+    width: min(460px, calc(100vw - 32px));
+    max-width: none;
+    margin: auto;
+    padding: 0;
+    color: var(--color-foreground);
+    background: transparent;
+    border: 0;
+  }
+
+  .install-dialog::backdrop {
+    background: rgba(9, 9, 11, 0.72);
+    backdrop-filter: blur(8px);
+  }
+
+  .install-dialog-panel {
+    display: flex;
+    flex-direction: column;
+    gap: 28px;
+    padding: 18px;
+    background: var(--color-popover);
+    border: 1px solid var(--color-border);
+    border-radius: 18px;
+    box-shadow: 0 24px 80px rgba(0, 0, 0, 0.32);
+  }
+
+  .install-dialog-close-row {
+    display: flex;
+    justify-content: flex-end;
+  }
+
+  .install-dialog-close {
+    min-height: 36px;
+    padding: 0 12px;
+    color: var(--color-muted-foreground);
+    font: inherit;
+    font-size: 13px;
+    background: transparent;
+    border: 0;
+    border-radius: 8px;
+    cursor: pointer;
+  }
+
+  .install-dialog-close:hover {
+    color: var(--color-foreground);
+    background: var(--color-muted);
+  }
+
+  .install-dialog-copy {
+    padding: 0 14px;
+  }
+
+  .install-dialog h2 {
+    margin: 0;
+    font-size: 25px;
+    font-weight: 560;
+    line-height: 1.15;
+    letter-spacing: -0.035em;
+  }
+
+  .install-dialog-copy > p:last-child {
+    margin: 14px 0 0;
+    color: var(--color-muted-foreground);
+    font-size: 14px;
+    line-height: 1.6;
+  }
+
+  .install-dialog-action {
+    width: 100%;
+    min-height: 48px;
+    padding: 0 18px;
+    color: var(--color-primary-foreground);
+    font: inherit;
+    font-size: 14px;
+    font-weight: 600;
+    background: var(--color-primary);
+    border: 1px solid var(--color-primary);
+    border-radius: 11px;
+    cursor: pointer;
+  }
+
+  .install-dialog-action:hover {
+    opacity: 0.9;
+  }
+
+  .install-dialog-close:focus-visible,
+  .install-dialog-action:focus-visible {
+    outline: 2px solid var(--color-primary);
+    outline-offset: 2px;
+  }
+
+  @media (max-width: 520px) {
+    .install-dialog-panel {
+      gap: 22px;
+      padding: 14px;
+      border-radius: 15px;
+    }
+
+    .install-dialog-copy {
+      padding: 0 8px;
+    }
+  }
+</style>

--- a/apps/marketing/src/lib/downloadInstallPrompt.test.ts
+++ b/apps/marketing/src/lib/downloadInstallPrompt.test.ts
@@ -1,0 +1,19 @@
+import { describe, expect, it } from "vite-plus/test";
+import {
+  MAC_DOWNLOAD_DIALOG_BODY,
+  installPromptPlatformForDownload,
+} from "./downloadInstallPrompt";
+
+describe("installPromptPlatformForDownload", () => {
+  it("shows the install prompt only after resolving a macOS download", () => {
+    expect(installPromptPlatformForDownload("mac", true)).toBe("mac");
+    expect(installPromptPlatformForDownload("mac", false)).toBeNull();
+    expect(installPromptPlatformForDownload("win", true)).toBeNull();
+    expect(installPromptPlatformForDownload("linux", true)).toBeNull();
+  });
+
+  it("explains why macOS may block the app", () => {
+    expect(MAC_DOWNLOAD_DIALOG_BODY).toMatch(/paid Developer Program/);
+    expect(MAC_DOWNLOAD_DIALOG_BODY).toMatch(/macOS may block Akeru Bot/);
+  });
+});

--- a/apps/marketing/src/lib/downloadInstallPrompt.ts
+++ b/apps/marketing/src/lib/downloadInstallPrompt.ts
@@ -1,0 +1,11 @@
+export const MAC_DOWNLOAD_DIALOG_TITLE = "Akeru Bot isn't signed yet";
+
+export const MAC_DOWNLOAD_DIALOG_BODY =
+  "We haven't joined Apple's paid Developer Program yet, so macOS may block Akeru Bot the first time you open it. Copy this prompt to your coding agent. It will verify the app and open it for you.";
+
+export function installPromptPlatformForDownload(
+  platform: string | undefined,
+  resolvedAsset: boolean,
+): "mac" | null {
+  return resolvedAsset && platform === "mac" ? "mac" : null;
+}

--- a/apps/marketing/src/pages/download.astro
+++ b/apps/marketing/src/pages/download.astro
@@ -1,5 +1,6 @@
 ---
 import Layout from "../layouts/Layout.astro";
+import InstallPromptDialog from "../components/InstallPromptDialog.astro";
 import { RELEASES_URL } from "../lib/releases";
 ---
 
@@ -19,7 +20,7 @@ import { RELEASES_URL } from "../lib/releases";
         <h2 class="platform-name">macOS</h2>
       </div>
       <div class="download-cards">
-        <a class="download-card" data-asset="arm64.dmg" href={RELEASES_URL}>
+        <a class="download-card" data-os="mac" data-asset="arm64.dmg" href={RELEASES_URL}>
           <span class="card-arch">Apple Silicon (arm64)</span>
           <span class="card-format">.dmg</span>
         </a>
@@ -33,7 +34,7 @@ import { RELEASES_URL } from "../lib/releases";
         <h2 class="platform-name">Windows</h2>
       </div>
       <div class="download-cards">
-        <a class="download-card" data-asset="x64.exe" href={RELEASES_URL}>
+        <a class="download-card" data-os="win" data-asset="x64.exe" href={RELEASES_URL}>
           <span class="card-arch">Windows 10, 11</span>
           <span class="card-format">.exe</span>
         </a>
@@ -47,7 +48,7 @@ import { RELEASES_URL } from "../lib/releases";
         <h2 class="platform-name">Linux</h2>
       </div>
       <div class="download-cards">
-        <a class="download-card" data-asset="x64.AppImage" href={RELEASES_URL}>
+        <a class="download-card" data-os="linux" data-asset="x64.AppImage" href={RELEASES_URL}>
           <span class="card-arch">x86_64</span>
           <span class="card-format">AppImage</span>
         </a>
@@ -63,9 +64,11 @@ import { RELEASES_URL } from "../lib/releases";
     </a>
   </p>
   </div>
+  <InstallPromptDialog />
 </Layout>
 
 <script>
+  import { installPromptPlatformForDownload } from "../lib/downloadInstallPrompt";
   import {
     fetchLatestRelease,
     requiresUnsignedInstall,
@@ -84,6 +87,8 @@ import { RELEASES_URL } from "../lib/releases";
       const suffix = card.dataset.asset;
       if (!suffix) return;
       const asset = await resolveAssetDownload(card, suffix, releasePromise);
+      const promptPlatform = installPromptPlatformForDownload(card.dataset.os, asset !== null);
+      if (promptPlatform) card.dataset.installPrompt = promptPlatform;
       card.dataset.unsigned = asset && requiresUnsignedInstall(suffix) ? "true" : "";
     });
 

--- a/apps/marketing/src/pages/index.astro
+++ b/apps/marketing/src/pages/index.astro
@@ -1,5 +1,6 @@
 ---
 import Layout from "../layouts/Layout.astro";
+import InstallPromptDialog from "../components/InstallPromptDialog.astro";
 import { docsUrl } from "../lib/site";
 import { RELEASES_URL } from "../lib/releases";
 
@@ -97,9 +98,6 @@ const DOWNLOAD_GLYPH = `<path d="M7 11.5L12 17.5L17 11.5H14L14 3H10L10 11.5H7Z" 
           <span>Read the docs</span>
         </a>
       </div>
-      <aside id="install-notice" class="install-notice" hidden>
-        <button id="copy-install-prompt" type="button">Copy verified install prompt</button>
-      </aside>
     </div>
     <div class="hero-shot">
       <img
@@ -165,7 +163,7 @@ const DOWNLOAD_GLYPH = `<path d="M7 11.5L12 17.5L17 11.5H14L14 3H10L10 11.5H7Z" 
       <div class="platform-cards">
         {
           platforms.map((platform) => (
-            <a class="platform-card" data-asset={platform.asset} href={RELEASES_URL}>
+            <a class="platform-card" data-os={platform.os} data-asset={platform.asset} href={RELEASES_URL}>
               <span class="platform-card-top">
                 <svg width="24" height="24" viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg" aria-hidden="true" set:html={platform.mark} />
                 <svg class="platform-card-glyph" width="18" height="18" viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg" aria-hidden="true" set:html={DOWNLOAD_GLYPH} />
@@ -183,11 +181,12 @@ const DOWNLOAD_GLYPH = `<path d="M7 11.5L12 17.5L17 11.5H14L14 3H10L10 11.5H7Z" 
       </a>
     </div>
   </section>
+  <InstallPromptDialog />
 </Layout>
 
 <script>
   import { pickMostVisibleDemo } from "../lib/demoPlayback";
-  import { installPromptForPlatform } from "../lib/installPrompt";
+  import { installPromptPlatformForDownload } from "../lib/downloadInstallPrompt";
   import {
     detectDownloadTarget,
     fetchLatestRelease,
@@ -203,8 +202,6 @@ const DOWNLOAD_GLYPH = `<path d="M7 11.5L12 17.5L17 11.5H14L14 3H10L10 11.5H7Z" 
     const button = document.getElementById("download-btn") as HTMLAnchorElement | null;
     const label = document.getElementById("download-label");
     const cards = document.querySelectorAll<HTMLAnchorElement>("a[data-asset]");
-    const installNotice = document.getElementById("install-notice");
-    const copyPrompt = document.getElementById("copy-install-prompt") as HTMLButtonElement | null;
 
     // Macs always get the arm64 build. Browsers cannot reliably tell Apple Silicon
     // from Intel (the UA lies, GPU strings lie), and the release workflow ships no
@@ -216,13 +213,6 @@ const DOWNLOAD_GLYPH = `<path d="M7 11.5L12 17.5L17 11.5H14L14 3H10L10 11.5H7Z" 
         button.dataset.os = platform.os;
         button.dataset.asset = platform.assetSuffix;
       }
-      const prompt = installPromptForPlatform(platform.os);
-      installNotice?.toggleAttribute("hidden", !prompt);
-      copyPrompt?.addEventListener("click", async () => {
-        if (!prompt) return;
-        await navigator.clipboard.writeText(prompt);
-        copyPrompt.textContent = "Copied";
-      });
     } else if (button && label) {
       label.textContent = "All downloads";
       button.href = RELEASES_URL;
@@ -234,14 +224,17 @@ const DOWNLOAD_GLYPH = `<path d="M7 11.5L12 17.5L17 11.5H14L14 3H10L10 11.5H7Z" 
       const suffix = card.dataset.asset;
       if (!suffix || card === button) return;
       const asset = await resolveAssetDownload(card, suffix, release);
+      const promptPlatform = installPromptPlatformForDownload(card.dataset.os, asset !== null);
+      if (promptPlatform) card.dataset.installPrompt = promptPlatform;
       card.dataset.unsigned = asset && requiresUnsignedInstall(suffix) ? "true" : "";
     });
 
     if (button && platform) {
       const asset = await resolveAssetDownload(button, platform.assetSuffix, release);
+      const promptPlatform = installPromptPlatformForDownload(platform.os, asset !== null);
+      if (promptPlatform) button.dataset.installPrompt = promptPlatform;
       button.dataset.unsigned = asset && platform.unsigned ? "true" : "";
       if (!asset && label) label.textContent = "All downloads";
-      if (!asset) installNotice?.setAttribute("hidden", "");
     }
     await Promise.all(cardDownloads);
 


### PR DESCRIPTION
macOS users could start a download without seeing the verified recovery path for an unsigned app. The existing prompt lived separately from the download action and did not explain why Gatekeeper might block Akeru Bot.

This adds a post-download dialog for resolved macOS assets. It explains that Akeru has not joined Apple's paid Developer Program yet and copies the existing verified install prompt. Windows, Linux, and fallback GitHub Releases links keep their current behavior.

## Before

![Before](https://github.com/user-attachments/assets/0a41f151-653b-4d91-a640-7c4d06bab07d)

## After

![After](https://github.com/user-attachments/assets/277598f5-f626-4e6f-8d48-b050f5ef6896)

## Verification

- `vp test run apps/marketing/src/lib/downloadInstallPrompt.test.ts apps/marketing/src/lib/installPrompt.test.ts apps/marketing/src/lib/releases.test.ts`
- `vp run --filter @t3tools/marketing typecheck`
- `vp run --filter @t3tools/marketing build`
- Browser check for copy, close, Escape, backdrop dismissal, focus return, and label reset

Model: gpt-5.6-sol
Harness: Codex through T3 Code
