### PR TITLE
fix(web): show Grok models during limited probes

### DIFF
--- a/apps/web/src/components/chat/ModelPickerContent.tsx
+++ b/apps/web/src/components/chat/ModelPickerContent.tsx
@@ -36,7 +36,7 @@ import { cn } from "~/lib/utils";
 import { getVirtualizedScrollFadeClassName } from "../ui/scroll-area";
 import { TooltipProvider } from "../ui/tooltip";
 import {
-  isProviderInstancePickerReady,
+  isProviderInstancePickerSelectable,
   isProviderInstancePickerVisible,
   type ProviderInstanceEntry,
 } from "../../providerInstances";
@@ -189,14 +189,14 @@ export const ModelPickerContent = memo(function ModelPickerContent(props: {
     [props.lockedContinuationGroupKey, props.lockedProvider],
   );
 
-  const readyInstanceSet = useMemo(() => {
-    const ready = new Set<ProviderInstanceId>();
+  const selectableInstanceSet = useMemo(() => {
+    const selectable = new Set<ProviderInstanceId>();
     for (const entry of instanceEntries) {
-      if (isProviderInstancePickerReady(entry)) {
-        ready.add(entry.instanceId);
+      if (isProviderInstancePickerSelectable(entry)) {
+        selectable.add(entry.instanceId);
       }
     }
-    return ready;
+    return selectable;
   }, [instanceEntries]);
 
   // Flatten models into a searchable array. One pass over the
@@ -212,7 +212,7 @@ export const ModelPickerContent = memo(function ModelPickerContent(props: {
         // its models — stale options shouldn't appear in the picker.
         continue;
       }
-      if (!readyInstanceSet.has(instanceId)) {
+      if (!selectableInstanceSet.has(instanceId)) {
         continue;
       }
       for (const model of models) {
@@ -233,7 +233,7 @@ export const ModelPickerContent = memo(function ModelPickerContent(props: {
       }
     }
     return out;
-  }, [modelOptionsByInstance, entryByInstanceId, readyInstanceSet]);
+  }, [modelOptionsByInstance, entryByInstanceId, selectableInstanceSet]);
 
   const isLocked = props.lockedProvider !== null;
   const isSearching = searchQuery.trim().length > 0;

--- a/apps/web/src/components/chat/ModelPickerSidebar.tsx
+++ b/apps/web/src/components/chat/ModelPickerSidebar.tsx
@@ -6,6 +6,7 @@ import { Tooltip, TooltipPopup, TooltipTrigger } from "../ui/tooltip";
 import { cn } from "~/lib/utils";
 import {
   isProviderInstancePickerReady,
+  isProviderInstancePickerSelectable,
   shouldShowInstanceBadge,
   type ProviderInstanceEntry,
 } from "../../providerInstances";
@@ -133,7 +134,8 @@ export const ModelPickerSidebar = memo(function ModelPickerSidebar(props: {
 
           {/* Instance buttons (one per configured instance — built-in + custom) */}
           {props.instanceEntries.map((entry) => {
-            const isUnavailable = !isProviderInstancePickerReady(entry);
+            const isUnavailable = !isProviderInstancePickerSelectable(entry);
+            const isNotReady = !isProviderInstancePickerReady(entry);
             const isContextDisabled = props.disabledInstanceIds?.has(entry.instanceId) ?? false;
             const isDisabled = isUnavailable || isContextDisabled;
             const isSelected = props.selectedInstanceId === entry.instanceId;
@@ -141,7 +143,7 @@ export const ModelPickerSidebar = memo(function ModelPickerSidebar(props: {
             const showNewBadge = props.newBadgeInstanceIds?.has(entry.instanceId) ?? false;
             const showInstanceBadge = shouldShowInstanceBadge(entry, props.instanceEntries);
 
-            const tooltip = isUnavailable
+            const tooltip = isNotReady
               ? describeUnavailableInstance(entry)
               : isContextDisabled
                 ? (props.getDisabledInstanceTooltip?.(entry) ?? entry.displayName)

--- a/apps/web/src/providerInstances.test.ts
+++ b/apps/web/src/providerInstances.test.ts
@@ -105,6 +105,27 @@ describe("isProviderInstancePickerSelectable", () => {
     expect(missing && isProviderInstancePickerSelectable(missing)).toBe(false);
     expect(unauthenticated && isProviderInstancePickerSelectable(unauthenticated)).toBe(false);
   });
+
+  it("rejects disabled provider snapshots with explicit or omitted availability", () => {
+    const [available, availabilityOmitted] = deriveProviderInstanceEntries([
+      provider({
+        provider: ProviderDriverKind.make("grok"),
+        instanceId: "grok_available",
+        status: "disabled",
+        availability: "available",
+      }),
+      provider({
+        provider: ProviderDriverKind.make("grok"),
+        instanceId: "grok_availability_omitted",
+        status: "disabled",
+      }),
+    ]);
+
+    expect(available && isProviderInstancePickerSelectable(available)).toBe(false);
+    expect(availabilityOmitted && isProviderInstancePickerSelectable(availabilityOmitted)).toBe(
+      false,
+    );
+  });
 });
 
 describe("isProviderInstancePickerVisible", () => {

--- a/apps/web/src/providerInstances.test.ts
+++ b/apps/web/src/providerInstances.test.ts
@@ -6,6 +6,7 @@ import {
   deriveProviderInstanceEntries,
   getDefaultProviderInstanceModel,
   isProviderInstancePickerReady,
+  isProviderInstancePickerSelectable,
   isProviderInstancePickerVisible,
   resolveDefaultProviderModelSelection,
   resolveSelectableProviderInstance,
@@ -16,7 +17,9 @@ function provider(input: {
   provider: ProviderDriverKind;
   instanceId: string;
   enabled?: boolean;
+  installed?: boolean;
   availability?: ServerProvider["availability"];
+  authStatus?: ServerProvider["auth"]["status"];
   displayName?: string;
   accentColor?: string;
   status?: ServerProvider["status"];
@@ -28,11 +31,11 @@ function provider(input: {
     ...(input.displayName ? { displayName: input.displayName } : {}),
     ...(input.accentColor ? { accentColor: input.accentColor } : {}),
     enabled: input.enabled ?? true,
-    installed: true,
+    installed: input.installed ?? true,
     version: null,
     status: input.status ?? "ready",
     ...(input.availability ? { availability: input.availability } : {}),
-    auth: { status: "authenticated" },
+    auth: { status: input.authStatus ?? "authenticated" },
     checkedAt: "2026-01-01T00:00:00.000Z",
     models: input.models ?? [],
     slashCommands: [],
@@ -68,6 +71,39 @@ describe("isProviderInstancePickerReady", () => {
     ]);
 
     expect(entry && isProviderInstancePickerReady(entry)).toBe(true);
+  });
+});
+
+describe("isProviderInstancePickerSelectable", () => {
+  it("keeps installed provider models selectable while the probe is limited", () => {
+    const [entry] = deriveProviderInstanceEntries([
+      provider({
+        provider: ProviderDriverKind.make("grok"),
+        instanceId: "grok",
+        status: "warning",
+        models: [model("grok-build")],
+      }),
+    ]);
+
+    expect(entry && isProviderInstancePickerSelectable(entry)).toBe(true);
+  });
+
+  it("rejects missing and explicitly unauthenticated providers", () => {
+    const [missing, unauthenticated] = deriveProviderInstanceEntries([
+      provider({
+        provider: ProviderDriverKind.make("grok"),
+        instanceId: "grok_missing",
+        installed: false,
+      }),
+      provider({
+        provider: ProviderDriverKind.make("grok"),
+        instanceId: "grok_signed_out",
+        authStatus: "unauthenticated",
+      }),
+    ]);
+
+    expect(missing && isProviderInstancePickerSelectable(missing)).toBe(false);
+    expect(unauthenticated && isProviderInstancePickerSelectable(unauthenticated)).toBe(false);
   });
 });
 

--- a/apps/web/src/providerInstances.ts
+++ b/apps/web/src/providerInstances.ts
@@ -75,6 +75,23 @@ export function isProviderInstancePickerReady(entry: ProviderInstanceEntry): boo
   return entry.enabled && entry.isAvailable && entry.status === "ready";
 }
 
+/**
+ * Whether an instance can expose its known models in the picker.
+ *
+ * A warning or error probe does not erase the server's model inventory. The
+ * user can still pick one of those models and retry the provider, matching the
+ * mobile client. Missing installs and explicit authentication failures remain
+ * unavailable.
+ */
+export function isProviderInstancePickerSelectable(entry: ProviderInstanceEntry): boolean {
+  return (
+    entry.enabled &&
+    entry.isAvailable &&
+    entry.installed &&
+    entry.snapshot.auth.status !== "unauthenticated"
+  );
+}
+
 /** Picker rails contain configured, enabled instances only. */
 export function isProviderInstancePickerVisible(entry: ProviderInstanceEntry): boolean {
   return entry.enabled;

--- a/apps/web/src/providerInstances.ts
+++ b/apps/web/src/providerInstances.ts
@@ -88,6 +88,7 @@ export function isProviderInstancePickerSelectable(entry: ProviderInstanceEntry)
     entry.enabled &&
     entry.isAvailable &&
     entry.installed &&
+    entry.status !== "disabled" &&
     entry.snapshot.auth.status !== "unauthenticated"
   );
 }


### PR DESCRIPTION
## What Changed

- Let installed providers expose known models while their probe is warning or failed.
- Keep missing binaries and explicitly unauthenticated providers unavailable.
- Preserve limited and error details in the provider tooltip.
- Add focused coverage for Grok fallback models and unavailable providers.

## Why

Grok provider snapshots retain the `grok-build` fallback model when ACP probing is not ready. The web picker required `status === "ready"`, so it discarded that inventory even when Settings reported Grok as detected. This matches the mobile client eligibility rule while keeping automatic provider selection strict.

## UI Changes

No screenshots. The request excluded screenshot and browser verification.

## Testing

- `vp test run apps/web/src/providerInstances.test.ts apps/web/src/components/chat/ChatComposer.modelPickerDialog.test.tsx`
- `vp lint apps/web/src/providerInstances.ts apps/web/src/providerInstances.test.ts apps/web/src/components/chat/ModelPickerContent.tsx apps/web/src/components/chat/ModelPickerSidebar.tsx`
- `vp run --filter @t3tools/web typecheck`
- `git diff --check`

## Checklist

- [x] This PR is small and focused
- [x] I explained what changed and why
- [x] This PR does not add a plugin or provider
- [ ] I included before/after screenshots for UI changes
- [x] This PR does not add animation or interaction changes

Model: gpt-5.6-sol
Harness: Codex harness in T3 Code