### PR TITLE
fix(mobile): keep the app icon light in dark mode

### DIFF
--- a/apps/mobile/app.config.ts
+++ b/apps/mobile/app.config.ts
@@ -58,7 +58,10 @@ const DEVELOPMENT_ASSETS = {
 
 const RELEASE_ASSETS = {
   appIcon: fromRepoRoot(BRAND_ASSET_PATHS.productionIosIconPng),
-  iosIcon: fromRepoRoot(BRAND_ASSET_PATHS.productionIosIconPng),
+  iosIcon: {
+    light: fromRepoRoot(BRAND_ASSET_PATHS.productionIosIconPng),
+    dark: fromRepoRoot(BRAND_ASSET_PATHS.productionIosIconPng),
+  },
   splashIcon: fromRepoRoot(BRAND_ASSET_PATHS.productionIosIconPng),
   androidAdaptiveForeground: fromRepoRoot(BRAND_ASSET_PATHS.productionIosIconPng),
   androidAdaptiveBackgroundColor: "#F4F1EA",

--- a/apps/mobile/src/appConfigIdentity.test.ts
+++ b/apps/mobile/src/appConfigIdentity.test.ts
@@ -18,4 +18,14 @@ describe("mobile release ownership", () => {
     expect(config).not.toContain("d763fcb8-d37c-41ea-a773-b54a0ab4a454");
     expect(config).not.toContain('owner: "pingdotgg"');
   });
+
+  it("keeps the release icon unchanged in dark appearance", () => {
+    const config = NodeFS.readFileSync(
+      NodePath.resolve(import.meta.dirname, "../app.config.ts"),
+      "utf8",
+    );
+
+    expect(config).toContain("light: fromRepoRoot(BRAND_ASSET_PATHS.productionIosIconPng)");
+    expect(config).toContain("dark: fromRepoRoot(BRAND_ASSET_PATHS.productionIosIconPng)");
+  });
 });


### PR DESCRIPTION
The installed iOS app lets the system generate a dark icon because the release config supplies only one icon appearance. This makes the home-screen icon differ from the favicon artwork.

Use the production favicon artwork for both light and dark iOS icon appearances. Add a focused regression test for the release config.

Tests:
- vp test run apps/mobile/src/appConfigIdentity.test.ts
- vp lint apps/mobile/app.config.ts apps/mobile/src/appConfigIdentity.test.ts
- Expo config assertion for matching light and dark icon paths

Model: gpt-5.6-sol
Harness: Codex harness in T3 Code