### PR TITLE
ci: validate merge queue candidates with Depot

### DIFF
--- a/.depot/workflows/ci.yml
+++ b/.depot/workflows/ci.yml
@@ -1,43 +1,21 @@
-# Depot CI runs Akeru checks on pull requests and main.
+# Depot CI validates the exact merge candidate before it reaches main.
 
 name: CI
 
 on:
-  pull_request:
-  push:
-    branches:
-      - main
+  merge_group:
+    types: [checks_requested]
+  workflow_dispatch:
 
 concurrency:
-  group: ci-${{ github.event.pull_request.number || github.sha }}
-  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+  group: ci-${{ github.ref }}
+  cancel-in-progress: true
 
 jobs:
-  public_dependencies:
-    name: Public dependency install
-    runs-on: depot-ubuntu-24.04-8
-    timeout-minutes: 15
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v6
-
-      - name: Setup Vite+
-        uses: voidzero-dev/setup-vp@v1
-        with:
-          node-version-file: package.json
-          cache: true
-          run-install: false
-
-      - name: Reject dependencies outside the repository
-        run: node scripts/check-public-dependencies.ts
-
-      - name: Install from the committed lockfile
-        run: vp install --frozen-lockfile
-
   check:
-    name: Lint, types, and builds
-    runs-on: depot-ubuntu-24.04-8
-    timeout-minutes: 15
+    name: Repository checks
+    runs-on: depot-ubuntu-24.04-4
+    timeout-minutes: 45
     steps:
       - name: Checkout
         uses: actions/checkout@v6
@@ -55,7 +33,13 @@ jobs:
         with:
           node-version-file: package.json
           cache: true
-          run-install: true
+          run-install: false
+
+      - name: Reject dependencies outside the repository
+        run: node scripts/check-public-dependencies.ts
+
+      - name: Install from the committed lockfile
+        run: vp install --frozen-lockfile
 
       - name: Ensure Electron runtime is installed
         run: vp run --filter @t3tools/desktop ensure:electron
@@ -92,85 +76,24 @@ jobs:
       - name: Build marketing site
         run: vp run build:marketing
 
-  test:
-    name: Focused workspace tests
-    runs-on: depot-ubuntu-24.04-8
-    timeout-minutes: 15
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v6
-
-      - name: Setup Vite+
-        uses: voidzero-dev/setup-vp@v1
-        with:
-          node-version-file: package.json
-          cache: true
-          run-install: true
-
-      - name: Ensure Electron runtime is installed
-        run: vp run --filter @t3tools/desktop ensure:electron
-
       - name: Test shipped desktop and shared packages
         run: vp run --parallel --concurrency-limit 4 --filter '!akeru-bot' --filter '!t3code-relay' --filter '!@t3tools/monorepo' --filter '!@t3tools/mobile' test
 
-  test_server:
-    name: Server tests (shard ${{ matrix.shard }}/${{ strategy.job-total }})
-    runs-on: depot-ubuntu-24.04-8
-    timeout-minutes: 15
-    strategy:
-      fail-fast: false
-      matrix:
-        shard: [1, 2, 3]
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v6
-
-      - name: Setup Vite+
-        uses: voidzero-dev/setup-vp@v1
-        with:
-          node-version-file: package.json
-          cache: true
-          run-install: true
-
-      - name: Test isolated server shard
+      - name: Test isolated server suite
         run: >-
           vp run --filter akeru-bot test
-          --shard ${{ matrix.shard }}/${{ strategy.job-total }}
           --exclude integration/orchestrationEngine.integration.test.ts
-
-  rust:
-    name: Resource monitor
-    runs-on: depot-ubuntu-24.04-8
-    timeout-minutes: 10
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v6
 
       - name: Setup Rust
         uses: dtolnay/rust-toolchain@stable
         with:
           components: rustfmt
 
-      - name: Check formatting
+      - name: Check resource monitor formatting
         run: cargo fmt --manifest-path native/resource-monitor/Cargo.toml -- --check
 
-      - name: Test
+      - name: Test resource monitor
         run: cargo test --locked --manifest-path native/resource-monitor/Cargo.toml
-
-  release_smoke:
-    name: Release smoke
-    runs-on: depot-ubuntu-24.04-8
-    timeout-minutes: 15
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v6
-
-      - name: Setup Vite+
-        uses: voidzero-dev/setup-vp@v1
-        with:
-          node-version-file: package.json
-          cache: true
-          run-install: true
 
       - name: Exercise release-only configuration
         run: vp run release:smoke

--- a/.depot/workflows/release-smoke.yml
+++ b/.depot/workflows/release-smoke.yml
@@ -21,7 +21,7 @@ concurrency:
 jobs:
   release_smoke:
     name: Release configuration
-    runs-on: depot-ubuntu-24.04-8
+    runs-on: depot-ubuntu-24.04-4
     timeout-minutes: 15
     steps:
       - name: Checkout
@@ -66,7 +66,7 @@ jobs:
             extension: exe
             rust_target: x86_64-pc-windows-msvc
           - label: Linux x64 AppImage
-            runner: depot-ubuntu-24.04-8
+            runner: depot-ubuntu-24.04-4
             platform: linux
             target: AppImage
             arch: x64
@@ -232,7 +232,7 @@ jobs:
   cli:
     name: CLI package
     needs: release_smoke
-    runs-on: depot-ubuntu-24.04-8
+    runs-on: depot-ubuntu-24.04-4
     timeout-minutes: 20
     env:
       RELEASE_VERSION: ${{ inputs.version }}
@@ -265,7 +265,7 @@ jobs:
   marketing:
     name: Marketing site
     needs: release_smoke
-    runs-on: depot-ubuntu-24.04-8
+    runs-on: depot-ubuntu-24.04-4
     timeout-minutes: 15
     steps:
       - name: Checkout

--- a/.depot/workflows/version-packages.yml
+++ b/.depot/workflows/version-packages.yml
@@ -12,12 +12,12 @@ permissions:
 
 concurrency:
   group: version-packages
-  cancel-in-progress: false
+  cancel-in-progress: true
 
 jobs:
   version:
     name: Update version PR
-    runs-on: depot-ubuntu-24.04-8
+    runs-on: depot-ubuntu-24.04-4
     timeout-minutes: 15
     steps:
       - name: Checkout

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -122,6 +122,7 @@ An empty database is a bad test. Seed your worktree's `.akeru` with a copy of re
 ## Pull requests
 
 - Never make a PR unless the developer explicitly asks you to do so.
+- Merge approved pull requests through GitHub's merge queue. Depot checks the queued merge candidate before GitHub writes it to `main`. See [`docs/internals/ci.md`](docs/internals/ci.md) for CI behavior.
 - Conventional commit titles, plain language: `fix(web): new threads no longer spike CPU`.
 - Body: the problem in a sentence or two, then how you fixed it. End with the model and harness that did the work.
 - UI changes need before/after images. Motion or timing needs a short video.

--- a/docs/internals/ci.md
+++ b/docs/internals/ci.md
@@ -2,24 +2,29 @@
 
 > For Akeru Bot maintainers.
 
-[`.depot/workflows/ci.yml`](../../.depot/workflows/ci.yml) runs on pull requests and pushes to `main`.
-All jobs use Depot CI on the 8-vCPU `depot-ubuntu-24.04-8` runner.
+[`.depot/workflows/ci.yml`](../../.depot/workflows/ci.yml) runs when GitHub adds a pull request to the
+merge queue. GitHub creates a temporary merge candidate from the pull request and the latest
+`main`, then Depot validates that exact revision. A failed check removes the pull request from the
+queue. A passing check lets GitHub merge it into `main` automatically. Maintainers can also dispatch
+the workflow manually for diagnostics. The workflow uses one 4-vCPU
+`depot-ubuntu-24.04-4` runner.
 Issue-label, PR-vouch, and PR-size jobs stay in GitHub Actions on `ubuntu-24.04` because they write GitHub issue and pull-request labels.
 
-- **Public dependency install.** The job rejects `file:` and `link:` dependencies that resolve
-  outside the repository, then runs `vp install --frozen-lockfile`.
-- **Lint, types, and builds.** The job checks lint and formatting, runs workspace type checks,
+- **Repository checks.** The job rejects external local dependencies, installs the committed
+  lockfile once, checks lint and formatting, runs workspace type checks,
   validates the plugin directory and contribution policy, builds the desktop pipeline, checks the
-  preload output, and builds the marketing site.
-- **Focused tests.** Separate jobs run the shipped desktop and shared-package tests, the sharded
-  server tests, and the resource-monitor tests. Relay and mobile-production packages are excluded.
-  The server shards exclude `orchestrationEngine.integration.test.ts` until the executor stack
+  preload output, builds the marketing site, tests shipped packages and the resource monitor, and
+  checks release-only configuration. Relay and mobile-production packages are excluded. The same
+  job runs the complete server suite. It excludes
+  `orchestrationEngine.integration.test.ts` until the executor stack
   restores its test adapter and stops the fixture from calling OpenAI with a test credential.
-- **Release smoke.** `scripts/release-smoke.ts` checks the public dependency rule, the supported
-  artifact matrix, Akeru naming, and the absence of retired publishing and deployment paths.
+
+The repository ruleset requires the merge queue and the Depot `Repository checks` result. Direct
+pushes to `main` cannot bypass this gate. Release workflows start after the validated revision lands
+on `main`; version packaging is separate from the merge queue.
 
 [`.depot/workflows/release-smoke.yml`](../../.depot/workflows/release-smoke.yml) is a manual, non-publishing
-artifact smoke workflow. It uses 8-vCPU Depot runners for Linux and Windows, plus Apple Silicon
+artifact smoke workflow. It uses 4-vCPU Depot runners for Linux, 8-vCPU Windows, plus Apple Silicon
 macOS. It builds a Developer ID signed macOS arm64 app. Electron-builder notarizes and staples the
 app before it packages the DMG. The workflow then submits and staples the DMG as a separate object.
 It checks both objects with Apple's verification tools. Windows and Linux artifacts stay unsigned.

--- a/docs/operations/release.md
+++ b/docs/operations/release.md
@@ -34,7 +34,7 @@ GitHub Actions owns the publishing workflow because Depot does not provide the m
 rejects the Windows runner needed for stable desktop artifacts. All Depot smoke jobs use a Depot
 runner label:
 
-- Linux uses the 8-vCPU `depot-ubuntu-24.04-8` runner.
+- Linux uses the 4-vCPU `depot-ubuntu-24.04-4` runner.
 - Windows uses the 8-vCPU `depot-windows-2025-8` runner.
 - macOS uses the Apple Silicon `depot-macos-15` image.
 

--- a/scripts/ci-workflow-policy.test.ts
+++ b/scripts/ci-workflow-policy.test.ts
@@ -1,0 +1,107 @@
+// @effect-diagnostics nodeBuiltinImport:off - Tests inspect repository policy files.
+import * as NodeFS from "node:fs";
+
+import { describe, expect, it } from "vite-plus/test";
+import { parse } from "yaml";
+
+type Step = {
+  readonly id?: string;
+  readonly if?: string;
+  readonly run?: string;
+};
+
+type Job = {
+  readonly "runs-on": string;
+  readonly steps: ReadonlyArray<Step>;
+};
+
+type Workflow = {
+  readonly on: Record<string, unknown>;
+  readonly concurrency?: {
+    readonly group?: string;
+    readonly "cancel-in-progress"?: boolean;
+  };
+  readonly jobs: Record<string, Job>;
+};
+
+function workflow(path: string): Workflow {
+  return parse(NodeFS.readFileSync(new URL(`../${path}`, import.meta.url), "utf8")) as Workflow;
+}
+
+describe("Depot workflow budget", () => {
+  it("validates the queued merge candidate in one 4-vCPU job", () => {
+    const ci = workflow(".depot/workflows/ci.yml");
+    const commands = Object.values(ci.jobs).flatMap((job) =>
+      job.steps.flatMap((step) => (step.run ? [step.run] : [])),
+    );
+
+    expect(Object.keys(ci.on)).toEqual(["merge_group", "workflow_dispatch"]);
+    expect(ci.on.merge_group).toEqual({ types: ["checks_requested"] });
+    expect(ci.on).not.toHaveProperty("push");
+    expect(ci.on).not.toHaveProperty("pull_request");
+    expect(ci.concurrency?.group).toBe("ci-${{ github.ref }}");
+    expect(ci.concurrency?.["cancel-in-progress"]).toBe(true);
+    expect(Object.keys(ci.jobs)).toEqual(["check"]);
+    expect(ci.jobs.check?.["runs-on"]).toBe("depot-ubuntu-24.04-4");
+
+    for (const command of [
+      "git ls-files .github/pr-assets",
+      "node scripts/check-public-dependencies.ts",
+      "vp install --frozen-lockfile",
+      "vp run --filter @t3tools/desktop ensure:electron",
+      "node scripts/validate-plugin-catalog.ts",
+      "scripts/validate-plugin-catalog.test.ts",
+      "scripts/plugin-contribution-policy.test.ts",
+      "plugins/catalog.test.ts",
+      "plugins/schema.test.ts",
+      "plugins/lifecycle-matrix.test.ts",
+      "vp run lint",
+      "vp run fmt:check",
+      "vp run typecheck",
+      "vp run build:desktop",
+      "apps/desktop/dist-electron/preload.cjs",
+      "vp run build:marketing",
+      "vp run --parallel --concurrency-limit 4",
+      "cargo fmt --manifest-path native/resource-monitor/Cargo.toml -- --check",
+      "cargo test --locked --manifest-path native/resource-monitor/Cargo.toml",
+      "vp run release:smoke",
+    ]) {
+      expect(commands.some((candidate) => candidate.includes(command))).toBe(true);
+    }
+
+    expect(ci.jobs.check).not.toHaveProperty("strategy");
+    const serverCommand =
+      commands.find((command) => command.includes("vp run --filter akeru-bot test")) ?? "";
+    expect(serverCommand).toContain("vp run --filter akeru-bot test");
+    expect(serverCommand).toContain(
+      "--exclude integration/orchestrationEngine.integration.test.ts",
+    );
+    expect(serverCommand).not.toContain("--shard");
+  });
+
+  it("coalesces version updates on a 4-vCPU runner", () => {
+    const versionPackages = workflow(".depot/workflows/version-packages.yml");
+    const versionJob = versionPackages.jobs.version;
+
+    expect(versionPackages.concurrency).toEqual({
+      group: "version-packages",
+      "cancel-in-progress": true,
+    });
+    expect(versionJob?.["runs-on"]).toBe("depot-ubuntu-24.04-4");
+    expect(versionJob?.steps.find((step) => step.run)?.run).toContain(
+      "vp run tegami version --no-checks",
+    );
+  });
+
+  it("uses 4-vCPU Linux runners in the manual release smoke workflow", () => {
+    const releaseSmoke = workflow(".depot/workflows/release-smoke.yml");
+    const text = NodeFS.readFileSync(
+      new URL("../.depot/workflows/release-smoke.yml", import.meta.url),
+      "utf8",
+    );
+
+    expect(text).not.toContain("depot-ubuntu-24.04-8");
+    expect(text).toContain("depot-ubuntu-24.04-4");
+    expect(Object.keys(releaseSmoke.jobs).length).toBeGreaterThan(0);
+  });
+});

--- a/scripts/release-smoke.ts
+++ b/scripts/release-smoke.ts
@@ -74,7 +74,7 @@ for (const [needle, label] of [
   ["label: Linux x64 AppImage", "Linux x64 AppImage"],
   ["runner: depot-macos-15", "Depot macOS runner"],
   ["runner: depot-windows-2025-8", "8-vCPU Depot Windows runner"],
-  ["runner: depot-ubuntu-24.04-8", "8-vCPU Depot Linux runner"],
+  ["runner: depot-ubuntu-24.04-4", "4-vCPU Depot Linux runner"],
   [
     "apple-actions/import-codesign-certs@5142e029c445c10ffc7149d172e540235a065466",
     "pinned Developer ID certificate import",
@@ -164,7 +164,11 @@ for (const [needle, label] of [
   assertOmits(ciWorkflow, needle, `CI workflow still contains ${label}.`);
 }
 
-assertContains(ciWorkflow, "runs-on: depot-ubuntu-24.04-8", "CI does not use Depot runners.");
+assertContains(
+  ciWorkflow,
+  "runs-on: depot-ubuntu-24.04-4",
+  "CI does not use 4-vCPU Depot runners.",
+);
 assertOmits(ciWorkflow, "runs-on: ubuntu-24.04", "GitHub-hosted Linux runners");
 assertOmits(releaseWorkflow, "runner: depot-macos-15", "unavailable Depot macOS runner");
 assertOmits(releaseWorkflow, "runner: depot-windows-2025-8", "unsupported Depot Windows runner");


### PR DESCRIPTION
Depot CI ran eight jobs on every pull request update and again after changes reached main. That consumed 13,613 vCPU-minutes in one day and still treated post-merge failures as notifications.

This change moves the full repository gate to GitHub merge queue candidates. Depot runs the same checks once in one 4-vCPU job against the exact revision GitHub plans to merge. It also lowers Linux release smoke and version-package runners to 4 vCPUs, coalesces superseded version updates, adds a focused workflow policy test, and documents the queue for maintainers and agents.

Verification:
- `vp test run scripts/ci-workflow-policy.test.ts scripts/plugin-contribution-policy.test.ts`
- `vp run release:smoke`
- targeted Vite+ lint and formatting
- `actionlint -ignore 'label ".+" is unknown' .depot/workflows/*.yml`\n- `git diff --check`\n\nModel: gpt-5.6-sol\nHarness: Codex harness in T3 Code