### PR TITLE
feat(bots): move model controls to sidebar

### DIFF
--- a/apps/server/src/channels/ChannelRuntime.ts
+++ b/apps/server/src/channels/ChannelRuntime.ts
@@ -345,7 +345,11 @@ export async function dispatchInboundChannelMessage(
       const project = model.projects.find((candidate) => candidate.deletedAt === null);
       if (!project) throw new Error("A project is required before a channel can start a turn.");
       const modelSelection = bot.engine
-        ? { instanceId: ProviderInstanceId.make(bot.engine.provider), model: bot.engine.model }
+        ? {
+            instanceId: ProviderInstanceId.make(bot.engine.provider),
+            model: bot.engine.model,
+            ...(bot.engine.options ? { options: bot.engine.options } : {}),
+          }
         : project.defaultModelSelection;
       if (!modelSelection)
         throw new Error(`Bot '${bot.name}' needs a model before channel messages.`);

--- a/apps/server/src/orchestration/Layers/BotPersistence.test.ts
+++ b/apps/server/src/orchestration/Layers/BotPersistence.test.ts
@@ -116,7 +116,14 @@ it.layer(TestLayer)("bot persistence", (it) => {
         description: "Investigates the highest-risk assumptions.",
         disabledMcpServerIds: [McpServerId.make("mcp-github")],
         avatar: { kind: "dither", seed: "pathfinder" },
-        engine: null,
+        engine: {
+          provider: "codex",
+          model: "gpt-5.6-sol",
+          options: [
+            { id: "reasoningEffort", value: "high" },
+            { id: "serviceTier", value: "priority" },
+          ],
+        },
         sandbox: null,
         runtimeMode: "approval-required",
         usageCap: { unit: "tokens", limit: 50_000 },
@@ -183,7 +190,14 @@ it.layer(TestLayer)("bot persistence", (it) => {
         description: "Investigates the highest-risk assumptions.",
         disabledMcpServerIds: [McpServerId.make("mcp-github")],
         avatar: { kind: "dither", seed: "pathfinder" },
-        engine: null,
+        engine: {
+          provider: "codex",
+          model: "gpt-5.6-sol",
+          options: [
+            { id: "reasoningEffort", value: "high" },
+            { id: "serviceTier", value: "priority" },
+          ],
+        },
         sandbox: null,
         runtimeMode: "approval-required",
         usageCap: { unit: "tokens", limit: 50_000 },
@@ -228,6 +242,14 @@ it.layer(TestLayer)("bot persistence", (it) => {
       const rebuiltBot = rebuilt.bots.find((bot) => bot.id === botId);
       assert.equal(rebuiltBot?.name, "Pathfinder");
       assert.equal(rebuiltBot?.voiceEnabled, true);
+      assert.deepEqual(rebuiltBot?.engine, {
+        provider: "codex",
+        model: "gpt-5.6-sol",
+        options: [
+          { id: "reasoningEffort", value: "high" },
+          { id: "serviceTier", value: "priority" },
+        ],
+      });
       assert.equal(rebuiltBot?.groupId, null);
       assert.equal(rebuiltBot?.archivedAt, null);
       assert.deepEqual(rebuilt.groups, []);

--- a/apps/server/src/orchestration/decider.ts
+++ b/apps/server/src/orchestration/decider.ts
@@ -2704,6 +2704,9 @@ export const decideOrchestrationCommand = Effect.fn("decideOrchestrationCommand"
                 modelSelection: {
                   instanceId: ProviderInstanceId.make(respondingBot.engine.provider),
                   model: respondingBot.engine.model,
+                  ...(respondingBot.engine.options
+                    ? { options: respondingBot.engine.options }
+                    : {}),
                 },
               }
             : command.modelSelection !== undefined

--- a/apps/server/src/provider/AkeruDelegationRuntime.ts
+++ b/apps/server/src/provider/AkeruDelegationRuntime.ts
@@ -394,6 +394,7 @@ export function createAkeruDelegationRuntime(options: AkeruDelegationRuntimeOpti
           : {
               instanceId: ProviderInstanceId.make(bot.engine.provider),
               model: bot.engine.model,
+              ...(bot.engine.options ? { options: bot.engine.options } : {}),
             },
       runtimeMode: grant.runtimeMode,
       interactionMode: "default",

--- a/apps/server/src/provider/AkeruMastraHarness.test.ts
+++ b/apps/server/src/provider/AkeruMastraHarness.test.ts
@@ -34,6 +34,7 @@ import {
   resolveAkeruTools,
   routineToolInputSchema,
   routineToolNeedsGlobalApproval,
+  withAkeruModelRunOptions,
 } from "./AkeruMastraHarness.ts";
 import { productFeedbackToolInputSchema } from "./AkeruMastraHarness.ts";
 import type { AkeruToolRuntime } from "./AkeruToolRuntime.ts";
@@ -382,6 +383,20 @@ describe("AkeruMastraHarness", () => {
       () => resolveAkeruMastraModel("kimi-for-coding/k3-256k", authStorage),
       "subscription access is unavailable",
     );
+  });
+
+  it("passes the saved Codex service tier to Mastra provider options", () => {
+    expect(
+      withAkeruModelRunOptions(
+        { providerOptions: { anthropic: { fallback: true }, openai: { store: false } } },
+        { modelOptions: { serviceTier: "priority" } },
+      ),
+    ).toEqual({
+      providerOptions: {
+        anthropic: { fallback: true },
+        openai: { store: false, serviceTier: "priority" },
+      },
+    });
   });
 
   it("configures Akeru as a general-purpose assistant with plugin awareness", () => {

--- a/apps/server/src/provider/AkeruMastraHarness.ts
+++ b/apps/server/src/provider/AkeruMastraHarness.ts
@@ -3,6 +3,7 @@ import * as NodeURL from "node:url";
 
 import { AuthStorage } from "@mastra/code-sdk/auth/storage";
 import { openaiCodexProvider } from "@mastra/code-sdk/providers/openai-codex";
+import { isThinkingLevelSetting } from "@mastra/code-sdk/thinking";
 import type { ToolsInput } from "@mastra/core/agent";
 import {
   AgentController as MastraAgentController,
@@ -139,9 +140,43 @@ export interface AkeruMastraState {
   readonly projectPath?: string;
   readonly yolo?: boolean;
   readonly botConversation?: boolean;
+  readonly modelOptions?: {
+    readonly reasoningEffort?: string;
+    readonly serviceTier?: string;
+  };
 }
 
 export type AkeruMastraSession = Session<AkeruMastraState>;
+
+type AkeruRunOptions = {
+  readonly providerOptions?: unknown;
+  readonly [key: string]: unknown;
+};
+
+export function withAkeruModelRunOptions(
+  runOptions: AkeruRunOptions,
+  state: AkeruMastraState,
+): AkeruRunOptions {
+  const serviceTier = state.modelOptions?.serviceTier;
+  if (!serviceTier) return runOptions;
+  const providerOptions =
+    typeof runOptions.providerOptions === "object" && runOptions.providerOptions !== null
+      ? runOptions.providerOptions
+      : {};
+  const openai =
+    "openai" in providerOptions &&
+    typeof providerOptions.openai === "object" &&
+    providerOptions.openai !== null
+      ? providerOptions.openai
+      : {};
+  return {
+    ...runOptions,
+    providerOptions: {
+      ...providerOptions,
+      openai: { ...openai, serviceTier },
+    },
+  };
+}
 
 export interface AkeruMastraHarnessOptions {
   readonly authStorage: AuthStorage;
@@ -260,6 +295,17 @@ function controllerModelId(requestContext: RequestContext): string {
     return DEFAULT_MODEL_ID;
   }
   return typeof session.modelId === "string" ? session.modelId : DEFAULT_MODEL_ID;
+}
+
+function controllerModelOptions(requestContext: RequestContext): AkeruMastraState["modelOptions"] {
+  const state = controllerContext(requestContext)?.state;
+  if (typeof state !== "object" || state === null || !("modelOptions" in state)) {
+    return undefined;
+  }
+  const modelOptions = state.modelOptions;
+  return typeof modelOptions === "object" && modelOptions !== null
+    ? (modelOptions as AkeruMastraState["modelOptions"])
+    : undefined;
 }
 
 function controllerResourceId(requestContext: RequestContext): string | undefined {
@@ -389,10 +435,15 @@ export function resolveAkeruMastraModel(
   modelId: string,
   authStorage: AuthStorage,
   getKimiAccess?: () => Promise<AkeruKimiAccess | undefined>,
+  modelOptions?: AkeruMastraState["modelOptions"],
 ) {
   const trimmed = modelId.trim();
   if (trimmed.startsWith("openai/")) {
-    return openaiCodexProvider(trimmed.slice("openai/".length), { authStorage });
+    const reasoningEffort = modelOptions?.reasoningEffort;
+    return openaiCodexProvider(trimmed.slice("openai/".length), {
+      authStorage,
+      ...(isThinkingLevelSetting(reasoningEffort) ? { thinkingLevel: reasoningEffort } : {}),
+    });
   }
   if (trimmed.startsWith("kimi-for-coding/")) {
     if (!getKimiAccess) throw new Error("Kimi For Coding subscription access is unavailable.");
@@ -747,6 +798,7 @@ export async function createAkeruMastraHarness(
         controllerModelId(requestContext),
         options.authStorage,
         options.getKimiAccess,
+        controllerModelOptions(requestContext),
       ),
     tools: ({ requestContext }) => resolveAkeruTools(requestContext, options),
     memory: observationalMemory.memory,
@@ -782,7 +834,7 @@ export async function createAkeruMastraHarness(
     intervalHandlers: [],
   });
   const controllerWithRunOptions = controller as unknown as {
-    buildSharedRunOptions: (session: unknown) => {
+    buildSharedRunOptions: (session: AkeruMastraSession) => {
       readonly requireToolApproval?: boolean | ((input: { readonly toolName: string }) => boolean);
       readonly [key: string]: unknown;
     };
@@ -790,11 +842,15 @@ export async function createAkeruMastraHarness(
   const buildSharedRunOptions = controllerWithRunOptions.buildSharedRunOptions.bind(controller);
   controllerWithRunOptions.buildSharedRunOptions = (session) => {
     const runOptions = buildSharedRunOptions(session);
-    if (runOptions.requireToolApproval !== true) return runOptions;
-    return {
-      ...runOptions,
-      requireToolApproval: ({ toolName }) => routineToolNeedsGlobalApproval(toolName),
-    };
+    const approvalOptions =
+      runOptions.requireToolApproval === true
+        ? {
+            ...runOptions,
+            requireToolApproval: ({ toolName }: { readonly toolName: string }) =>
+              routineToolNeedsGlobalApproval(toolName),
+          }
+        : runOptions;
+    return withAkeruModelRunOptions(approvalOptions, session.state.get());
   };
 
   const observeAfterTurn = (input: AkeruBackgroundObservationInput) => {

--- a/apps/server/src/provider/Layers/AgentController.test.ts
+++ b/apps/server/src/provider/Layers/AgentController.test.ts
@@ -210,6 +210,7 @@ function makeMastraHarness() {
   const listeners = new Set<(event: AgentControllerEvent) => void>();
   let modeId = "build";
   let modelId = "openai/gpt-5.6-sol";
+  let state: Record<string, unknown> = {};
   let resolveSend: (() => void) | undefined;
   const rejectSends: Array<(cause: unknown) => void> = [];
   const sendMessage = vi.fn(
@@ -220,7 +221,12 @@ function makeMastraHarness() {
       }),
   );
   const session = {
-    state: { set: vi.fn(async () => undefined) },
+    state: {
+      get: () => state,
+      set: vi.fn(async (next: Record<string, unknown>) => {
+        state = next;
+      }),
+    },
     mode: {
       get: () => modeId,
       switch: vi.fn(async ({ modeId: next }: { readonly modeId: string }) => {
@@ -2729,6 +2735,66 @@ describe("AgentControllerLive", () => {
         });
         expect(bridge.startSession).not.toHaveBeenCalled();
         expect(bridge.getCapabilities).not.toHaveBeenCalled();
+      }),
+      bridge.service,
+      mastra.factory,
+    );
+  });
+
+  it.effect("applies saved Codex options to initial and active Mastra sessions", () => {
+    const bridge = makeBridge();
+    const mastra = makeMastraHarness();
+    return provideController(
+      Effect.gen(function* () {
+        const controller = yield* AgentController;
+        yield* controller.resolveEngine({
+          threadId: codexThreadId,
+          engine: {
+            provider: "codex",
+            model: "gpt-5.6-sol",
+            options: [
+              { id: "reasoningEffort", value: "high" },
+              { id: "serviceTier", value: "priority" },
+            ],
+          },
+          fallback: codexSelection,
+          mode: "default",
+          botConversation: true,
+        });
+        yield* controller.startSession(codexThreadId, {
+          threadId: codexThreadId,
+          provider: ProviderDriverKind.make("codex"),
+          providerInstanceId: codexInstanceId,
+          cwd: process.cwd(),
+          runtimeMode: "approval-required",
+        });
+
+        expect(mastra.session.state.set).toHaveBeenLastCalledWith(
+          expect.objectContaining({
+            modelOptions: { reasoningEffort: "high", serviceTier: "priority" },
+          }),
+        );
+
+        yield* controller.resolveEngine({
+          threadId: codexThreadId,
+          engine: {
+            provider: "codex",
+            model: "gpt-5.6-sol",
+            options: [
+              { id: "reasoningEffort", value: "low" },
+              { id: "serviceTier", value: "flex" },
+            ],
+          },
+          fallback: codexSelection,
+          mode: "default",
+          botConversation: true,
+        });
+
+        expect(mastra.session.state.set).toHaveBeenLastCalledWith(
+          expect.objectContaining({
+            modelOptions: { reasoningEffort: "low", serviceTier: "flex" },
+          }),
+        );
       }),
       bridge.service,
       mastra.factory,

--- a/apps/server/src/provider/Layers/AgentController.ts
+++ b/apps/server/src/provider/Layers/AgentController.ts
@@ -46,6 +46,7 @@ import {
   AKERU_CREATE_ROUTINE_TOOL_NAME,
 } from "@t3tools/contracts";
 import { HostProcessPlatform } from "@t3tools/shared/hostProcess";
+import { getModelSelectionStringOptionValue } from "@t3tools/shared/model";
 import * as Effect from "effect/Effect";
 import * as Layer from "effect/Layer";
 import * as Option from "effect/Option";
@@ -54,6 +55,7 @@ import * as Semaphore from "effect/Semaphore";
 import * as Stream from "effect/Stream";
 
 import { resolveAttachmentPath } from "../../attachmentStore.ts";
+import { getCodexServiceTierOptionValue } from "../../codexModelOptions.ts";
 import { BotInboxService } from "../../bot-inbox/service.ts";
 import { recordUserActionIncident } from "../../bot-inbox/userActionIncidents.ts";
 import { ServerConfig } from "../../config.ts";
@@ -143,6 +145,19 @@ interface ResolvedEngine {
   readonly mastraModelId: string;
   readonly mode: "default" | "plan";
   readonly botConversation: boolean;
+}
+
+function mastraModelOptions(resolved: ResolvedEngine) {
+  if (resolved.provider !== "codex") return undefined;
+  const reasoningEffort = getModelSelectionStringOptionValue(
+    resolved.modelSelection,
+    "reasoningEffort",
+  );
+  const serviceTier = getCodexServiceTierOptionValue(resolved.modelSelection);
+  return {
+    ...(reasoningEffort ? { reasoningEffort } : {}),
+    ...(serviceTier ? { serviceTier } : {}),
+  };
 }
 
 interface ActiveAssistantMessage {
@@ -1479,6 +1494,14 @@ const make = (options?: AgentControllerLiveOptions) =>
           resolvedByThread.set(String(input.threadId), resolved);
           const active = sessions.get(String(input.threadId));
           if (active && usesMastraCode(resolved.provider)) {
+            const { modelOptions: _priorModelOptions, ...activeState } = active.session.state.get();
+            const nextModelOptions = mastraModelOptions(resolved);
+            yield* runMastra("state.set", () =>
+              active.session.state.set({
+                ...activeState,
+                ...(nextModelOptions ? { modelOptions: nextModelOptions } : {}),
+              }),
+            );
             yield* runMastra("model.switch", () =>
               active.session.model.switch({ modelId: resolved.mastraModelId }),
             );
@@ -1831,11 +1854,13 @@ const make = (options?: AgentControllerLiveOptions) =>
         toolRuntime.unregisterSession(key);
       });
       const active = yield* Effect.gen(function* () {
+        const modelOptions = mastraModelOptions(resolved);
         yield* runMastra("state.set", () =>
           session.state.set({
             ...(input.cwd ? { projectPath: input.cwd } : {}),
             yolo: false,
             botConversation: resolved.botConversation,
+            ...(modelOptions ? { modelOptions } : {}),
           }),
         );
         yield* runMastra("model.switch", () =>

--- a/apps/server/src/provider/Layers/AgentController.ts
+++ b/apps/server/src/provider/Layers/AgentController.ts
@@ -1465,6 +1465,7 @@ const make = (options?: AgentControllerLiveOptions) =>
               : {
                   instanceId: ProviderInstanceId.make(input.engine.provider),
                   model: input.engine.model,
+                  ...(input.engine.options ? { options: input.engine.options } : {}),
                 };
           const inspected = yield* inspectEngine(modelSelection);
           const resolved: ResolvedEngine = {

--- a/apps/web/src/components/chat/TraitsPicker.tsx
+++ b/apps/web/src/components/chat/TraitsPicker.tsx
@@ -325,36 +325,44 @@ export const TraitsMenuContent = memo(function TraitsMenuContentImpl({
                 value={selectedValue}
                 onValueChange={(value) => handleSelectChange(descriptor, value)}
               >
-                {descriptor.options.map((option) => (
-                  <MenuRadioItem
-                    key={option.id}
-                    value={option.id}
-                    hideIndicator
-                    // Base UI keeps radio menus open by default. Close on pick so
-                    // the traits menu behaves like the model picker.
-                    closeOnClick
-                    disabled={ultrathinkInBodyText && descriptor.id === primarySelectDescriptor?.id}
-                  >
-                    <span className="flex w-full min-w-0 flex-col">
-                      <span className="flex w-full min-w-0 items-center justify-between gap-3">
-                        <span className="min-w-0 truncate">
-                          {option.label}
-                          {option.isDefault ? (
-                            <>
-                              {" "}
-                              <DefaultBadge />
-                            </>
-                          ) : null}
+                {descriptor.options
+                  .filter(
+                    (option) =>
+                      allowPromptInjectedEffort ||
+                      !descriptor.promptInjectedValues?.includes(option.id),
+                  )
+                  .map((option) => (
+                    <MenuRadioItem
+                      key={option.id}
+                      value={option.id}
+                      hideIndicator
+                      // Base UI keeps radio menus open by default. Close on pick so
+                      // the traits menu behaves like the model picker.
+                      closeOnClick
+                      disabled={
+                        ultrathinkInBodyText && descriptor.id === primarySelectDescriptor?.id
+                      }
+                    >
+                      <span className="flex w-full min-w-0 flex-col">
+                        <span className="flex w-full min-w-0 items-center justify-between gap-3">
+                          <span className="min-w-0 truncate">
+                            {option.label}
+                            {option.isDefault ? (
+                              <>
+                                {" "}
+                                <DefaultBadge />
+                              </>
+                            ) : null}
+                          </span>
                         </span>
+                        {option.description ? (
+                          <span className="max-w-56 text-pretty text-muted-foreground/80 text-xs">
+                            {option.description}
+                          </span>
+                        ) : null}
                       </span>
-                      {option.description ? (
-                        <span className="max-w-56 text-pretty text-muted-foreground/80 text-xs">
-                          {option.description}
-                        </span>
-                      ) : null}
-                    </span>
-                  </MenuRadioItem>
-                ))}
+                    </MenuRadioItem>
+                  ))}
               </MenuRadioGroup>
             </MenuGroup>
           </div>

--- a/apps/web/src/components/roster/BotDetailsPanel.test.tsx
+++ b/apps/web/src/components/roster/BotDetailsPanel.test.tsx
@@ -107,6 +107,22 @@ describe("BotDetailsPanel", () => {
     expect(source).toContain("RIGHT_PANEL_INLINE_LAYOUT_MEDIA_QUERY");
   });
 
+  it("owns model and reasoning controls in the bot sidebar", () => {
+    const source = NodeFS.readFileSync(new URL("./BotDetailsPanel.tsx", import.meta.url), "utf8");
+    const composerSource = NodeFS.readFileSync(
+      new URL("./BotPromptComposer.tsx", import.meta.url),
+      "utf8",
+    );
+
+    expect(source).toContain("<BotModelPicker");
+    expect(source).toContain("<TraitsPicker");
+    expect(source).toContain(">Reasoning</div>");
+    expect(source).toContain("options: modelOptions");
+    expect(composerSource).not.toContain("BotModelPicker");
+    expect(composerSource).not.toContain("TraitsPicker");
+    expect(composerSource).not.toContain("reasoningPicker");
+  });
+
   it("collapses and reopens desktop without changing the mobile sheet", () => {
     const collapsed = reduceBotDetailsPanelState(
       { desktopOpen: true, mobileOpen: false },

--- a/apps/web/src/components/roster/BotDetailsPanel.tsx
+++ b/apps/web/src/components/roster/BotDetailsPanel.tsx
@@ -41,6 +41,7 @@ import { Sheet, SheetClose, SheetPopup, SheetTitle } from "../ui/sheet";
 import { Textarea } from "../ui/textarea";
 import { Switch } from "../ui/switch";
 import { Tooltip, TooltipPopup, TooltipTrigger } from "../ui/tooltip";
+import { shouldRenderTraitsControls, TraitsPicker } from "../chat/TraitsPicker";
 import { AvatarPickerDialog } from "./AvatarPickerDialog";
 import { BotAvatarView } from "./BotAvatarView";
 import { BotBrowserPreview } from "./BotBrowserPreview";
@@ -178,6 +179,14 @@ function BotProfileEditor({
         : null) ??
       defaultSelection.model,
   );
+  const [modelOptions, setModelOptions] = useState(
+    () =>
+      bot.engine?.options ??
+      (bot.engine?.provider === defaultSelection.instanceId &&
+      bot.engine.model === defaultSelection.model
+        ? defaultSelection.options
+        : undefined),
+  );
   const modelOptionsByInstance = useMemo(
     () => getCustomModelOptionsByInstance(settings, providers),
     [providers, settings],
@@ -187,11 +196,37 @@ function BotProfileEditor({
     if (engineChanged) return;
     setProvider(bot.engine?.provider ?? defaultSelection.instanceId);
     if (bot.engine?.model) setModel(bot.engine.model);
-  }, [bot.engine, defaultSelection.instanceId, engineChanged]);
+    setModelOptions(
+      bot.engine?.options ??
+        (bot.engine?.provider === defaultSelection.instanceId &&
+        bot.engine.model === defaultSelection.model
+          ? defaultSelection.options
+          : undefined),
+    );
+  }, [bot.engine, defaultSelection, engineChanged]);
 
   const normalizedLabel = label.trim() || null;
   const normalizedDescription = description.trim() || null;
-  const nextEngine: Bot["engine"] = engineChanged && model ? { provider, model } : bot.engine;
+  const nextEngine: Bot["engine"] =
+    engineChanged && model
+      ? {
+          provider,
+          model,
+          ...(modelOptions ? { options: modelOptions } : {}),
+        }
+      : bot.engine;
+  const showModelOptions =
+    activeEntry !== undefined &&
+    model.length > 0 &&
+    shouldRenderTraitsControls({
+      provider: activeEntry.driverKind,
+      models: activeEntry.models,
+      model,
+      prompt: "",
+      modelOptions,
+      allowPromptInjectedEffort: false,
+      planModeEnabled: settings.planModeEnabled,
+    });
   const resolvedUsageCap = resolveBotUsageCapForProvider(usageCap, activeEntry?.driverKind);
   const usageCapDirty =
     !resolvedUsageCap.valid || resolvedUsageCap.value?.limit !== bot.usageCap?.limit;
@@ -290,6 +325,12 @@ function BotProfileEditor({
                 onChange={(instanceId, nextModel) => {
                   setProvider(instanceId);
                   setModel(nextModel);
+                  setModelOptions(
+                    defaultSelection.instanceId === instanceId &&
+                      defaultSelection.model === nextModel
+                      ? defaultSelection.options
+                      : undefined,
+                  );
                   setEngineChanged(true);
                   markChanged();
                 }}
@@ -299,6 +340,31 @@ function BotProfileEditor({
             )}
           </div>
         </div>
+
+        {showModelOptions && activeEntry ? (
+          <div className="space-y-2">
+            <div className="text-sm font-medium">Reasoning</div>
+            <div className="flex min-h-10 items-center rounded-lg border border-border bg-muted/20 px-2">
+              <TraitsPicker
+                provider={activeEntry.driverKind}
+                instanceId={activeEntry.instanceId}
+                models={activeEntry.models}
+                model={model}
+                prompt=""
+                onPromptChange={() => {}}
+                modelOptions={modelOptions}
+                allowPromptInjectedEffort={false}
+                planModeEnabled={settings.planModeEnabled}
+                triggerClassName="w-full max-w-none justify-between"
+                onModelOptionsChange={(nextOptions) => {
+                  setModelOptions(nextOptions);
+                  setEngineChanged(true);
+                  markChanged();
+                }}
+              />
+            </div>
+          </div>
+        ) : null}
 
         <BotUsageSection environmentId={active ? environmentId : null} botId={bot.id} />
 

--- a/apps/web/src/components/roster/BotPromptComposer.test.tsx
+++ b/apps/web/src/components/roster/BotPromptComposer.test.tsx
@@ -1,8 +1,6 @@
 import { renderToStaticMarkup } from "react-dom/server";
 import { afterEach, describe, expect, it, vi } from "vite-plus/test";
 
-import { deriveProviderInstanceEntries } from "../../providerInstances";
-import { composerTestInstanceId, makeComposerTestProvider } from "../../test/chatComposerProps";
 import { visitElements } from "../../test/reactElementTree";
 import {
   BotPromptAttachments,
@@ -92,40 +90,21 @@ describe("bot prompt composer", () => {
 
   it("uses the available chat width", () => {
     const markup = renderToStaticMarkup(
-      <BotPromptComposer
-        botName="Akeru"
-        disabled={false}
-        modelPicker={null}
-        onSubmit={vi.fn(async () => true)}
-      />,
+      <BotPromptComposer botName="Akeru" disabled={false} onSubmit={vi.fn(async () => true)} />,
     );
 
     expect(markup).toContain('class="w-full px-4');
     expect(markup).not.toContain("max-w-4xl");
   });
 
-  it("shows the active model and keeps it changeable", () => {
-    const instanceEntries = deriveProviderInstanceEntries([makeComposerTestProvider()]);
+  it("does not render model or reasoning controls", () => {
     const markup = renderToStaticMarkup(
-      <BotPromptComposer
-        botName="Akeru"
-        disabled={false}
-        modelPicker={{
-          activeInstanceId: composerTestInstanceId,
-          model: "gpt-5-codex",
-          instanceEntries,
-          modelOptionsByInstance: new Map([
-            [composerTestInstanceId, [{ slug: "gpt-5-codex", name: "Launchbar Model" }]],
-          ]),
-          onChange: vi.fn(),
-        }}
-        onSubmit={vi.fn(async () => true)}
-      />,
+      <BotPromptComposer botName="Akeru" disabled={false} onSubmit={vi.fn(async () => true)} />,
     );
 
-    expect(markup).toContain("Launchbar Model");
-    expect(markup).toContain('aria-label="Change model"');
-    expect(markup).toContain("data-chat-provider-model-picker");
+    expect(markup).not.toContain("Reasoning");
+    expect(markup).not.toContain('aria-label="Change model"');
+    expect(markup).not.toContain("data-chat-provider-model-picker");
   });
 
   it("creates stable previews in file order and releases their object URLs", () => {

--- a/apps/web/src/components/roster/BotPromptComposer.tsx
+++ b/apps/web/src/components/roster/BotPromptComposer.tsx
@@ -1,7 +1,7 @@
 import { useAtomValue } from "@effect/atom-react";
 import { PROVIDER_SEND_TURN_MAX_ATTACHMENTS } from "@t3tools/contracts";
 import { ArrowUpIcon, AtSignIcon, PaperclipIcon, PlusIcon } from "lucide-react";
-import { type ComponentProps, useCallback, useEffect, useRef, useState } from "react";
+import { useCallback, useEffect, useRef, useState } from "react";
 
 import {
   hydrateImagesFromPersisted,
@@ -25,7 +25,6 @@ import { ComposerStashMenu } from "../chat/ComposerStashMenu";
 import { Menu, MenuItem, MenuPopup, MenuTrigger } from "../ui/menu";
 import { toastManager } from "../ui/toast";
 import { clearBotDraft, readBotDraft, writeBotDraft } from "./botDraftStore";
-import { BotModelPicker } from "./BotModelPicker";
 import {
   BotPromptAttachments,
   buildBotPromptAttachmentPreview,
@@ -33,11 +32,6 @@ import {
   releaseBotPromptAttachments,
   type BotPromptAttachment,
 } from "./BotPromptAttachments";
-
-type BotModelPickerProps = Pick<
-  ComponentProps<typeof BotModelPicker>,
-  "activeInstanceId" | "model" | "instanceEntries" | "modelOptionsByInstance" | "onChange"
->;
 
 export function isBotPromptExpanded(prompt: string): boolean {
   return prompt.includes("\n") || prompt.length > 80;
@@ -114,14 +108,12 @@ export function BotPromptComposer({
   draftKey,
   disabled,
   mentionBots = EMPTY_MENTION_BOTS,
-  modelPicker,
   onSubmit,
 }: {
   botName: string;
   draftKey?: string;
   disabled: boolean;
   mentionBots?: ReadonlyArray<MentionBot>;
-  modelPicker: BotModelPickerProps | null;
   onSubmit: (prompt: string, files: readonly File[], respondingBotId?: string) => Promise<boolean>;
 }) {
   const keybindings = useAtomValue(primaryServerKeybindingsAtom);
@@ -184,7 +176,7 @@ export function BotPromptComposer({
     [releaseAttachments],
   );
 
-  const expanded = modelPicker !== null || attachments.length > 0 || isBotPromptExpanded(draft);
+  const expanded = attachments.length > 0 || isBotPromptExpanded(draft);
   const addFiles = (next: FileList | readonly File[]) => {
     revisionRef.current += 1;
     const added = createBotPromptAttachments(Array.from(next));
@@ -595,15 +587,6 @@ export function BotPromptComposer({
                 ))}
               </MenuPopup>
             </Menu>
-            {modelPicker ? (
-              <BotModelPicker
-                activeInstanceId={modelPicker.activeInstanceId}
-                model={modelPicker.model}
-                instanceEntries={modelPicker.instanceEntries}
-                modelOptionsByInstance={modelPicker.modelOptionsByInstance}
-                onChange={modelPicker.onChange}
-              />
-            ) : null}
           </div>
           <button
             type="submit"

--- a/apps/web/src/components/roster/BotThreadLanding.tsx
+++ b/apps/web/src/components/roster/BotThreadLanding.tsx
@@ -1,7 +1,6 @@
 import { useAtomValue } from "@effect/atom-react";
 import {
   BotId,
-  type BotEngine,
   type ChannelMessageOrigin,
   type EnvironmentId,
   type MessageId,
@@ -13,10 +12,7 @@ import { useEffect, useMemo, useState } from "react";
 import { usePrimarySettings } from "../../hooks/useSettings";
 import { selectOpenBotInboxItems } from "../../botInbox";
 import { canManageChannels, connectedChannelBinding } from "../../channelAccess";
-import {
-  getCustomModelOptionsByInstance,
-  resolveAppModelSelectionState,
-} from "../../modelSelection";
+import { resolveAppModelSelectionState } from "../../modelSelection";
 import {
   applyProviderInstanceSettings,
   deriveProviderInstanceEntries,
@@ -120,12 +116,9 @@ export function BotThreadLanding({ botId }: { readonly botId: string }) {
   const canManageChannelBindings = canManageChannels(channelSession.data);
   const settings = usePrimarySettings();
   const providers = useAtomValue(primaryServerProvidersAtom);
-  const updateBot = useAtomCommand(botEnvironment.update, { reportFailure: false });
   const bots = useRosterStore((state) => state.bots);
   const bot = bots.find((candidate) => candidate.id === botId);
-  const [pendingEngine, setPendingEngine] = useState<BotEngine | null>(null);
-  const [modelUpdatePending, setModelUpdatePending] = useState(false);
-  const configuredEngine = pendingEngine ?? bot?.engine ?? null;
+  const configuredEngine = bot?.engine ?? null;
   const instanceEntries = useMemo(
     () =>
       sortProviderInstanceEntries(
@@ -148,17 +141,7 @@ export function BotThreadLanding({ botId }: { readonly botId: string }) {
       }),
     [configuredEngine, defaultSelection, instanceEntries, providers, settings],
   );
-  const activeEntry = useMemo(
-    () => instanceEntries.find((entry) => entry.instanceId === stickyEngine?.instanceId) ?? null,
-    [instanceEntries, stickyEngine?.instanceId],
-  );
-  const activeModel = stickyEngine?.model ?? null;
-  const modelOptionsByInstance = useMemo(
-    () => getCustomModelOptionsByInstance(settings, providers),
-    [providers, settings],
-  );
-  const effectiveModelSelection = stickyEngine;
-  const runtime = useBotThreadRuntime(botId, effectiveModelSelection);
+  const runtime = useBotThreadRuntime(botId, stickyEngine);
   const approvalState = useRosterPendingApproval(runtime.linkedThreadRef);
   const activities = useThreadActivities(runtime.linkedThreadRef);
   const stepMeters = useMemo(() => buildBotStepMeters(activities), [activities]);
@@ -170,16 +153,6 @@ export function BotThreadLanding({ botId }: { readonly botId: string }) {
       : serverEnvironment.subscriptionAuth({ environmentId, input: {} }),
   );
   const snapshot = useAtomValue(environmentSnapshotAtom(environmentId ?? NO_ENVIRONMENT));
-
-  useEffect(() => {
-    if (
-      pendingEngine &&
-      bot?.engine?.provider === pendingEngine.provider &&
-      bot.engine.model === pendingEngine.model
-    ) {
-      setPendingEngine(null);
-    }
-  }, [bot?.engine, pendingEngine]);
 
   useEffect(() => {
     if (!bot || bot.archivedAt !== null) {
@@ -330,48 +303,17 @@ export function BotThreadLanding({ botId }: { readonly botId: string }) {
               pendingApproval !== null ||
               voiceCall.activeCall?.botId === bot.id ||
               voiceCall.startingBotId === bot.id ||
-              modelUpdatePending ||
-              effectiveModelSelection === null ||
+              stickyEngine === null ||
               !runtime.botReady ||
               !runtime.bootstrapped ||
               runtime.defaultProject === null
             }
-            modelPicker={
-              environmentId && activeEntry && activeModel
-                ? {
-                    activeInstanceId: activeEntry.instanceId,
-                    model: activeModel,
-                    instanceEntries,
-                    modelOptionsByInstance,
-                    onChange: (instanceId, model) => {
-                      const nextEngine = { provider: instanceId, model };
-                      setPendingEngine(nextEngine);
-                      setModelUpdatePending(true);
-                      void updateBot({
-                        environmentId,
-                        input: {
-                          botId: BotId.make(bot.id),
-                          engine: nextEngine,
-                        },
-                      }).then((result) => {
-                        setModelUpdatePending(false);
-                        if (result._tag === "Failure") {
-                          setPendingEngine(null);
-                          toastManager.add({ type: "error", title: "Could not change model" });
-                        }
-                      });
-                    },
-                  }
-                : null
-            }
             onSubmit={runtime.send}
           />
-          {effectiveModelSelection === null ? (
+          {stickyEngine === null ? (
             <p className="px-4 pb-3 text-center text-xs text-muted-foreground">
               Enable a provider before you message this bot.
             </p>
-          ) : modelUpdatePending ? (
-            <p className="px-4 pb-3 text-center text-xs text-muted-foreground">Changing model…</p>
           ) : !runtime.botReady ? (
             <p className="px-4 pb-3 text-center text-xs text-muted-foreground">Connecting bot…</p>
           ) : runtime.bootstrapped && runtime.defaultProject === null ? (

--- a/apps/web/src/components/roster/GroupThreadLanding.tsx
+++ b/apps/web/src/components/roster/GroupThreadLanding.tsx
@@ -231,7 +231,6 @@ export function GroupThreadLanding({ groupId }: { readonly groupId: string }) {
             boss === null
           }
           mentionBots={members.map((bot) => ({ id: bot.id, name: bot.name }))}
-          modelPicker={null}
           onSubmit={runtime.send}
         />
       </div>

--- a/apps/web/src/components/roster/botEngineSelection.test.ts
+++ b/apps/web/src/components/roster/botEngineSelection.test.ts
@@ -16,14 +16,22 @@ describe("resolveStickyBotEngine", () => {
     if (!instanceId) throw new Error("missing instance");
 
     const resolved = resolveStickyBotEngine({
-      engine: { provider: instanceId, model: "gpt-5.6-sol" },
+      engine: {
+        provider: instanceId,
+        model: "gpt-5.6-sol",
+        options: [{ id: "reasoningEffort", value: "high" }],
+      },
       instanceEntries,
       settings,
       providers,
       defaultSelection: { instanceId, model: "gpt-5.6-luna" },
     });
 
-    expect(resolved).toEqual({ instanceId, model: "gpt-5.6-sol" });
+    expect(resolved).toEqual({
+      instanceId,
+      model: "gpt-5.6-sol",
+      options: [{ id: "reasoningEffort", value: "high" }],
+    });
   });
 
   it("uses the default instance when the bot has no engine", () => {
@@ -40,5 +48,30 @@ describe("resolveStickyBotEngine", () => {
     });
 
     expect(resolved?.instanceId).toBe(instanceId);
+  });
+
+  it("inherits app options when an older bot engine matches the app model", () => {
+    const providers = [makeComposerTestProvider()];
+    const instanceEntries = deriveProviderInstanceEntries(providers);
+    const instanceId = instanceEntries[0]?.instanceId;
+    if (!instanceId) throw new Error("missing instance");
+
+    expect(
+      resolveStickyBotEngine({
+        engine: { provider: instanceId, model: "gpt-5.6-sol" },
+        instanceEntries,
+        settings,
+        providers,
+        defaultSelection: {
+          instanceId,
+          model: "gpt-5.6-sol",
+          options: [{ id: "reasoningEffort", value: "medium" }],
+        },
+      }),
+    ).toEqual({
+      instanceId,
+      model: "gpt-5.6-sol",
+      options: [{ id: "reasoningEffort", value: "medium" }],
+    });
   });
 });

--- a/apps/web/src/components/roster/botEngineSelection.ts
+++ b/apps/web/src/components/roster/botEngineSelection.ts
@@ -1,6 +1,7 @@
 import {
   ProviderInstanceId,
   type BotEngine,
+  type ModelSelection,
   type ServerProvider,
   type UnifiedSettings,
 } from "@t3tools/contracts";
@@ -16,8 +17,8 @@ export function resolveStickyBotEngine(input: {
   readonly instanceEntries: ReadonlyArray<ProviderInstanceEntry>;
   readonly settings: UnifiedSettings;
   readonly providers: ReadonlyArray<ServerProvider>;
-  readonly defaultSelection: { readonly instanceId: ProviderInstanceId; readonly model: string };
-}): { readonly instanceId: ProviderInstanceId; readonly model: string } | null {
+  readonly defaultSelection: ModelSelection;
+}): ModelSelection | null {
   const preferredId = ProviderInstanceId.make(
     input.engine?.provider ?? input.defaultSelection.instanceId,
   );
@@ -27,10 +28,28 @@ export function resolveStickyBotEngine(input: {
     null;
   if (!entry) return null;
   if (input.engine && input.engine.provider === entry.instanceId) {
-    return { instanceId: entry.instanceId, model: input.engine.model };
+    const options =
+      input.engine.options ??
+      (input.defaultSelection.instanceId === entry.instanceId &&
+      input.defaultSelection.model === input.engine.model
+        ? input.defaultSelection.options
+        : undefined);
+    return {
+      instanceId: entry.instanceId,
+      model: input.engine.model,
+      ...(options ? { options } : {}),
+    };
   }
   const model =
     resolveAppModelSelectionForInstance(entry.instanceId, input.settings, input.providers, null) ??
     input.defaultSelection.model;
-  return { instanceId: entry.instanceId, model };
+  return {
+    instanceId: entry.instanceId,
+    model,
+    ...(input.defaultSelection.instanceId === entry.instanceId &&
+    input.defaultSelection.model === model &&
+    input.defaultSelection.options
+      ? { options: input.defaultSelection.options }
+      : {}),
+  };
 }

--- a/apps/web/src/components/roster/types.ts
+++ b/apps/web/src/components/roster/types.ts
@@ -1,4 +1,4 @@
-import type { ChannelBinding, GroupMembership, McpServerId } from "@t3tools/contracts";
+import type { BotEngine, ChannelBinding, GroupMembership, McpServerId } from "@t3tools/contracts";
 
 /**
  * Local mirror of the bot roster wire shape the server-side persistence work
@@ -30,7 +30,7 @@ export interface Bot {
   description: string | null;
   disabledMcpServerIds: readonly McpServerId[];
   avatar: BotAvatar;
-  engine: { provider: string; model: string } | null;
+  engine: BotEngine | null;
   sandbox: "local" | "e2b" | "daytona" | "vercel" | "upstash" | null;
   runtimeMode: "approval-required" | "auto-accept-edits" | "auto" | "full-access";
   usageCap: { unit: "tokens"; limit: number } | null;

--- a/apps/web/src/components/roster/useGroupThreadRuntime.ts
+++ b/apps/web/src/components/roster/useGroupThreadRuntime.ts
@@ -168,6 +168,7 @@ export function useGroupThreadRuntime(groupId: string) {
         ? {
             instanceId: ProviderInstanceId.make(respondingBot.engine.provider),
             model: respondingBot.engine.model,
+            ...(respondingBot.engine.options ? { options: respondingBot.engine.options } : {}),
           }
         : (activeProject.defaultModelSelection ?? appDefaultModelSelection);
 

--- a/packages/contracts/src/orchestration.test.ts
+++ b/packages/contracts/src/orchestration.test.ts
@@ -5,6 +5,7 @@ import * as Schema from "effect/Schema";
 import { ChannelConnectionId, MessageId } from "./baseSchemas.ts";
 import {
   BotAvatar,
+  BotEngine,
   DEFAULT_LOCAL_EXECUTION_MODE,
   DEFAULT_PROVIDER_INTERACTION_MODE,
   DEFAULT_RUNTIME_MODE,
@@ -36,6 +37,7 @@ import {
 import { ProviderInstanceId } from "./providerInstance.ts";
 
 const decodeBotAvatar = Schema.decodeUnknownEffect(BotAvatar);
+const decodeBotEngine = Schema.decodeUnknownEffect(BotEngine);
 const decodeOrchestrationBot = Schema.decodeUnknownEffect(OrchestrationBot);
 const decodeTurnDiffInput = Schema.decodeUnknownEffect(OrchestrationGetTurnDiffInput);
 const decodeFullThreadDiffInput = Schema.decodeUnknownEffect(OrchestrationGetFullThreadDiffInput);
@@ -86,6 +88,33 @@ it.effect("decodes every bot avatar variant", () =>
         { kind: "dither", seed: "scout" },
         { kind: "image", assetPath: "bots/scout.png", dithered: true },
       ],
+    );
+  }),
+);
+
+it.effect("decodes bot engine options while keeping old engines valid", () =>
+  Effect.gen(function* () {
+    assert.deepStrictEqual(yield* decodeBotEngine({ provider: "codex", model: "gpt-5.6-sol" }), {
+      provider: "codex",
+      model: "gpt-5.6-sol",
+    });
+    assert.deepStrictEqual(
+      yield* decodeBotEngine({
+        provider: "codex",
+        model: "gpt-5.6-sol",
+        options: [
+          { id: "reasoningEffort", value: "high" },
+          { id: "serviceTier", value: "priority" },
+        ],
+      }),
+      {
+        provider: "codex",
+        model: "gpt-5.6-sol",
+        options: [
+          { id: "reasoningEffort", value: "high" },
+          { id: "serviceTier", value: "priority" },
+        ],
+      },
     );
   }),
 );

--- a/packages/contracts/src/orchestration.ts
+++ b/packages/contracts/src/orchestration.ts
@@ -323,6 +323,7 @@ export type BotAvatar = typeof BotAvatar.Type;
 export const BotEngine = Schema.Struct({
   provider: TrimmedNonEmptyString,
   model: TrimmedNonEmptyString,
+  options: Schema.optionalKey(ProviderOptionSelections),
 });
 export type BotEngine = typeof BotEngine.Type;
 


### PR DESCRIPTION
Bot model settings were split between the bot sidebar and the message composer. Reasoning and service tier were transient composer choices, so channel and delegated turns could ignore them.

This moves all model controls into the bot settings sidebar. The bot engine now saves provider options and carries them into direct, group, channel, and delegated turns. The message composer returns to prompt and attachment controls only.

## Before

![Reasoning controls in the message composer](https://github.com/user-attachments/assets/f0699e80-7efd-442a-bcc2-915f3aba3cac)

## After

![Model and reasoning controls in the bot sidebar](https://github.com/user-attachments/assets/553614a9-93d1-41b2-967c-a59d0861e269)

## Verification

- `vp test run packages/contracts/src/orchestration.test.ts apps/server/src/orchestration/Layers/BotPersistence.test.ts apps/web/src/components/roster/BotPromptComposer.test.tsx apps/web/src/components/roster/BotDetailsPanel.test.tsx apps/web/src/components/roster/botEngineSelection.test.ts apps/web/src/components/chat/TraitsPicker.test.ts`
- Web, server, and contracts type checks
- Integrated browser pass for selecting and saving `High`

Model: gpt-5.6-sol
Harness: Codex harness in T3 Code
