### PR TITLE
fix(release): exclude plugins from Windows file budget

### DIFF
--- a/scripts/build-desktop-artifact.test.ts
+++ b/scripts/build-desktop-artifact.test.ts
@@ -694,6 +694,37 @@ it.layer(NodeServices.layer)("build-desktop-artifact", (it) => {
     ),
   );
 
+  it.effect("excludes the plugin catalog from the Windows loose-file budget", () =>
+    Effect.scoped(
+      Effect.gen(function* () {
+        const fs = yield* FileSystem.FileSystem;
+        const path = yield* Path.Path;
+        const fixture = yield* makeWindowsPayloadFixture({ copyUnpackedNatives: true });
+        const baseline = yield* validateWindowsPackagedPayload({
+          stageDistDir: fixture.stageDistDir,
+          appExecutableName: fixture.appExecutableName,
+          targetArch: "x64",
+        });
+        const pluginDir = path.join(fixture.packagedAppDir, "resources/plugins/entries/example");
+        yield* fs.makeDirectory(pluginDir, { recursive: true });
+        yield* Effect.forEach(
+          Array.from({ length: 100 }, (_, index) => index),
+          (index) => fs.writeFileString(path.join(pluginDir, `${String(index)}.json`), "{}"),
+          { concurrency: "unbounded" },
+        );
+
+        const withCatalog = yield* validateWindowsPackagedPayload({
+          stageDistDir: fixture.stageDistDir,
+          appExecutableName: fixture.appExecutableName,
+          targetArch: "x64",
+          fileLimit: baseline.fileCount,
+        });
+
+        assert.equal(withCatalog.fileCount, baseline.fileCount);
+      }),
+    ),
+  );
+
   it.effect("probes fff through the packaged Windows primary instead of helper executables", () => {
     const commands: Array<{
       readonly command: string;

--- a/scripts/build-desktop-artifact.ts
+++ b/scripts/build-desktop-artifact.ts
@@ -2146,10 +2146,14 @@ function collectUnpackedAsarFiles(
   return output;
 }
 
-const countPayloadFiles = Effect.fn("desktopArtifact.countPayloadFiles")(function* (root: string) {
+const countPayloadFiles = Effect.fn("desktopArtifact.countPayloadFiles")(function* (input: {
+  readonly root: string;
+  readonly excludedDirectories?: ReadonlyArray<string>;
+}) {
   const fs = yield* FileSystem.FileSystem;
   const path = yield* Path.Path;
-  const pendingDirectories = [root];
+  const excludedDirectories = new Set(input.excludedDirectories ?? []);
+  const pendingDirectories = [input.root];
   let count = 0;
 
   while (pendingDirectories.length > 0) {
@@ -2160,7 +2164,7 @@ const countPayloadFiles = Effect.fn("desktopArtifact.countPayloadFiles")(functio
       const entryPath = path.join(directory, entry);
       const stat = yield* fs.stat(entryPath);
       if (stat.type === "Directory") {
-        pendingDirectories.push(entryPath);
+        if (!excludedDirectories.has(entryPath)) pendingDirectories.push(entryPath);
       } else if (stat.type === "File") {
         count += 1;
       }
@@ -2359,7 +2363,10 @@ export const validateWindowsPackagedPayload = Effect.fn(
     });
   }
 
-  const fileCount = yield* countPayloadFiles(packagedAppDir);
+  const fileCount = yield* countPayloadFiles({
+    root: packagedAppDir,
+    excludedDirectories: [path.join(resourcesDir, "plugins")],
+  });
   if (fileCount > fileLimit) {
     return yield* new WindowsPackagedPayloadValidationError({
       reason: "file-limit-exceeded",


### PR DESCRIPTION
The Windows installer built successfully, then the loose-file regression guard rejected the payload because the packaged plugin catalog adds 156 intentional files. The guard still used its pre-catalog limit of 80 files.

This excludes only `resources/plugins` from that budget. Server files, ASAR-unpacked native files, and every other packaged file still count toward the limit. A focused test adds 100 catalog files and proves the measured payload count does not change.

Verification:

- `vp test run scripts/build-desktop-artifact.test.ts` passed, 47 tests.
- Targeted formatting and lint passed. Lint reported two existing warnings in `scripts/build-desktop-artifact.ts`.
- `git diff --check` passed.

Model: gpt-5.6-sol
Harness: Codex in T3 Code