### PR TITLE
fix(web): replace sidebar footer labels with icons

### DIFF
--- a/apps/web/src/components/sidebar/SidebarChrome.test.ts
+++ b/apps/web/src/components/sidebar/SidebarChrome.test.ts
@@ -38,6 +38,9 @@ describe("sidebar footer", () => {
     expect(formatEnabledPluginBadge(0)).toBeNull();
     expect(formatEnabledPluginBadge(3)).toBe("3");
     expect(formatEnabledPluginBadge(100)).toBe("99+");
+
+    const source = NodeFS.readFileSync(new URL("./SidebarChrome.tsx", import.meta.url), "utf8");
+    expect(source).toContain('className="relative overflow-visible!"');
   });
 
   it("counts removed builtins and custom MCP servers without inventing catalog logos", () => {

--- a/apps/web/src/components/sidebar/SidebarChrome.test.ts
+++ b/apps/web/src/components/sidebar/SidebarChrome.test.ts
@@ -7,6 +7,7 @@ import { describe, expect, it } from "vite-plus/test";
 import { loadCatalog } from "../../../../../plugins";
 import {
   findActiveComputerUseControl,
+  formatEnabledPluginBadge,
   formatEnabledPluginStatus,
   summarizeEnabledPlugins,
 } from "./SidebarChrome";
@@ -31,6 +32,12 @@ describe("sidebar footer", () => {
     expect(formatEnabledPluginStatus(0)).toBe("No plugins enabled");
     expect(formatEnabledPluginStatus(1)).toBe("1 plugin enabled");
     expect(formatEnabledPluginStatus(3)).toBe("3 plugins enabled");
+  });
+
+  it("shows a compact plugin count without overflowing the icon", () => {
+    expect(formatEnabledPluginBadge(0)).toBeNull();
+    expect(formatEnabledPluginBadge(3)).toBe("3");
+    expect(formatEnabledPluginBadge(100)).toBe("99+");
   });
 
   it("counts removed builtins and custom MCP servers without inventing catalog logos", () => {

--- a/apps/web/src/components/sidebar/SidebarChrome.tsx
+++ b/apps/web/src/components/sidebar/SidebarChrome.tsx
@@ -228,7 +228,7 @@ function SidebarPluginButton({
           render={
             <SidebarMenuButton
               aria-label={`Plugins, ${statusLabel}`}
-              className="relative"
+              className="relative overflow-visible!"
               size="icon"
               onClick={onClick}
             >

--- a/apps/web/src/components/sidebar/SidebarChrome.tsx
+++ b/apps/web/src/components/sidebar/SidebarChrome.tsx
@@ -32,7 +32,6 @@ import { environmentSnapshotAtom } from "../../state/shell";
 import { threadEnvironment } from "../../state/threads";
 import { useAtomCommand } from "../../state/use-atom-command";
 import { AkeruMark } from "../AkeruMark";
-import { PluginLogoImage } from "../plugins/PluginsCatalog";
 import { isBuiltinMcpServer } from "../plugins/pluginRegistry";
 import { cn } from "../../lib/utils";
 import {
@@ -167,6 +166,11 @@ export function formatEnabledPluginStatus(enabledCount: number): string {
   return `${enabledCount} ${enabledCount === 1 ? "plugin" : "plugins"} enabled`;
 }
 
+export function formatEnabledPluginBadge(enabledCount: number): string | null {
+  if (enabledCount === 0) return null;
+  return enabledCount > 99 ? "99+" : String(enabledCount);
+}
+
 export function summarizeEnabledPlugins(
   servers: readonly McpServer[],
   catalog: readonly PluginDefinition[] = PLUGIN_CATALOG,
@@ -198,44 +202,49 @@ function SidebarPluginSummaryForEnvironment({
   readonly onClick: () => void;
 }) {
   const servers = useAtomValue(environmentMcpServersAtom(environmentId));
-  const { enabledCount, enabledPlugins } = summarizeEnabledPlugins(servers);
+  const { enabledCount } = summarizeEnabledPlugins(servers);
   const statusLabel = formatEnabledPluginStatus(enabledCount);
 
   return (
-    <SidebarMenuItem>
+    <SidebarPluginButton enabledCount={enabledCount} onClick={onClick} statusLabel={statusLabel} />
+  );
+}
+
+function SidebarPluginButton({
+  enabledCount,
+  onClick,
+  statusLabel,
+}: {
+  readonly enabledCount: number;
+  readonly onClick: () => void;
+  readonly statusLabel: string;
+}) {
+  const badgeLabel = formatEnabledPluginBadge(enabledCount);
+
+  return (
+    <SidebarMenuItem className="shrink-0">
       <Tooltip>
         <TooltipTrigger
           render={
             <SidebarMenuButton
               aria-label={`Plugins, ${statusLabel}`}
-              className="h-auto min-h-12 gap-2 rounded-xl px-2 py-2 group-data-[collapsible=icon]:size-8! group-data-[collapsible=icon]:min-h-8! group-data-[collapsible=icon]:justify-center group-data-[collapsible=icon]:p-0!"
+              className="relative"
+              size="icon"
               onClick={onClick}
             >
-              <AppIcon className="size-[18px] shrink-0" icon={PlugSocketIcon} />
-              <span className="flex min-w-0 flex-1 flex-col items-start group-data-[collapsible=icon]:hidden">
-                <span className="text-sm font-medium leading-5">Plugins</span>
-                <span className="truncate text-xs leading-4 text-sidebar-muted-foreground">
-                  {statusLabel}
-                </span>
-              </span>
-              {enabledPlugins.length > 0 ? (
+              <AppIcon className="size-4" icon={PlugSocketIcon} />
+              {badgeLabel ? (
                 <span
                   aria-hidden="true"
-                  className="flex shrink-0 -space-x-1.5 group-data-[collapsible=icon]:hidden"
+                  className="absolute -right-1 -top-1 flex h-4 min-w-4 items-center justify-center rounded-full bg-sidebar-primary px-1 text-[9px] font-semibold tabular-nums text-sidebar-primary-foreground"
                 >
-                  {enabledPlugins.slice(0, 3).map((plugin) => (
-                    <PluginLogoImage
-                      className="size-6 rounded-md"
-                      key={plugin.id}
-                      plugin={plugin}
-                    />
-                  ))}
+                  {badgeLabel}
                 </span>
               ) : null}
             </SidebarMenuButton>
           }
         />
-        <TooltipPopup side="right">{`Plugins · ${statusLabel}`}</TooltipPopup>
+        <TooltipPopup side="top">{`Plugins · ${statusLabel}`}</TooltipPopup>
       </Tooltip>
     </SidebarMenuItem>
   );
@@ -245,21 +254,11 @@ function SidebarPluginSummary({ onClick }: { readonly onClick: () => void }) {
   const environmentId = usePrimaryEnvironmentId();
   if (!environmentId) {
     return (
-      <SidebarMenuItem>
-        <SidebarMenuButton
-          aria-label="Plugins, connect an environment to manage plugins"
-          className="h-auto min-h-12 gap-2 rounded-xl px-2 py-2"
-          onClick={onClick}
-        >
-          <AppIcon className="size-[18px] shrink-0" icon={PlugSocketIcon} />
-          <span className="flex min-w-0 flex-1 flex-col items-start group-data-[collapsible=icon]:hidden">
-            <span className="text-sm font-medium leading-5">Plugins</span>
-            <span className="truncate text-xs leading-4 text-sidebar-muted-foreground">
-              Connect an environment
-            </span>
-          </span>
-        </SidebarMenuButton>
-      </SidebarMenuItem>
+      <SidebarPluginButton
+        enabledCount={0}
+        onClick={onClick}
+        statusLabel="Connect an environment"
+      />
     );
   }
   return <SidebarPluginSummaryForEnvironment environmentId={environmentId} onClick={onClick} />;
@@ -350,17 +349,12 @@ function SidebarUtilityItem({
   onClick: () => void;
 }) {
   return (
-    <SidebarMenuItem className="min-w-0 flex-1 group-data-[collapsible=icon]:flex-none">
+    <SidebarMenuItem className="shrink-0">
       <Tooltip>
         <TooltipTrigger
           render={
-            <SidebarMenuButton
-              aria-label={label}
-              className="w-full justify-center gap-1.5 text-xs group-data-[collapsible=icon]:size-8! group-data-[collapsible=icon]:p-0!"
-              onClick={onClick}
-            >
+            <SidebarMenuButton aria-label={label} size="icon" onClick={onClick}>
               {icon}
-              <span className="group-data-[collapsible=icon]:hidden">{label}</span>
             </SidebarMenuButton>
           }
         />
@@ -399,10 +393,8 @@ export const SidebarChromeFooter = memo(function SidebarChromeFooter() {
         <SidebarProviderUpdatePill />
         <SidebarUpdateArchitectureWarning />
       </div>
-      <SidebarMenu>
+      <SidebarMenu className="flex-row items-center justify-center gap-1 group-data-[collapsible=icon]:flex-col">
         <SidebarPluginSummary onClick={handlePluginsClick} />
-      </SidebarMenu>
-      <SidebarMenu className="flex-row items-center gap-1 group-data-[collapsible=icon]:flex-col">
         <SidebarUtilityItem
           icon={<AppIcon className="size-4" icon={Settings02Icon} />}
           label="Settings"

--- a/apps/web/src/components/sidebar/SidebarUpdatePill.tsx
+++ b/apps/web/src/components/sidebar/SidebarUpdatePill.tsx
@@ -244,7 +244,7 @@ function SidebarUpdateControl() {
   }, [prefersReducedMotion, state?.status]);
 
   return (
-    <SidebarMenuItem className="ml-auto shrink-0">
+    <SidebarMenuItem className="shrink-0">
       <Tooltip>
         <TooltipTrigger
           render={


### PR DESCRIPTION
The sidebar footer split full text labels across a narrow, resizable column. Settings, Feedback, and Usage clipped before users could read them.

This change replaces the footer labels and plugin summary with one centered icon rail. Tooltips and accessible labels preserve each action name, while a compact badge keeps the enabled plugin count visible.

## Before

![Sidebar footer before](https://github.com/user-attachments/assets/0bb99502-4852-4160-8135-19c09aca53b4)

## After

![Sidebar footer after](https://github.com/user-attachments/assets/aea81150-126e-4400-b47a-208b45e2c828)

## Verification

- `vp test run apps/web/src/components/sidebar/SidebarChrome.test.ts`
- `vp lint apps/web/src/components/sidebar/SidebarChrome.tsx apps/web/src/components/sidebar/SidebarChrome.test.ts apps/web/src/components/sidebar/SidebarUpdatePill.tsx`
- Opened Plugins, Settings, Feedback, and Usage in the isolated web app
- Confirmed the Settings hover tooltip and accessible button labels

Model: gpt-5.6-sol
Harness: Codex harness in T3 Code
