### PR TITLE
fix(release): publish native desktop artifacts

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -228,7 +228,9 @@ jobs:
         uses: actions/upload-artifact@v7
         with:
           name: stable-${{ matrix.platform }}-${{ matrix.arch }}
-          path: release/*
+          path: |
+            release/*
+            !release/builder-debug.yml
           if-no-files-found: error
           retention-days: 7
 

--- a/scripts/build-desktop-artifact.test.ts
+++ b/scripts/build-desktop-artifact.test.ts
@@ -462,6 +462,7 @@ it.layer(NodeServices.layer)("build-desktop-artifact", (it) => {
       assert.notProperty(mac, "asarUnpack");
       assert.notProperty(linux, "asarUnpack");
       assert.notProperty(win, "asarUnpack");
+      assert.equal(linux.artifactName, "Akeru-Bot-${version}-x64.${ext}");
       assert.deepStrictEqual(win.extraResources, [
         {
           from: "apps/desktop/prod-resources/resource-monitor",

--- a/scripts/build-desktop-artifact.ts
+++ b/scripts/build-desktop-artifact.ts
@@ -1795,7 +1795,10 @@ export const createBuildConfig = Effect.fn("createBuildConfig")(function* (
   const buildConfig: Record<string, unknown> = {
     appId: DESKTOP_APP_ID,
     productName: resolveDesktopProductName(version),
-    artifactName: "Akeru-Bot-${version}-${arch}.${ext}",
+    artifactName:
+      platform === "linux"
+        ? "Akeru-Bot-${version}-x64.${ext}"
+        : "Akeru-Bot-${version}-${arch}.${ext}",
     electronLanguages: [...DESKTOP_ELECTRON_LANGUAGES],
     files: [...DESKTOP_FILE_EXCLUSIONS, ...(platform === "mac" ? MAC_FILE_EXCLUSIONS : [])],
     directories: {

--- a/scripts/release-smoke.ts
+++ b/scripts/release-smoke.ts
@@ -48,8 +48,13 @@ for (const relativePath of [".github/workflows/ci.yml"] as const) {
 
 assertContains(
   desktopArtifactBuilder,
-  'artifactName: "Akeru-Bot-${version}-${arch}.${ext}"',
+  '"Akeru-Bot-${version}-${arch}.${ext}"',
   "Desktop artifacts do not use the Akeru Bot release name.",
+);
+assertContains(
+  desktopArtifactBuilder,
+  '"Akeru-Bot-${version}-x64.${ext}"',
+  "Linux desktop artifacts do not use the advertised x64 release name.",
 );
 assertContains(serverCli, '"akeru-bot",', "CLI publishing does not select the Akeru package.");
 assertContains(
@@ -140,6 +145,11 @@ assertContains(
   releaseWorkflow,
   "APPLE_API_KEY: ${{ runner.temp }}/notarytool-api-key.p8",
   "Signed macOS verification cannot access the App Store Connect key.",
+);
+assertContains(
+  releaseWorkflow,
+  "!release/builder-debug.yml",
+  "Stable release uploads electron-builder debug metadata.",
 );
 const desktopJobHeader = /\n  desktop:\n([\s\S]*?)\n    strategy:/u.exec(releaseWorkflow)?.[1];
 if (!desktopJobHeader) throw new Error("Stable release workflow is missing the desktop job.");

--- a/scripts/verify-release-assets.test.ts
+++ b/scripts/verify-release-assets.test.ts
@@ -9,6 +9,21 @@ import { expectedReleaseAssetNames, verifyReleaseAssets } from "./verify-release
 import { verifyReleaseCandidate } from "./verify-release-candidate.ts";
 
 describe("verify-release-assets", () => {
+  it("matches the native desktop artifact names", () => {
+    NodeAssert.deepEqual(expectedReleaseAssetNames("1.2.3"), [
+      "Akeru-Bot-1.2.3-arm64.dmg",
+      "Akeru-Bot-1.2.3-arm64.dmg.blockmap",
+      "Akeru-Bot-1.2.3-arm64.zip",
+      "Akeru-Bot-1.2.3-arm64.zip.blockmap",
+      "Akeru-Bot-1.2.3-x64.exe",
+      "Akeru-Bot-1.2.3-x64.exe.blockmap",
+      "Akeru-Bot-1.2.3-x64.AppImage",
+      "latest-mac.yml",
+      "latest.yml",
+      "latest-linux.yml",
+    ]);
+  });
+
   it("rejects missing assets and writes verified SHA256SUMS for the exact release set", async () => {
     const directory = await NodeFSP.mkdtemp(
       NodePath.join(NodeOS.tmpdir(), "akeru-release-assets-"),

--- a/scripts/verify-release-assets.ts
+++ b/scripts/verify-release-assets.ts
@@ -8,7 +8,9 @@ import * as NodePath from "node:path";
 export function expectedReleaseAssetNames(version: string): readonly string[] {
   return [
     `Akeru-Bot-${version}-arm64.dmg`,
+    `Akeru-Bot-${version}-arm64.dmg.blockmap`,
     `Akeru-Bot-${version}-arm64.zip`,
+    `Akeru-Bot-${version}-arm64.zip.blockmap`,
     `Akeru-Bot-${version}-x64.exe`,
     `Akeru-Bot-${version}-x64.exe.blockmap`,
     `Akeru-Bot-${version}-x64.AppImage`,


### PR DESCRIPTION
The stable release built all three native installers, but its final asset check expected stale Electron Builder output names. The publish job rejected the generated macOS blockmaps, Linux AppImage name, and debug metadata.

Use the advertised `x64` Linux filename, include the macOS update blockmaps in the verified checksum set, and exclude Electron Builder debug metadata from uploaded release assets. Focused packaging tests and the release smoke check now cover the exact contract.

Model: gpt-5.6-sol
Harness: Codex harness in T3 Code