### PR TITLE
chore(release): version packages for v0.0.37

### DIFF
--- a/.tegami/publish-lock.yaml
+++ b/.tegami/publish-lock.yaml
@@ -1,5 +1,5 @@
 core:changelogs:
-  - content: "---\npackages:\n  group:akeru:\n    type: patch\n---\n\n### Changes\n\n- [#114](https://github.com/opencoredev/akeru-bot/pull/114) fix(release): ship desktop apps without CLI\n- [#115](https://github.com/opencoredev/akeru-bot/pull/115) fix(legal): preserve licenses and correct fork attribution\n- [#116](https://github.com/opencoredev/akeru-bot/pull/116) feat(marketing): explain unsigned macOS downloads\n- [#117](https://github.com/opencoredev/akeru-bot/pull/117) fix(release): launch packaged desktop apps before publishing\n"
+  - content: "---\npackages:\n  group:akeru:\n    type: patch\n---\n\n### Changes\n\n- [#124](https://github.com/opencoredev/akeru-bot/pull/124) fix(web): prevent duplicate bot panes\n"
     filename: stable-release.md
     v: 0.0.0
 core:packages:
@@ -8,6 +8,8 @@ core:packages:
   - id: npm:@t3tools/oxlint-plugin-t3code
     updated: false
   - id: npm:@t3tools/scripts
+    updated: false
+  - id: npm:akeru-feedback
     updated: false
   - changelogIds:
       - stable-release.md
@@ -23,8 +25,6 @@ core:packages:
       - stable-release.md
     id: npm:@t3tools/web
     updated: true
-  - id: npm:akeru-feedback
-    updated: false
   - id: npm:@t3tools/client-runtime
     updated: false
   - changelogIds:
@@ -33,27 +33,27 @@ core:packages:
     updated: true
   - id: npm:effect-acp
     updated: false
-  - id: npm:effect-codex-app-server
-    updated: false
   - id: npm:@t3tools/shared
     updated: false
-  - id: npm:@t3tools/ssh
+  - id: npm:effect-codex-app-server
     updated: false
   - id: npm:@t3tools/tailscale
+    updated: false
+  - id: npm:@t3tools/ssh
     updated: false
 npm:packages:
   - id: npm:@t3tools/monorepo
   - id: npm:@t3tools/oxlint-plugin-t3code
   - id: npm:@t3tools/scripts
+  - id: npm:akeru-feedback
   - id: npm:@t3tools/desktop
   - id: npm:@t3tools/marketing
   - id: npm:akeru-bot
   - id: npm:@t3tools/web
-  - id: npm:akeru-feedback
   - id: npm:@t3tools/client-runtime
   - id: npm:@t3tools/contracts
   - id: npm:effect-acp
-  - id: npm:effect-codex-app-server
   - id: npm:@t3tools/shared
-  - id: npm:@t3tools/ssh
+  - id: npm:effect-codex-app-server
   - id: npm:@t3tools/tailscale
+  - id: npm:@t3tools/ssh

--- a/apps/desktop/CHANGELOG.md
+++ b/apps/desktop/CHANGELOG.md
@@ -1,3 +1,9 @@
+## @t3tools/desktop@0.0.37
+
+### Changes
+
+- [#124](https://github.com/opencoredev/akeru-bot/pull/124) fix(web): prevent duplicate bot panes
+
 ## @t3tools/desktop@0.0.36
 
 ### Changes

--- a/apps/desktop/package.json
+++ b/apps/desktop/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@t3tools/desktop",
-  "version": "0.0.36",
+  "version": "0.0.37",
   "private": true,
   "type": "module",
   "main": "dist-electron/main.cjs",

--- a/apps/server/CHANGELOG.md
+++ b/apps/server/CHANGELOG.md
@@ -1,3 +1,9 @@
+## akeru-bot@0.0.37
+
+### Changes
+
+- [#124](https://github.com/opencoredev/akeru-bot/pull/124) fix(web): prevent duplicate bot panes
+
 ## akeru-bot@0.0.36
 
 ### Changes

--- a/apps/server/package.json
+++ b/apps/server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "akeru-bot",
-  "version": "0.0.36",
+  "version": "0.0.37",
   "license": "MIT",
   "repository": {
     "type": "git",

--- a/apps/web/CHANGELOG.md
+++ b/apps/web/CHANGELOG.md
@@ -1,3 +1,9 @@
+## @t3tools/web@0.0.37
+
+### Changes
+
+- [#124](https://github.com/opencoredev/akeru-bot/pull/124) fix(web): prevent duplicate bot panes
+
 ## @t3tools/web@0.0.36
 
 ### Changes

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@t3tools/web",
-  "version": "0.0.36",
+  "version": "0.0.37",
   "private": true,
   "type": "module",
   "scripts": {

--- a/packages/contracts/CHANGELOG.md
+++ b/packages/contracts/CHANGELOG.md
@@ -1,3 +1,9 @@
+## @t3tools/contracts@0.0.37
+
+### Changes
+
+- [#124](https://github.com/opencoredev/akeru-bot/pull/124) fix(web): prevent duplicate bot panes
+
 ## @t3tools/contracts@0.0.36
 
 ### Changes

--- a/packages/contracts/package.json
+++ b/packages/contracts/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@t3tools/contracts",
-  "version": "0.0.36",
+  "version": "0.0.37",
   "private": true,
   "files": [
     "dist"


### PR DESCRIPTION
Prepare the stable `0.0.37` desktop release containing the bot-switch pane fix from #124.

Update the four synchronized release packages and generated changelogs.

Verified with the release smoke checks, release asset verification tests, targeted formatting, and `git diff --check`.

Model: gpt-5.6-sol
Harness: Codex harness in T3 Code