### PR TITLE
fix(web): prevent duplicate bot panes

### DIFF
--- a/apps/web/src/routes/_chat.bots.$botId.tsx
+++ b/apps/web/src/routes/_chat.bots.$botId.tsx
@@ -20,6 +20,7 @@ import { toRoutinePanelItem, toRoutineSchedule } from "../components/roster/rout
 import { useRosterStore } from "../components/roster/rosterStore";
 import { toastManager } from "../components/ui/toast";
 import { randomUUID } from "../lib/utils";
+import { botRoutePanelKeys } from "./botRoutePanelKeys";
 import { botEnvironment } from "../state/bots";
 import { usePrimaryEnvironmentId } from "../state/environments";
 import { routineEnvironment } from "../state/routines";
@@ -31,6 +32,7 @@ const NO_ENVIRONMENT = "" as EnvironmentId;
 
 function BotThreadRouteView() {
   const { botId } = Route.useParams();
+  const panelKeys = botRoutePanelKeys(botId);
   const environmentId = usePrimaryEnvironmentId();
   const updateBot = useAtomCommand(botEnvironment.update, { reportFailure: false });
   const draftRoutine = useAtomCommand(routineEnvironment.draft, { reportFailure: false });
@@ -148,10 +150,10 @@ function BotThreadRouteView() {
 
   return (
     <>
-      <BotThreadLanding key={botId} botId={botId} />
+      <BotThreadLanding key={panelKeys.thread} botId={botId} />
       {bot ? (
         <BotDetailsPanel
-          key={bot.id}
+          key={panelKeys.details}
           bot={bot}
           threadRef={threadRef}
           routinePanel={{

--- a/apps/web/src/routes/botRoutePanelKeys.test.ts
+++ b/apps/web/src/routes/botRoutePanelKeys.test.ts
@@ -1,0 +1,21 @@
+// @effect-diagnostics nodeBuiltinImport:off - The route contract reads its source.
+import * as NodeFS from "node:fs";
+
+import { describe, expect, it } from "vite-plus/test";
+
+import { botRoutePanelKeys } from "./botRoutePanelKeys";
+
+describe("bot route panel keys", () => {
+  it("gives sibling panels separate identities for the same bot", () => {
+    const keys = botRoutePanelKeys("bot-1");
+
+    expect(keys.thread).not.toBe(keys.details);
+  });
+
+  it("uses the separate identities for both route siblings", () => {
+    const source = NodeFS.readFileSync(new URL("./_chat.bots.$botId.tsx", import.meta.url), "utf8");
+
+    expect(source).toContain("key={panelKeys.thread}");
+    expect(source).toContain("key={panelKeys.details}");
+  });
+});

--- a/apps/web/src/routes/botRoutePanelKeys.ts
+++ b/apps/web/src/routes/botRoutePanelKeys.ts
@@ -1,0 +1,6 @@
+export function botRoutePanelKeys(botId: string) {
+  return {
+    thread: `thread:${botId}`,
+    details: `details:${botId}`,
+  } as const;
+}


### PR DESCRIPTION
Switching between bots could leave stale bot panes mounted side by side. The route gave the thread pane and details pane the same React key, which made sibling reconciliation unsupported.

Namespace the two panel keys while preserving the intended per-bot remount. Add a focused regression test for distinct sibling identities and their route wiring.

Verified with 24 focused tests, web type checking, targeted lint and formatting, 12 paced bot switches, and 30 rapid bot switches against an isolated snapshot of real Akeru data. Every switch retained one bot landing and one main pane, with no new duplicate-key errors.

Model: gpt-5.6-sol
Harness: Codex harness in T3 Code