### PR TITLE
fix(channels): restore settings and delivery

### DIFF
--- a/apps/server/src/orchestration/runtimeLayer.test.ts
+++ b/apps/server/src/orchestration/runtimeLayer.test.ts
@@ -2,22 +2,21 @@ import { assert, it } from "@effect/vitest";
 import * as NodeServices from "@effect/platform-node/NodeServices";
 import * as Effect from "effect/Effect";
 import * as Layer from "effect/Layer";
-import * as Option from "effect/Option";
 
 import * as ChannelDeliveryStore from "../channels/ChannelDeliveryStore.ts";
 import * as ServerConfig from "../config.ts";
 import { SqlitePersistenceMemory } from "../persistence/Layers/Sqlite.ts";
 import * as RepositoryIdentityResolver from "../project/RepositoryIdentityResolver.ts";
-import { OrchestrationInfrastructureLayerLive } from "./runtimeLayer.ts";
+import { OrchestrationLayerLive } from "./runtimeLayer.ts";
 
 it.effect("provides channel delivery storage to the server runtime", () =>
   Effect.gen(function* () {
-    const store = yield* Effect.serviceOption(ChannelDeliveryStore.ChannelDeliveryStore);
+    const store = yield* ChannelDeliveryStore.ChannelDeliveryStore;
 
-    assert.isTrue(Option.isSome(store));
+    assert.isFunction(store.claim);
   }).pipe(
     Effect.provide(
-      OrchestrationInfrastructureLayerLive.pipe(
+      OrchestrationLayerLive.pipe(
         Layer.provideMerge(RepositoryIdentityResolver.layer),
         Layer.provideMerge(SqlitePersistenceMemory),
         Layer.provideMerge(

--- a/apps/server/src/orchestration/runtimeLayer.test.ts
+++ b/apps/server/src/orchestration/runtimeLayer.test.ts
@@ -1,0 +1,30 @@
+import { assert, it } from "@effect/vitest";
+import * as NodeServices from "@effect/platform-node/NodeServices";
+import * as Effect from "effect/Effect";
+import * as Layer from "effect/Layer";
+import * as Option from "effect/Option";
+
+import * as ChannelDeliveryStore from "../channels/ChannelDeliveryStore.ts";
+import * as ServerConfig from "../config.ts";
+import { SqlitePersistenceMemory } from "../persistence/Layers/Sqlite.ts";
+import * as RepositoryIdentityResolver from "../project/RepositoryIdentityResolver.ts";
+import { OrchestrationInfrastructureLayerLive } from "./runtimeLayer.ts";
+
+it.effect("provides channel delivery storage to the server runtime", () =>
+  Effect.gen(function* () {
+    const store = yield* Effect.serviceOption(ChannelDeliveryStore.ChannelDeliveryStore);
+
+    assert.isTrue(Option.isSome(store));
+  }).pipe(
+    Effect.provide(
+      OrchestrationInfrastructureLayerLive.pipe(
+        Layer.provideMerge(RepositoryIdentityResolver.layer),
+        Layer.provideMerge(SqlitePersistenceMemory),
+        Layer.provideMerge(
+          ServerConfig.layerTest(process.cwd(), { prefix: "runtime-layer-test-" }),
+        ),
+        Layer.provideMerge(NodeServices.layer),
+      ),
+    ),
+  ),
+);

--- a/apps/server/src/orchestration/runtimeLayer.ts
+++ b/apps/server/src/orchestration/runtimeLayer.ts
@@ -36,6 +36,7 @@ export const OrchestrationInfrastructureLayerLive = Layer.mergeAll(
   ProjectionBotRepositoryLive,
   ProjectionGroupRepositoryLive,
   BotUsageLedgerLive,
+  ChannelDeliveryStoreLive,
   MemoryRepositoriesLive,
   // Shared background-liveness and plan-progress registries: written by
   // runtime ingestion, read by the snapshot query. provideMerge feeds the

--- a/apps/web/src/components/settings/SettingsDialog.test.ts
+++ b/apps/web/src/components/settings/SettingsDialog.test.ts
@@ -1,0 +1,11 @@
+import { describe, expect, it } from "vite-plus/test";
+
+import { SETTINGS_NAV_ITEMS } from "./SettingsDialog";
+
+describe("settings dialog navigation", () => {
+  it("shows Bot channels as a navigation tab", () => {
+    expect(SETTINGS_NAV_ITEMS).toContainEqual(
+      expect.objectContaining({ section: "channels", label: "Bot channels" }),
+    );
+  });
+});

--- a/apps/web/src/components/settings/SettingsDialog.tsx
+++ b/apps/web/src/components/settings/SettingsDialog.tsx
@@ -6,6 +6,7 @@ import {
   HardDriveIcon,
   KeyboardIcon,
   Link02Icon,
+  Message01Icon,
   PaintBrush01Icon,
   SecurityCheckIcon,
   Settings02Icon,
@@ -76,7 +77,7 @@ const SECTION_PANELS: Readonly<Record<SettingsSection, ComponentType>> = {
 };
 
 /** Sections with a nav row. Anything else is reached from a link inside a panel. */
-const NAV_ITEMS: ReadonlyArray<{
+export const SETTINGS_NAV_ITEMS: ReadonlyArray<{
   readonly section: SettingsSection;
   readonly label: string;
   readonly icon: IconSvgElement;
@@ -84,6 +85,7 @@ const NAV_ITEMS: ReadonlyArray<{
   { section: "general", label: "General", icon: Settings02Icon },
   { section: "appearance", label: "Appearance", icon: PaintBrush01Icon },
   { section: "providers", label: "Providers", icon: BotIcon },
+  { section: "channels", label: "Bot channels", icon: Message01Icon },
   { section: "browser", label: "Browser", icon: BrowserIcon },
   { section: "sandbox", label: "Sandbox", icon: HardDriveIcon },
   { section: "voice", label: "Voice", icon: CallIcon },
@@ -114,7 +116,7 @@ export function SettingsDialog() {
           aria-label="Settings sections"
           className="flex w-52 shrink-0 flex-col gap-0.5 border-e bg-muted/30 p-2 max-sm:w-full max-sm:flex-row max-sm:overflow-x-auto max-sm:border-e-0 max-sm:border-b"
         >
-          {NAV_ITEMS.map((item) => {
+          {SETTINGS_NAV_ITEMS.map((item) => {
             const isActive = section === item.section;
             return (
               <button


### PR DESCRIPTION
## Why

Bot channels had no visible Settings navigation entry. Valid channel saves also failed before persistence because the production runtime did not provide channel delivery storage.

## What changed

- Add Bot channels to the Settings navigation.
- Provide channel delivery storage from the orchestration infrastructure layer.
- Add focused regressions for both runtime wiring and navigation.

## Testing

- `vp test run apps/web/src/components/settings/SettingsDialog.test.ts apps/web/src/components/settings/BotChannelsSettings.test.ts apps/web/src/settingsDialogStore.test.ts`
- `vp test run apps/server/src/orchestration/runtimeLayer.test.ts apps/server/src/channels/ChannelRuntime.test.ts apps/server/src/channels/ChannelDeliveryStore.test.ts`
- `vp run --filter @t3tools/web typecheck`
- `vp run --filter akeru-bot typecheck`
- Targeted `vp lint`
- `git diff --check`

## Screenshot

![Bot channels Settings tab](https://github.com/user-attachments/assets/f77e8794-cf83-43e2-ac0c-7e93e033c5a6)

Model: gpt-5.6-sol
Harness: Codex harness in T3 Code
