### PR TITLE
feat(bots): personalize Akeru prompts

### DIFF
--- a/apps/server/src/provider/AkeruAgentInstructions.ts
+++ b/apps/server/src/provider/AkeruAgentInstructions.ts
@@ -1,20 +1,45 @@
-export const AKERU_AGENT_INSTRUCTIONS = [
-  "You are Akeru, a general-purpose assistant.",
-  "Help with conversation, research, writing, planning, operations, and technical work.",
-  "Do not assume that a request is a software-engineering task.",
-  "You are not limited to coding. Describe yourself as a general assistant with coding tools.",
-  "Use enabled plugin tools when they help with the request.",
-  "When preview_* tools are present, use them for browser work so the user can watch in the shared browser.",
-  "Call preview_status first. Call preview_open if no browser is attached, then use preview_navigate, preview_snapshot, and the focused preview interaction tools.",
-  "Prefer preview_* tools over browser_* tools when both are present.",
-  "Use workspace tools only when the task requires file or command work.",
-  "When asked about available tools, describe only tools present in the current turn.",
-  "Do not claim that a tool ran unless its result is present in this turn.",
-  "Use akeru_create_routine when the user asks for recurring or scheduled work.",
-  "Use akeru_list_routines before answering whether a routine exists or what state it is in, including enabled, disabled, paused, blocked, or failed.",
-  "When the user asks to delete routines, call akeru_list_routines, then call akeru_delete_routines with the selected IDs. The delete tool asks for confirmation, so do not ask for separate confirmation.",
-  "Routine output goes to the current chat unless the user names an enabled plugin such as Slack. Use the current device timezone unless the user names another timezone.",
-].join("\n");
+import * as DateTime from "effect/DateTime";
+
+export interface AkeruInstructionContext {
+  readonly name?: string;
+  readonly now?: DateTime.DateTime;
+}
+
+function botName(name: string | undefined): string {
+  return name?.trim().replace(/\s+/g, " ") || "Akeru";
+}
+
+function currentDate(now: DateTime.DateTime): string {
+  return DateTime.formatLocal(now, { locale: "en-US", dateStyle: "full" });
+}
+
+export function createAkeruAgentInstructions(context: AkeruInstructionContext = {}): string {
+  const name = botName(context.name);
+  const date = currentDate(context.now ?? DateTime.nowUnsafe());
+  return [
+    `You are ${name}, a sharp, curious general assistant. Today is ${date}.`,
+    "Treat each request on its own terms. Coding is one kind of work, not the default.",
+    "Write like a thoughtful human teammate. Match the user's tone and detail. Be warm without fawning and confident without hiding uncertainty.",
+    "Lead with the answer. Use plain, specific language, active voice, and natural rhythm. Use first person when it fits.",
+    "Have a point of view when the facts support one. Name real tradeoffs instead of flattening every answer into neutral pros and cons.",
+    "Keep structure proportional to the task. Prefer short prose. Use headings and lists only when they make the answer easier to use.",
+    "Silently reread before sending. Cut filler, puffery, canned praise, vague claims, repeated conclusions, and stock launch language. Rewrite generic sentences.",
+    "For copy, use concrete facts. Name every drawback the user gives you. Never invent or disguise a benefit.",
+    "Use periods and commas for asides. Never use em or en dashes, parenthetical asides, or spaced hyphens as dashes.",
+    "Start with substance instead of a greeting. End on the useful point instead of a generic offer to do more.",
+    "Use enabled plugin tools when they help with the request.",
+    "When preview_* tools are present, use them for browser work so the user can watch in the shared browser.",
+    "Call preview_status first. Call preview_open if no browser is attached, then use preview_navigate, preview_snapshot, and the focused preview interaction tools.",
+    "Prefer preview_* tools over browser_* tools when both are present.",
+    "Use workspace tools only when the task requires file or command work.",
+    "When asked about available tools, describe only tools present in the current turn.",
+    "Do not claim that a tool ran unless its result is present in this turn.",
+    "Use akeru_create_routine when the user asks for recurring or scheduled work.",
+    "Use akeru_list_routines before answering whether a routine exists or what state it is in, including enabled, disabled, paused, blocked, or failed.",
+    "When the user asks to delete routines, call akeru_list_routines, then call akeru_delete_routines with the selected IDs. The delete tool asks for confirmation, so do not ask for separate confirmation.",
+    "Routine output goes to the current chat unless the user names an enabled plugin such as Slack. Use the current device timezone unless the user names another timezone.",
+  ].join("\n");
+}
 
 export const AKERU_BOT_TURN_INSTRUCTIONS = [
   "Before you use a tool for a visible user request, first answer with one short plain-language sentence that acknowledges the request and says what you will do next.",
@@ -22,6 +47,6 @@ export const AKERU_BOT_TURN_INSTRUCTIONS = [
   "Treat a hidden system reminder or automatic continuation as ongoing work, not a new user request. Skip the opening reply and continue with only useful status notes.",
 ].join("\n");
 
-export const AKERU_BOT_INSTRUCTIONS = [AKERU_AGENT_INSTRUCTIONS, AKERU_BOT_TURN_INSTRUCTIONS].join(
-  "\n",
-);
+export function createAkeruBotInstructions(context: AkeruInstructionContext = {}): string {
+  return [createAkeruAgentInstructions(context), AKERU_BOT_TURN_INSTRUCTIONS].join("\n");
+}

--- a/apps/server/src/provider/AkeruMastraHarness.test.ts
+++ b/apps/server/src/provider/AkeruMastraHarness.test.ts
@@ -17,7 +17,10 @@ import {
 import * as DateTime from "effect/DateTime";
 import { assert, describe, expect, it, vi } from "vite-plus/test";
 
-import { AKERU_AGENT_INSTRUCTIONS, AKERU_BOT_INSTRUCTIONS } from "./AkeruAgentInstructions.ts";
+import {
+  createAkeruAgentInstructions,
+  createAkeruBotInstructions,
+} from "./AkeruAgentInstructions.ts";
 import {
   AKERU_RECENT_MESSAGE_LIMIT,
   AKERU_DELETE_ROUTINES_TOOL_NAME,
@@ -384,25 +387,41 @@ describe("AkeruMastraHarness", () => {
     );
   });
 
-  it("configures Akeru as a general-purpose assistant with plugin awareness", () => {
-    assert.include(AKERU_AGENT_INSTRUCTIONS, "general-purpose assistant");
-    assert.include(AKERU_AGENT_INSTRUCTIONS, "enabled plugin tools");
-    assert.include(AKERU_AGENT_INSTRUCTIONS, "Prefer preview_* tools over browser_* tools");
-    assert.include(AKERU_AGENT_INSTRUCTIONS, "akeru_list_routines");
-    assert.include(AKERU_AGENT_INSTRUCTIONS, "Do not assume");
-    assert.notInclude(AKERU_AGENT_INSTRUCTIONS, "coding agent");
+  it("builds a compact, human prompt with the bot name and current date", () => {
+    const instructions = createAkeruAgentInstructions({
+      name: "  Research\nBot  ",
+      now: DateTime.makeUnsafe("2026-09-02T12:00:00.000Z"),
+    });
+
+    assert.include(instructions, "You are Research Bot, a sharp, curious general assistant");
+    assert.include(instructions, "Today is Wednesday, September 2, 2026");
+    assert.include(instructions, "Write like a thoughtful human teammate");
+    assert.include(instructions, "Silently reread before sending");
+    assert.include(instructions, "Name every drawback");
+    assert.include(instructions, "Never use em or en dashes");
+    assert.include(instructions, "enabled plugin tools");
+    assert.include(instructions, "Prefer preview_* tools over browser_* tools");
+    assert.include(instructions, "akeru_list_routines");
+    assert.notInclude(instructions, "—");
+    assert.notInclude(instructions, "coding agent");
+    assert.isBelow(createAkeruBotInstructions({ now: DateTime.nowUnsafe() }).length, 3_000);
   });
 
   it("adds reply and status rules only to bot conversations", () => {
+    const now = DateTime.makeUnsafe("2026-09-02T12:00:00.000Z");
     const regular = new RequestContext();
     regular.setRaw("controller", { state: { botConversation: false } });
     const bot = new RequestContext();
-    bot.setRaw("controller", { state: { botConversation: true } });
+    bot.setRaw("controller", { state: { botConversation: true, botName: "Mina" } });
 
-    assert.equal(resolveAkeruInstructions(regular), AKERU_AGENT_INSTRUCTIONS);
-    assert.equal(resolveAkeruInstructions(bot), AKERU_BOT_INSTRUCTIONS);
-    assert.include(resolveAkeruInstructions(bot), "Before you use a tool");
-    assert.include(resolveAkeruInstructions(bot), "automatic continuation");
+    assert.equal(resolveAkeruInstructions(regular, now), createAkeruAgentInstructions({ now }));
+    assert.equal(
+      resolveAkeruInstructions(bot, now),
+      createAkeruBotInstructions({ name: "Mina", now }),
+    );
+    assert.include(resolveAkeruInstructions(bot, now), "You are Mina");
+    assert.include(resolveAkeruInstructions(bot, now), "Before you use a tool");
+    assert.include(resolveAkeruInstructions(bot, now), "automatic continuation");
   });
 
   it("selects implemented runtime tools without dropping approval-aware plugins", async () => {

--- a/apps/server/src/provider/AkeruMastraHarness.ts
+++ b/apps/server/src/provider/AkeruMastraHarness.ts
@@ -36,11 +36,15 @@ import {
   type ProductFeedbackToolDraft as ProductFeedbackToolDraftValue,
   type AkeruCreateRoutineInput as AkeruCreateRoutineInputValue,
 } from "@t3tools/contracts";
+import * as DateTime from "effect/DateTime";
 import * as Exit from "effect/Exit";
 import * as Schema from "effect/Schema";
 import { z } from "zod";
 
-import { AKERU_AGENT_INSTRUCTIONS, AKERU_BOT_INSTRUCTIONS } from "./AkeruAgentInstructions.ts";
+import {
+  createAkeruAgentInstructions,
+  createAkeruBotInstructions,
+} from "./AkeruAgentInstructions.ts";
 import { akeruKimiProvider, type AkeruKimiAccess } from "./AkeruKimiProvider.ts";
 import { createAkeruMastraTools } from "./AkeruMastraTools.ts";
 import type { AkeruToolRuntime } from "./AkeruToolRuntime.ts";
@@ -139,6 +143,7 @@ export interface AkeruMastraState {
   readonly projectPath?: string;
   readonly yolo?: boolean;
   readonly botConversation?: boolean;
+  readonly botName?: string;
 }
 
 export type AkeruMastraSession = Session<AkeruMastraState>;
@@ -401,14 +406,23 @@ export function resolveAkeruMastraModel(
   throw new Error(`Mastra has no subscription transport for model '${modelId}'.`);
 }
 
-export function resolveAkeruInstructions(requestContext: RequestContext): string {
+export function resolveAkeruInstructions(
+  requestContext: RequestContext,
+  now = DateTime.nowUnsafe(),
+): string {
   const state = controllerContext(requestContext)?.state;
-  return typeof state === "object" &&
+  const isBotConversation =
+    typeof state === "object" &&
     state !== null &&
     "botConversation" in state &&
-    state.botConversation === true
-    ? AKERU_BOT_INSTRUCTIONS
-    : AKERU_AGENT_INSTRUCTIONS;
+    state.botConversation === true;
+  const name =
+    isBotConversation && "botName" in state && typeof state.botName === "string"
+      ? state.botName
+      : "Akeru";
+  return isBotConversation
+    ? createAkeruBotInstructions({ name, now })
+    : createAkeruAgentInstructions({ name, now });
 }
 
 export async function resolveAkeruTools(

--- a/apps/server/src/provider/Layers/AgentController.test.ts
+++ b/apps/server/src/provider/Layers/AgentController.test.ts
@@ -887,6 +887,38 @@ describe("AgentControllerLive", () => {
     );
   });
 
+  it.effect("keeps the current bot name in reused Mastra session state", () => {
+    const bridge = makeBridge();
+    const mastra = makeMastraHarness();
+    return provideController(
+      Effect.gen(function* () {
+        const controller = yield* AgentController;
+        yield* resolveCodex(controller);
+        const input = {
+          threadId: codexThreadId,
+          provider: ProviderDriverKind.make("codex"),
+          providerInstanceId: codexInstanceId,
+          modelSelection: codexSelection,
+          runtimeMode: "full-access" as const,
+          botId: BotId.make("bot-one"),
+        };
+
+        yield* controller.startSession(codexThreadId, { ...input, botName: "Research bot" });
+        expect(mastra.session.state.set).toHaveBeenLastCalledWith(
+          expect.objectContaining({ botConversation: true, botName: "Research bot" }),
+        );
+
+        yield* controller.startSession(codexThreadId, { ...input, botName: "Mina" });
+        expect(mastra.createSession).toHaveBeenCalledOnce();
+        expect(mastra.session.state.set).toHaveBeenLastCalledWith(
+          expect.objectContaining({ botConversation: true, botName: "Mina" }),
+        );
+      }),
+      bridge.service,
+      mastra.factory,
+    );
+  });
+
   it.effect("queues Mastra follow-ups while the current turn is active", () => {
     const bridge = makeBridge();
     const mastra = makeMastraHarness();

--- a/apps/server/src/provider/Layers/AgentController.test.ts
+++ b/apps/server/src/provider/Layers/AgentController.test.ts
@@ -919,6 +919,40 @@ describe("AgentControllerLive", () => {
     );
   });
 
+  it.effect("clears a stale bot name in reused Mastra session state", () => {
+    const bridge = makeBridge();
+    const mastra = makeMastraHarness();
+    return provideController(
+      Effect.gen(function* () {
+        const controller = yield* AgentController;
+        yield* resolveCodex(controller);
+        const input = {
+          threadId: codexThreadId,
+          provider: ProviderDriverKind.make("codex"),
+          providerInstanceId: codexInstanceId,
+          modelSelection: codexSelection,
+          runtimeMode: "full-access" as const,
+          botId: BotId.make("bot-one"),
+        };
+
+        yield* controller.startSession(codexThreadId, { ...input, botName: "Research bot" });
+        yield* controller.startSession(codexThreadId, input);
+        expect(mastra.session.state.set).toHaveBeenLastCalledWith(
+          expect.objectContaining({ botConversation: true, botName: "" }),
+        );
+
+        yield* controller.startSession(codexThreadId, { ...input, botName: "Research bot" });
+        yield* controller.startSession(codexThreadId, { ...input, botName: "" });
+        expect(mastra.createSession).toHaveBeenCalledOnce();
+        expect(mastra.session.state.set).toHaveBeenLastCalledWith(
+          expect.objectContaining({ botConversation: true, botName: "" }),
+        );
+      }),
+      bridge.service,
+      mastra.factory,
+    );
+  });
+
   it.effect("queues Mastra follow-ups while the current turn is active", () => {
     const bridge = makeBridge();
     const mastra = makeMastraHarness();

--- a/apps/server/src/provider/Layers/AgentController.ts
+++ b/apps/server/src/provider/Layers/AgentController.ts
@@ -1584,6 +1584,14 @@ const make = (options?: AgentControllerLiveOptions) =>
         existing.mcpServerIds.every((id) => input.mcpServers?.some((server) => server.id === id))
       ) {
         existing.runtimeMode = access.runtimeMode;
+        yield* runMastra("state.set", () =>
+          existing.session.state.set({
+            ...(input.cwd ? { projectPath: input.cwd } : {}),
+            yolo: false,
+            botConversation: resolved.botConversation,
+            ...(input.botName ? { botName: input.botName } : {}),
+          }),
+        );
         const toolSession = { ...existing.toolSession };
         delete toolSession.botId;
         delete toolSession.botName;
@@ -1835,6 +1843,7 @@ const make = (options?: AgentControllerLiveOptions) =>
             ...(input.cwd ? { projectPath: input.cwd } : {}),
             yolo: false,
             botConversation: resolved.botConversation,
+            ...(input.botName ? { botName: input.botName } : {}),
           }),
         );
         yield* runMastra("model.switch", () =>

--- a/apps/server/src/provider/Layers/AgentController.ts
+++ b/apps/server/src/provider/Layers/AgentController.ts
@@ -1589,7 +1589,7 @@ const make = (options?: AgentControllerLiveOptions) =>
             ...(input.cwd ? { projectPath: input.cwd } : {}),
             yolo: false,
             botConversation: resolved.botConversation,
-            ...(input.botName ? { botName: input.botName } : {}),
+            botName: input.botName || "",
           }),
         );
         const toolSession = { ...existing.toolSession };

--- a/apps/server/src/provider/Layers/ClaudeAdapter.test.ts
+++ b/apps/server/src/provider/Layers/ClaudeAdapter.test.ts
@@ -418,7 +418,7 @@ describe("ClaudeAdapterLive", () => {
           "append" in createInput.options.systemPrompt
             ? (createInput.options.systemPrompt.append ?? "")
             : "";
-        assert.include(appendedInstructions, "general-purpose assistant");
+        assert.include(appendedInstructions, "general assistant");
         assert.notInclude(appendedInstructions, "Before you use a tool");
       }).pipe(
         Effect.provideService(Random.Random, makeDeterministicRandomService()),
@@ -436,6 +436,7 @@ describe("ClaudeAdapterLive", () => {
         provider: ProviderDriverKind.make("claudeAgent"),
         runtimeMode: "full-access",
         botId: "bot-1" as never,
+        botName: "Mina",
       });
 
       const systemPrompt = harness.getLastCreateQueryInput()?.options.systemPrompt;
@@ -445,6 +446,8 @@ describe("ClaudeAdapterLive", () => {
           : "";
       assert.include(appendedInstructions, "Before you use a tool");
       assert.include(appendedInstructions, "automatic continuation");
+      assert.include(appendedInstructions, "You are Mina");
+      assert.match(appendedInstructions, /Today is [A-Z][a-z]+, [A-Z][a-z]+ \d{1,2}, \d{4}/);
     }).pipe(
       Effect.provideService(Random.Random, makeDeterministicRandomService()),
       Effect.provide(harness.layer),

--- a/apps/server/src/provider/Layers/ClaudeAdapter.ts
+++ b/apps/server/src/provider/Layers/ClaudeAdapter.ts
@@ -78,7 +78,10 @@ import * as Stream from "effect/Stream";
 
 import { resolveAttachmentPath } from "../../attachmentStore.ts";
 import { ServerConfig } from "../../config.ts";
-import { AKERU_AGENT_INSTRUCTIONS, AKERU_BOT_INSTRUCTIONS } from "../AkeruAgentInstructions.ts";
+import {
+  createAkeruAgentInstructions,
+  createAkeruBotInstructions,
+} from "../AkeruAgentInstructions.ts";
 import * as McpProviderSession from "../../mcp/McpProviderSession.ts";
 import { toClaudeMcpServers } from "../McpServerConfig.ts";
 import { resolveClaudeSdkExecutablePath } from "../Drivers/ClaudeExecutable.ts";
@@ -4320,7 +4323,9 @@ export const makeClaudeAdapter = Effect.fn("makeClaudeAdapter")(function* (
         systemPrompt: {
           type: "preset",
           preset: "claude_code",
-          append: input.botId ? AKERU_BOT_INSTRUCTIONS : AKERU_AGENT_INSTRUCTIONS,
+          append: input.botId
+            ? createAkeruBotInstructions({ ...(input.botName ? { name: input.botName } : {}) })
+            : createAkeruAgentInstructions(),
         },
         settingSources: [...CLAUDE_SETTING_SOURCES],
         // `ultracode` is a Claude Code setting, not an API effort level. It is


### PR DESCRIPTION
## What Changed

- Build Akeru instructions with the bot's current name and local date.
- Add compact writing rules for direct, specific, human-sounding replies.
- Refresh bot identity in reused Mastra sessions and pass it to Claude sessions.
- Cover prompt size, identity, date, session reuse, and provider wiring.

## Why

The shared prompt was static and generic. Named bots could not identify themselves from the prompt, long-running sessions had no current date, and replies often used canned AI phrasing.

## Checklist

- [x] This PR is small and focused
- [x] I explained what changed and why
- [x] I linked the accepted plugin or provider proposal in **Why**, or this PR does not add one
- [x] I included before/after screenshots for any UI changes
- [x] I included a video for animation/interaction changes

## Testing

- `vp test run apps/server/src/provider/AkeruMastraHarness.test.ts apps/server/src/provider/Layers/AgentController.test.ts apps/server/src/provider/Layers/ClaudeAdapter.test.ts`
- `vp run --filter akeru-bot typecheck`
- `vp fmt --check apps/server/src/provider/AkeruAgentInstructions.ts apps/server/src/provider/AkeruMastraHarness.ts apps/server/src/provider/AkeruMastraHarness.test.ts apps/server/src/provider/Layers/AgentController.ts apps/server/src/provider/Layers/AgentController.test.ts apps/server/src/provider/Layers/ClaudeAdapter.ts apps/server/src/provider/Layers/ClaudeAdapter.test.ts`
- Real `gpt-5.6-sol` prompt pass for identity, date, opinion, casual writing, and honest listing copy

Model: gpt-5.6-sol
Harness: Codex in T3 Code on macOS
