### PR TITLE
feat(web): switch bots with number shortcuts

### DIFF
--- a/apps/web/src/components/roster/BotRosterSidebar.shortcuts.test.ts
+++ b/apps/web/src/components/roster/BotRosterSidebar.shortcuts.test.ts
@@ -1,0 +1,19 @@
+// @effect-diagnostics nodeBuiltinImport:off - This integration guard reads the listener source.
+import * as NodeFS from "node:fs";
+import { describe, expect, it } from "vite-plus/test";
+
+describe("bot roster shortcuts", () => {
+  it("passes every documented live UI flag to shortcut resolution", () => {
+    const source = NodeFS.readFileSync(new URL("./BotRosterSidebar.tsx", import.meta.url), "utf8");
+    const shortcutContext = source.slice(
+      source.indexOf("const command = resolveShortcutCommand"),
+      source.indexOf("const bot = resolveRosterShortcutBot"),
+    );
+
+    expect(shortcutContext).toContain("terminalFocus: isTerminalFocused()");
+    expect(shortcutContext).toContain("terminalOpen");
+    expect(shortcutContext).toContain("previewFocus: isPreviewFocused()");
+    expect(shortcutContext).toContain("previewOpen");
+    expect(shortcutContext).toContain("modelPickerOpen: isModelPickerOpen()");
+  });
+});

--- a/apps/web/src/components/roster/BotRosterSidebar.tsx
+++ b/apps/web/src/components/roster/BotRosterSidebar.tsx
@@ -1,4 +1,5 @@
 import { DragDropContext, Draggable, Droppable, type DropResult } from "@hello-pangea/dnd";
+import { useAtomValue } from "@effect/atom-react";
 import { scopeThreadRef } from "@t3tools/client-runtime/environment";
 import { BotId, EnvironmentId, GroupId, ThreadId } from "@t3tools/contracts";
 import { Link, useLocation, useNavigate } from "@tanstack/react-router";
@@ -18,10 +19,14 @@ import { useShallow } from "zustand/react/shallow";
 
 import { isElectron } from "../../env";
 import { useClientSettings } from "../../hooks/useSettings";
+import { resolveShortcutCommand } from "../../keybindings";
+import { isTerminalFocused } from "../../lib/terminalFocus";
 import { cn, randomUUID } from "../../lib/utils";
+import { isModelPickerOpen } from "../../modelPickerVisibility";
 import { botEnvironment } from "../../state/bots";
 import { useThreadMessages, useThreadShells } from "../../state/entities";
 import { usePrimaryEnvironmentId } from "../../state/environments";
+import { primaryServerKeybindingsAtom } from "../../state/server";
 import { useAtomCommand } from "../../state/use-atom-command";
 import { SidebarChromeFooter } from "../sidebar/SidebarChrome";
 import { Button } from "../ui/button";
@@ -55,8 +60,10 @@ import {
   resolveRosterIndicator,
   parseRosterBotDragId,
   parseRosterGroupDropId,
+  orderRosterBotsForShortcuts,
   rosterBotDragId,
   rosterGroupDropId,
+  resolveRosterShortcutBot,
   type RosterLastMessage,
   type RosterPresence,
 } from "./roster.logic";
@@ -520,6 +527,7 @@ function PinnedRosterItem({
 export default function BotRosterSidebar() {
   useServerRosterSync();
   const navigate = useNavigate();
+  const keybindings = useAtomValue(primaryServerKeybindingsAtom);
   const environmentId = usePrimaryEnvironmentId();
   const createBotCommand = useAtomCommand(botEnvironment.create, {
     reportFailure: false,
@@ -658,6 +666,33 @@ export default function BotRosterSidebar() {
     useRosterStore.getState().selectBot(bot.id);
     void navigate({ to: "/bots/$botId", params: { botId: bot.id } });
   };
+
+  const shortcutBots = useMemo(
+    () => orderRosterBotsForShortcuts(bots, pinnedItems, sections),
+    [bots, pinnedItems, sections],
+  );
+  useEffect(() => {
+    const onWindowKeyDown = (event: KeyboardEvent) => {
+      if (event.defaultPrevented || event.repeat) return;
+      const command = resolveShortcutCommand(event, keybindings, {
+        context: {
+          terminalFocus: isTerminalFocused(),
+          modelPickerOpen: isModelPickerOpen(),
+        },
+      });
+      const bot = resolveRosterShortcutBot(command ?? "", shortcutBots);
+      if (!bot) return;
+
+      event.preventDefault();
+      event.stopPropagation();
+      pendingClickedBotIdRef.current = bot.id;
+      useRosterStore.getState().selectBot(bot.id);
+      void navigate({ to: "/bots/$botId", params: { botId: bot.id } });
+    };
+
+    window.addEventListener("keydown", onWindowKeyDown);
+    return () => window.removeEventListener("keydown", onWindowKeyDown);
+  }, [keybindings, navigate, shortcutBots]);
 
   const [newBotOpen, setNewBotOpen] = useState(false);
   const [newGroupOpen, setNewGroupOpen] = useState(false);

--- a/apps/web/src/components/roster/BotRosterSidebar.tsx
+++ b/apps/web/src/components/roster/BotRosterSidebar.tsx
@@ -20,14 +20,17 @@ import { useShallow } from "zustand/react/shallow";
 import { isElectron } from "../../env";
 import { useClientSettings } from "../../hooks/useSettings";
 import { resolveShortcutCommand } from "../../keybindings";
+import { isPreviewFocused } from "../../lib/previewFocus";
 import { isTerminalFocused } from "../../lib/terminalFocus";
 import { cn, randomUUID } from "../../lib/utils";
 import { isModelPickerOpen } from "../../modelPickerVisibility";
+import { selectActiveRightPanel, useRightPanelStore } from "../../rightPanelStore";
 import { botEnvironment } from "../../state/bots";
 import { useThreadMessages, useThreadShells } from "../../state/entities";
 import { usePrimaryEnvironmentId } from "../../state/environments";
 import { primaryServerKeybindingsAtom } from "../../state/server";
 import { useAtomCommand } from "../../state/use-atom-command";
+import { selectThreadTerminalUiState, useTerminalUiStateStore } from "../../terminalUiStateStore";
 import { SidebarChromeFooter } from "../sidebar/SidebarChrome";
 import { Button } from "../ui/button";
 import {
@@ -69,6 +72,7 @@ import {
 } from "./roster.logic";
 import { useRosterStore, type RosterItemRef, type RosterSection } from "./rosterStore";
 import type { Bot, BotAvatar, Group } from "./types";
+import { useBotThreadRef } from "./useBotThreadRef";
 import { useServerRosterSync } from "./useServerRoster";
 
 /** Avatar with a yellow needs-you light and a green working light. */
@@ -547,6 +551,20 @@ export default function BotRosterSidebar() {
     })),
   );
   const [query, setQuery] = useState("");
+  const activeBotThreadRef = useBotThreadRef(
+    pathname.startsWith("/bots/") ? (selectedBotId ?? "") : "",
+  );
+  const terminalOpen = useTerminalUiStateStore((state) =>
+    activeBotThreadRef
+      ? selectThreadTerminalUiState(state.terminalUiStateByThreadKey, activeBotThreadRef)
+          .terminalOpen
+      : false,
+  );
+  const previewOpen = useRightPanelStore((state) =>
+    activeBotThreadRef
+      ? selectActiveRightPanel(state.byThreadKey, activeBotThreadRef) === "preview"
+      : false,
+  );
 
   const visibleBots = useMemo(
     () => filterRosterBots(bots, query).filter((bot) => bot.archivedAt === null),
@@ -677,6 +695,9 @@ export default function BotRosterSidebar() {
       const command = resolveShortcutCommand(event, keybindings, {
         context: {
           terminalFocus: isTerminalFocused(),
+          terminalOpen,
+          previewFocus: isPreviewFocused(),
+          previewOpen,
           modelPickerOpen: isModelPickerOpen(),
         },
       });
@@ -692,7 +713,7 @@ export default function BotRosterSidebar() {
 
     window.addEventListener("keydown", onWindowKeyDown);
     return () => window.removeEventListener("keydown", onWindowKeyDown);
-  }, [keybindings, navigate, shortcutBots]);
+  }, [keybindings, navigate, previewOpen, shortcutBots, terminalOpen]);
 
   const [newBotOpen, setNewBotOpen] = useState(false);
   const [newGroupOpen, setNewGroupOpen] = useState(false);

--- a/apps/web/src/components/roster/roster.logic.test.ts
+++ b/apps/web/src/components/roster/roster.logic.test.ts
@@ -12,8 +12,8 @@ import {
   DEFAULT_BLOB_COLOR,
   DEFAULT_BLOB_SHAPE,
   formatRosterTimestamp,
-  groupContainsBot,
   isRecordableChatPath,
+  orderRosterBotsForShortcuts,
   parseChatPath,
   randomBotAvatar,
   resolveBlobRendering,
@@ -21,6 +21,7 @@ import {
   resolveLatestRosterMessage,
   resolveRosterBotId,
   resolveRosterIndicator,
+  resolveRosterShortcutBot,
   parseRosterBotDragId,
   parseRosterGroupDropId,
   rosterBotDragId,
@@ -245,6 +246,51 @@ describe("filterRosterBots", () => {
     expect(filterRosterBots(bots, "research").map((entry) => entry.id)).toEqual(["1"]);
     expect(filterRosterBots(bots, "interfaces").map((entry) => entry.id)).toEqual(["2"]);
     expect(filterRosterBots(bots, "nobody")).toEqual([]);
+  });
+});
+
+describe("roster bot shortcuts", () => {
+  it("puts pinned bots first, then follows section and unassigned order", () => {
+    const bots = [
+      bot({ id: "free-a", name: "Free A" }),
+      bot({ id: "section-b", name: "Section B" }),
+      bot({ id: "pinned-a", name: "Pinned A" }),
+      bot({ id: "section-a", name: "Section A" }),
+      bot({ id: "pinned-b", name: "Pinned B" }),
+      bot({ id: "archived", name: "Archived", archivedAt: "2026-08-20T00:00:00.000Z" }),
+      bot({ id: "free-b", name: "Free B" }),
+    ];
+
+    const ordered = orderRosterBotsForShortcuts(
+      bots,
+      [
+        { kind: "group", id: "group-a" },
+        { kind: "bot", id: "pinned-b" },
+        { kind: "bot", id: "archived" },
+        { kind: "bot", id: "pinned-a" },
+      ],
+      [{ botIds: ["section-a", "pinned-a", "section-b"] }],
+    );
+
+    expect(ordered.map((entry) => entry.id)).toEqual([
+      "pinned-b",
+      "pinned-a",
+      "section-a",
+      "section-b",
+      "free-a",
+      "free-b",
+    ]);
+  });
+
+  it("maps jump commands to the matching bot and ignores empty slots", () => {
+    const ordered = Array.from({ length: 9 }, (_, index) =>
+      bot({ id: `bot-${index + 1}`, name: `Bot ${index + 1}` }),
+    );
+
+    expect(resolveRosterShortcutBot("thread.jump.1", ordered)?.id).toBe("bot-1");
+    expect(resolveRosterShortcutBot("thread.jump.9", ordered)?.id).toBe("bot-9");
+    expect(resolveRosterShortcutBot("thread.jump.9", ordered.slice(0, 8))).toBeNull();
+    expect(resolveRosterShortcutBot("thread.next", ordered)).toBeNull();
   });
 });
 

--- a/apps/web/src/components/roster/roster.logic.ts
+++ b/apps/web/src/components/roster/roster.logic.ts
@@ -5,6 +5,7 @@ import {
   type GroupPersonMembership,
 } from "@t3tools/contracts";
 import type { TimestampFormat } from "@t3tools/contracts/settings";
+import { threadJumpIndexFromCommand } from "../../keybindings";
 import { formatShortTimestamp, parseTimestampDate } from "../../timestampFormat";
 import type { Bot, BotAvatar, BotBlobShape, Group } from "./types";
 
@@ -227,6 +228,42 @@ export function filterRosterBots(bots: readonly Bot[], query: string): Bot[] {
       (bot.label?.toLowerCase().includes(needle) ?? false) ||
       (bot.description?.toLowerCase().includes(needle) ?? false),
   );
+}
+
+type RosterShortcutItem = { kind: "bot" | "group"; id: string };
+type RosterShortcutSection = { botIds: readonly string[] };
+
+export function orderRosterBotsForShortcuts(
+  bots: readonly Bot[],
+  pinnedItems: readonly RosterShortcutItem[],
+  sections: readonly RosterShortcutSection[],
+): Bot[] {
+  const botsById = new Map(
+    bots.filter((bot) => bot.archivedAt === null).map((bot) => [bot.id, bot] as const),
+  );
+  const ordered: Bot[] = [];
+  const addedIds = new Set<string>();
+  const addBot = (botId: string) => {
+    const bot = botsById.get(botId);
+    if (!bot || addedIds.has(botId)) return;
+    addedIds.add(botId);
+    ordered.push(bot);
+  };
+
+  for (const item of pinnedItems) {
+    if (item.kind === "bot") addBot(item.id);
+  }
+  for (const section of sections) {
+    for (const botId of section.botIds) addBot(botId);
+  }
+  for (const bot of bots) addBot(bot.id);
+
+  return ordered;
+}
+
+export function resolveRosterShortcutBot(command: string, orderedBots: readonly Bot[]): Bot | null {
+  const index = threadJumpIndexFromCommand(command);
+  return index === null ? null : (orderedBots[index] ?? null);
 }
 
 export function isCurrentGroupPerson(

--- a/docs/user/keybindings.md
+++ b/docs/user/keybindings.md
@@ -55,6 +55,10 @@ so add one in **Settings** → **Keybindings** if you want to use it.
 `thread.settle` settles the active thread or restores it when it is already settled. Its default
 shortcut is `mod+shift+s`, and it does not run while the terminal has focus.
 
+`thread.jump.1` through `thread.jump.9` switch to the matching bot and default to `mod+1` through
+`mod+9`. Pinned bots come first. Other bots follow their section and roster order. Groups do not
+take a shortcut number.
+
 The command palette searches active thread titles, projects, branches, user messages, and final
 agent responses across connected environments. Message matches show one labeled excerpt while
 keeping the thread's project, branch, and machine context visible. Message search begins after two


### PR DESCRIPTION
The bot roster did not handle the existing number shortcut commands, so Mod+1 through Mod+9 could not switch between bots.

This adds roster shortcut dispatch using the existing configurable T3 Code keybindings. Pinned bots take the first slots, followed by section order and then unassigned bots. Groups and archived bots do not consume a slot. Focused tests cover ordering and command mapping, and the user keybinding guide documents the behavior.

Model: gpt-5.6-sol
Harness: Codex harness in T3 Code