### PR TITLE
fix(desktop): recover failed update installs

### DIFF
--- a/apps/desktop/src/app/DesktopEnvironment.test.ts
+++ b/apps/desktop/src/app/DesktopEnvironment.test.ts
@@ -118,6 +118,20 @@ describe("DesktopEnvironment", () => {
     }),
   );
 
+  it.effect("ignores an ambient development port in packaged apps", () =>
+    Effect.gen(function* () {
+      const environment = yield* makeEnvironment(
+        {
+          isPackaged: true,
+          appPath: "/Applications/Akeru Bot.app/Contents/Resources/app.asar",
+        },
+        { T3CODE_PORT: "3773" },
+      );
+
+      assert.deepEqual(environment.configuredBackendPort, Option.none());
+    }),
+  );
+
   it.effect("keeps implicit development state separate from production state", () =>
     Effect.gen(function* () {
       const development = yield* makeEnvironment(

--- a/apps/desktop/src/app/DesktopEnvironment.ts
+++ b/apps/desktop/src/app/DesktopEnvironment.ts
@@ -219,7 +219,7 @@ const make = Effect.fn("desktop.environment.make")(function* (
       : path.join(input.appPath, "dev-app-update.yml"),
     devServerUrl,
     devRemoteT3ServerEntryPath: config.devRemoteT3ServerEntryPath,
-    configuredBackendPort: config.configuredBackendPort,
+    configuredBackendPort: input.isPackaged ? Option.none() : config.configuredBackendPort,
     commitHashOverride: config.commitHashOverride,
     otlpTracesUrl: config.otlpTracesUrl,
     otlpExportIntervalMs: config.otlpExportIntervalMs,

--- a/apps/desktop/src/updates/DesktopUpdates.test.ts
+++ b/apps/desktop/src/updates/DesktopUpdates.test.ts
@@ -31,6 +31,7 @@ interface UpdatesHarnessOptions {
   readonly setUpdateChannelError?: DesktopAppSettings.DesktopSettingsWriteError;
   readonly setDisableDifferentialDownload?: Effect.Effect<void>;
   readonly stopBackend?: Effect.Effect<void>;
+  readonly startBackend?: Effect.Effect<void>;
   readonly env?: Record<string, string | undefined>;
 }
 
@@ -116,7 +117,7 @@ function makeHarness(options: UpdatesHarnessOptions = {}) {
   const stubBackendInstance: DesktopBackendPool.DesktopBackendInstance = {
     id: DesktopBackendPool.PRIMARY_INSTANCE_ID,
     label: Effect.succeed("Windows"),
-    start: Effect.void,
+    start: options.startBackend ?? Effect.void,
     stop: () => options.stopBackend ?? Effect.void,
     currentConfig: Effect.succeed(Option.none()),
     snapshot: Effect.succeed({
@@ -538,6 +539,36 @@ describe("DesktopUpdates", () => {
 
         const result = yield* updates.install;
         assert.isTrue(result.accepted);
+      }),
+    ).pipe(Effect.provide(Layer.merge(TestClock.layer(), harness.layer)));
+  });
+
+  it.effect("restarts stopped backends when update installation fails", () => {
+    let starts = 0;
+    const harness = makeHarness({
+      startBackend: Effect.sync(() => {
+        starts += 1;
+      }),
+    });
+
+    return Effect.scoped(
+      Effect.gen(function* () {
+        const desktopState = yield* DesktopState.DesktopState;
+        const updates = yield* DesktopUpdates.DesktopUpdates;
+        yield* updates.configure;
+        harness.emit("update-downloaded", { version: "1.2.4" });
+        yield* flushCallbacks;
+
+        const install = yield* updates.install;
+        assert.isTrue(install.accepted);
+
+        harness.emit("error", new Error("installer failed"));
+        yield* flushCallbacks;
+
+        assert.equal(starts, 1);
+        assert.isFalse(yield* Ref.get(desktopState.quitting));
+        const state = yield* updates.getState;
+        assert.equal(state.errorContext, "install");
       }),
     ).pipe(Effect.provide(Layer.merge(TestClock.layer(), harness.layer)));
   });

--- a/apps/desktop/src/updates/DesktopUpdates.ts
+++ b/apps/desktop/src/updates/DesktopUpdates.ts
@@ -635,6 +635,11 @@ export const make = Effect.gen(function* () {
     if (Option.isSome(activeAction) && activeAction.value === "install") {
       yield* finishUpdateAction("install");
       yield* Ref.set(desktopState.quitting, false);
+      const instances = yield* pool.list;
+      yield* Effect.forEach(instances, (instance) => instance.start, {
+        concurrency: "unbounded",
+        discard: true,
+      });
       yield* updateState((current) =>
         reduceDesktopUpdateStateOnInstallFailure(current, error.message),
       );


### PR DESCRIPTION
Packaged Akeru inherited an ambient T3CODE_PORT, which could send the renderer to another local server while its own backend failed to bind. A failed update install could then leave the old desktop process alive after its backends and windows had stopped.

Packaged builds now ignore the development-only port override and use the existing free-port selection. If the updater reports an install failure, the desktop clears its quitting state and restarts every registered backend so the main window can recover. Focused tests cover both failure paths.

Model: gpt-5.6-sol
Harness: Codex harness in T3 Code