### PR TITLE
fix(feedback): use production endpoint by default

### DIFF
--- a/packages/contracts/src/settings.test.ts
+++ b/packages/contracts/src/settings.test.ts
@@ -48,7 +48,7 @@ describe("ServerSettings product feedback", () => {
   it("defaults to the Akeru endpoint and remains server patchable", () => {
     expect(decodeServerSettings({})).toMatchObject({
       productFeedbackEnabled: true,
-      productFeedbackEndpoint: "https://feedback.akeru.bot/v1/feedback",
+      productFeedbackEndpoint: "https://feedback.akeru-bot.com/v1/feedback",
     });
     expect(
       decodeServerSettingsPatch({

--- a/packages/contracts/src/settings.ts
+++ b/packages/contracts/src/settings.ts
@@ -153,7 +153,7 @@ export const DEFAULT_ENVIRONMENT_IDENTIFICATION_MODE: EnvironmentIdentificationM
 export const FontFamilyPreference = Schema.String.check(Schema.isMaxLength(200));
 export type FontFamilyPreference = typeof FontFamilyPreference.Type;
 
-export const DEFAULT_PRODUCT_FEEDBACK_ENDPOINT = "https://feedback.akeru.bot/v1/feedback";
+export const DEFAULT_PRODUCT_FEEDBACK_ENDPOINT = "https://feedback.akeru-bot.com/v1/feedback";
 export const AKERU_MARKETING_SITE_URL = "https://akeru.bot";
 export const AKERU_PRIVACY_POLICY_VERSION = "2026-08-31";
 export const AKERU_TERMS_VERSION = "2026-08-31";


### PR DESCRIPTION
New installs still default to the retired `feedback.akeru.bot` endpoint.

Use the live `https://feedback.akeru-bot.com/v1/feedback` endpoint and update the settings contract assertion.

Test: `vp test run packages/contracts/src/settings.test.ts` (69 passed)

Model: gpt-5.6-sol
Harness: Codex in T3 Code