### PR TITLE
ci: run Depot checks on pull requests

### DIFF
--- a/.depot/workflows/ci.yml
+++ b/.depot/workflows/ci.yml
@@ -1,19 +1,20 @@
-# Depot CI validates the exact merge candidate before it reaches main.
+# Depot CI validates pull requests before they reach main.
 
 name: CI
 
 on:
-  merge_group:
-    types: [checks_requested]
+  pull_request:
+    types: [opened, synchronize, reopened, ready_for_review]
   workflow_dispatch:
 
 concurrency:
-  group: ci-${{ github.ref }}
+  group: ci-${{ github.event.pull_request.number || github.ref }}
   cancel-in-progress: true
 
 jobs:
   check:
     name: Repository checks
+    if: ${{ github.event_name == 'workflow_dispatch' || github.event.pull_request.draft == false }}
     runs-on: depot-ubuntu-24.04-4
     timeout-minutes: 45
     steps:

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -122,7 +122,7 @@ An empty database is a bad test. Seed your worktree's `.akeru` with a copy of re
 ## Pull requests
 
 - Never make a PR unless the developer explicitly asks you to do so.
-- Merge approved pull requests through GitHub's merge queue. Depot checks the queued merge candidate before GitHub writes it to `main`. See [`docs/internals/ci.md`](docs/internals/ci.md) for CI behavior.
+- Merge pull requests only after Depot's required `Repository checks` job passes. See [`docs/internals/ci.md`](docs/internals/ci.md) for CI behavior.
 - Conventional commit titles, plain language: `fix(web): new threads no longer spike CPU`.
 - Body: the problem in a sentence or two, then how you fixed it. End with the model and harness that did the work.
 - UI changes need before/after images. Motion or timing needs a short video.

--- a/docs/internals/ci.md
+++ b/docs/internals/ci.md
@@ -2,12 +2,10 @@
 
 > For Akeru Bot maintainers.
 
-[`.depot/workflows/ci.yml`](../../.depot/workflows/ci.yml) runs when GitHub adds a pull request to the
-merge queue. GitHub creates a temporary merge candidate from the pull request and the latest
-`main`, then Depot validates that exact revision. A failed check removes the pull request from the
-queue. A passing check lets GitHub merge it into `main` automatically. Maintainers can also dispatch
-the workflow manually for diagnostics. The workflow uses one 4-vCPU
-`depot-ubuntu-24.04-4` runner.
+[`.depot/workflows/ci.yml`](../../.depot/workflows/ci.yml) runs on each ready pull request revision.
+Draft pull requests do not use a Depot runner. A new revision cancels the older run for that pull
+request. Maintainers can also dispatch the workflow manually for diagnostics. The workflow uses one
+4-vCPU `depot-ubuntu-24.04-4` runner.
 Issue-label, PR-vouch, and PR-size jobs stay in GitHub Actions on `ubuntu-24.04` because they write GitHub issue and pull-request labels.
 
 - **Repository checks.** The job rejects external local dependencies, installs the committed
@@ -19,9 +17,9 @@ Issue-label, PR-vouch, and PR-size jobs stay in GitHub Actions on `ubuntu-24.04`
   `orchestrationEngine.integration.test.ts` until the executor stack
   restores its test adapter and stops the fixture from calling OpenAI with a test credential.
 
-The repository ruleset requires the merge queue and the Depot `Repository checks` result. Direct
-pushes to `main` cannot bypass this gate. Release workflows start after the validated revision lands
-on `main`; version packaging is separate from the merge queue.
+The repository ruleset requires the Depot `Repository checks` result before a pull request can
+merge. Direct pushes to `main` cannot bypass this gate. Release workflows start after the validated
+revision lands on `main`; version packaging is separate from pull-request CI.
 
 [`.depot/workflows/release-smoke.yml`](../../.depot/workflows/release-smoke.yml) is a manual, non-publishing
 artifact smoke workflow. It uses 4-vCPU Depot runners for Linux, 8-vCPU Windows, plus Apple Silicon

--- a/scripts/ci-workflow-policy.test.ts
+++ b/scripts/ci-workflow-policy.test.ts
@@ -11,6 +11,7 @@ type Step = {
 };
 
 type Job = {
+  readonly if?: string;
   readonly "runs-on": string;
   readonly steps: ReadonlyArray<Step>;
 };
@@ -29,19 +30,24 @@ function workflow(path: string): Workflow {
 }
 
 describe("Depot workflow budget", () => {
-  it("validates the queued merge candidate in one 4-vCPU job", () => {
+  it("validates ready pull requests in one 4-vCPU job", () => {
     const ci = workflow(".depot/workflows/ci.yml");
     const commands = Object.values(ci.jobs).flatMap((job) =>
       job.steps.flatMap((step) => (step.run ? [step.run] : [])),
     );
 
-    expect(Object.keys(ci.on)).toEqual(["merge_group", "workflow_dispatch"]);
-    expect(ci.on.merge_group).toEqual({ types: ["checks_requested"] });
+    expect(Object.keys(ci.on)).toEqual(["pull_request", "workflow_dispatch"]);
+    expect(ci.on.pull_request).toEqual({
+      types: ["opened", "synchronize", "reopened", "ready_for_review"],
+    });
     expect(ci.on).not.toHaveProperty("push");
-    expect(ci.on).not.toHaveProperty("pull_request");
-    expect(ci.concurrency?.group).toBe("ci-${{ github.ref }}");
+    expect(ci.on).not.toHaveProperty("merge_group");
+    expect(ci.concurrency?.group).toBe("ci-${{ github.event.pull_request.number || github.ref }}");
     expect(ci.concurrency?.["cancel-in-progress"]).toBe(true);
     expect(Object.keys(ci.jobs)).toEqual(["check"]);
+    expect(ci.jobs.check?.if).toBe(
+      "${{ github.event_name == 'workflow_dispatch' || github.event.pull_request.draft == false }}",
+    );
     expect(ci.jobs.check?.["runs-on"]).toBe("depot-ubuntu-24.04-4");
 
     for (const command of [


### PR DESCRIPTION
The merge queue adds a workflow step that we do not want for this repository.

This change runs the consolidated Depot job on ready pull requests instead. Drafts use no Depot runner, newer revisions cancel older runs, and GitHub still requires the Depot result before a normal squash merge. The CI documentation and agent instruction now match that behavior.

Verification:
- `vp test run scripts/ci-workflow-policy.test.ts scripts/plugin-contribution-policy.test.ts`
- `vp run release:smoke`
- targeted lint and formatting
- `actionlint -ignore 'label ".+" is unknown' .depot/workflows/*.yml`\n- `git diff --check`\n\nModel: gpt-5.6-sol\nHarness: Codex harness in T3 Code