### PR TITLE
fix(release): restore native publishing runners

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,6 +1,6 @@
-# Depot builds every stable asset before the final job creates the tag and release.
+# Native GitHub runners build every stable asset before the final job creates the tag and release.
 
-name: Stable release
+name: Stable release native
 
 on:
   workflow_dispatch:
@@ -22,7 +22,7 @@ concurrency:
 jobs:
   preflight:
     name: Release preflight
-    runs-on: depot-ubuntu-24.04-8
+    runs-on: ubuntu-24.04
     timeout-minutes: 15
     outputs:
       version: ${{ steps.version.outputs.version }}
@@ -81,19 +81,19 @@ jobs:
       matrix:
         include:
           - label: macOS arm64 DMG
-            runner: depot-macos-15
+            runner: macos-15
             platform: mac
             target: dmg
             arch: arm64
             rust_target: aarch64-apple-darwin
           - label: Windows x64 NSIS
-            runner: depot-windows-2025-8
+            runner: windows-2025
             platform: win
             target: nsis
             arch: x64
             rust_target: x86_64-pc-windows-msvc
           - label: Linux x64 AppImage
-            runner: depot-ubuntu-24.04-8
+            runner: ubuntu-24.04
             platform: linux
             target: AppImage
             arch: x64
@@ -235,7 +235,7 @@ jobs:
   release:
     name: Publish stable release
     needs: [preflight, desktop]
-    runs-on: depot-ubuntu-24.04-8
+    runs-on: ubuntu-24.04
     timeout-minutes: 15
     env:
       GH_TOKEN: ${{ github.token }}

--- a/docs/internals/ci.md
+++ b/docs/internals/ci.md
@@ -27,10 +27,10 @@ The workflow also builds and dry-runs the CLI package and checks the marketing s
 desktop artifacts for seven days. It does not create a GitHub release, publish a package, or deploy
 a site.
 
-Merging a stable version change to `main` starts [the stable Depot workflow](../../.depot/workflows/release.yml).
-Depot builds the advertised desktop targets and CLI package before it creates the `vX.Y.Z` tag and
-GitHub Release. The final job verifies the exact asset names and `SHA256SUMS`. Missing signing
-credentials produce unsigned macOS and Windows artifacts. Complete credentials use the existing
-Developer ID, notarization, and Azure Trusted Signing paths.
+Merging a stable version change to `main` starts [the native stable workflow](../../.github/workflows/release.yml).
+GitHub-hosted macOS, Windows, and Linux runners build the advertised desktop targets before the
+workflow creates the `vX.Y.Z` tag and GitHub Release. The final job verifies the exact asset names
+and `SHA256SUMS`. Missing signing credentials produce unsigned macOS and Windows artifacts.
+Complete credentials use the existing Developer ID, notarization, and Azure Trusted Signing paths.
 
 See the [release smoke runbook](../operations/release.md) for the exact validation path.

--- a/docs/operations/release.md
+++ b/docs/operations/release.md
@@ -30,7 +30,9 @@ release announcements.
 ## Depot setup
 
 CI and release smoke run on Depot CI. Code Access is already installed for `opencoredev/akeru-bot`.
-GitHub Actions no longer owns those jobs. All Depot jobs use a Depot runner label:
+GitHub Actions owns the publishing workflow because Depot does not provide the macOS runner and
+rejects the Windows runner needed for stable desktop artifacts. All Depot smoke jobs use a Depot
+runner label:
 
 - Linux uses the 8-vCPU `depot-ubuntu-24.04-8` runner.
 - Windows uses the 8-vCPU `depot-windows-2025-8` runner.

--- a/scripts/release-smoke.ts
+++ b/scripts/release-smoke.ts
@@ -24,7 +24,7 @@ function assertOmits(haystack: string, needle: string, message: string): void {
   if (haystack.toLowerCase().includes(needle.toLowerCase())) throw new Error(message);
 }
 
-const releaseWorkflow = read(".depot/workflows/release.yml");
+const releaseWorkflow = read(".github/workflows/release.yml");
 const versionPackagesWorkflow = read(".depot/workflows/version-packages.yml");
 const releaseSmokeWorkflow = read(".depot/workflows/release-smoke.yml");
 const ciWorkflow = read(".depot/workflows/ci.yml");
@@ -40,7 +40,7 @@ for (const workflowFile of NodeFS.readdirSync(depotWorkflowDirectory)) {
   }
 }
 
-for (const relativePath of [".github/workflows/ci.yml", ".github/workflows/release.yml"] as const) {
+for (const relativePath of [".github/workflows/ci.yml"] as const) {
   if (NodeFS.existsSync(NodePath.join(repoRoot, relativePath))) {
     throw new Error(`GitHub Actions still owns ${relativePath}; move it to .depot/workflows.`);
   }
@@ -109,9 +109,9 @@ for (const [needle, label] of [
   ["label: macOS arm64 DMG", "macOS arm64 DMG"],
   ["label: Windows x64 NSIS", "Windows x64 NSIS"],
   ["label: Linux x64 AppImage", "Linux x64 AppImage"],
-  ["runner: depot-macos-15", "Depot macOS runner"],
-  ["runner: depot-windows-2025-8", "Depot Windows runner"],
-  ["runner: depot-ubuntu-24.04-8", "Depot Linux runner"],
+  ["runner: macos-15", "GitHub-hosted macOS runner"],
+  ["runner: windows-2025", "GitHub-hosted Windows runner"],
+  ["runner: ubuntu-24.04", "GitHub-hosted Linux runner"],
   ["Signing credentials must be either complete or absent.", "unsigned signing fallback"],
   ["--signed", "existing signed build path"],
   ["xcrun notarytool submit", "macOS notarization"],
@@ -156,9 +156,9 @@ for (const [needle, label] of [
 
 assertContains(ciWorkflow, "runs-on: depot-ubuntu-24.04-8", "CI does not use Depot runners.");
 assertOmits(ciWorkflow, "runs-on: ubuntu-24.04", "GitHub-hosted Linux runners");
-assertOmits(releaseWorkflow, "runner: macos-15", "GitHub-hosted macOS runner");
-assertOmits(releaseWorkflow, "runner: windows-2025", "GitHub-hosted Windows runner");
-assertOmits(releaseWorkflow, "runner: ubuntu-24.04", "GitHub-hosted Linux runner");
+assertOmits(releaseWorkflow, "runner: depot-macos-15", "unavailable Depot macOS runner");
+assertOmits(releaseWorkflow, "runner: depot-windows-2025-8", "unsupported Depot Windows runner");
+assertOmits(releaseWorkflow, "runner: depot-ubuntu-24.04-8", "Depot Linux runner");
 assertOmits(
   desktopArtifactBuilder,
   'const DESKTOP_APP_ID = "com.t3tools.t3code"',
@@ -171,6 +171,7 @@ assertContains(
 );
 
 for (const relativePath of [
+  ".depot/workflows/release.yml",
   ".github/workflows/deploy-relay.yml",
   ".github/workflows/desktop-macos-preview.yml",
   ".github/workflows/mobile-eas-preview.yml",


### PR DESCRIPTION
The stable release stopped before building macOS or Windows. Depot does not provide the configured macOS runner and rejects the configured Windows runner label.

This moves only the publishing workflow back to GitHub-hosted macOS, Windows, and Linux runners. Depot still owns normal CI and the non-publishing release smoke workflow. The mounted-DMG launch gate remains in the macOS release job.

Verification:

- `vp run release:smoke`
- `vp test run scripts/verify-release-assets.test.ts`
- `vp fmt --check .github/workflows/release.yml scripts/release-smoke.ts docs/internals/ci.md docs/operations/release.md`
- `git diff --check`

Model: gpt-5.6-sol
Harness: Codex in T3 Code