### PR TITLE
fix(desktop): package lazy server dependencies

### DIFF
--- a/apps/server/package.json
+++ b/apps/server/package.json
@@ -47,6 +47,7 @@
     "chat": "4.39.0",
     "e2b": "^2.32.0",
     "effect": "catalog:",
+    "execa": "9.6.1",
     "libsql": "0.5.29",
     "msgpackr-extract": "3.0.4",
     "node-pty": "^1.1.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -522,6 +522,9 @@ importers:
       effect:
         specifier: 4.0.0-beta.103
         version: 4.0.0-beta.103(patch_hash=af36b7948b6f9c56623074662b51dade5699880c1a7c71245de73e13c3185fb6)
+      execa:
+        specifier: 9.6.1
+        version: 9.6.1
       libsql:
         specifier: 0.5.29
         version: 0.5.29

--- a/scripts/build-desktop-artifact.test.ts
+++ b/scripts/build-desktop-artifact.test.ts
@@ -101,6 +101,7 @@ function iconResizeSpawnerLayer(
 
 const makeWindowsPayloadFixture = Effect.fn("test.makeWindowsPayloadFixture")(function* (input: {
   readonly copyUnpackedNatives: boolean;
+  readonly includeLazyRuntimePackage?: boolean;
   readonly serverEntrySource?: string;
 }) {
   const fs = yield* FileSystem.FileSystem;
@@ -111,6 +112,7 @@ const makeWindowsPayloadFixture = Effect.fn("test.makeWindowsPayloadFixture")(fu
   const sourceDir = path.join(tempDir, "server-source");
   const serverEntryPath = path.join(sourceDir, "apps/server/dist/bin.mjs");
   const nativePath = path.join(sourceDir, "node_modules/native/addon.node");
+  const execaManifestPath = path.join(sourceDir, "node_modules/execa/package.json");
   yield* fs.makeDirectory(path.dirname(serverEntryPath), { recursive: true });
   yield* fs.makeDirectory(path.dirname(nativePath), { recursive: true });
   yield* fs.writeFileString(
@@ -119,6 +121,17 @@ const makeWindowsPayloadFixture = Effect.fn("test.makeWindowsPayloadFixture")(fu
       'import { readdirSync } from "node:fs";\nreaddirSync(new URL("../../../../plugins/entries/", import.meta.url));\nconsole.log("server");\n',
   );
   yield* fs.writeFileString(nativePath, "native-binary");
+  if (input.includeLazyRuntimePackage !== false) {
+    yield* fs.makeDirectory(path.dirname(execaManifestPath), { recursive: true });
+    yield* fs.writeFileString(
+      execaManifestPath,
+      '{"name":"execa","version":"9.6.1","type":"module","exports":"./index.js"}',
+    );
+    yield* fs.writeFileString(
+      path.join(sourceDir, "node_modules/execa/index.js"),
+      "export const execa = () => undefined;\n",
+    );
+  }
 
   const generatedAsarPath = path.join(tempDir, WINDOWS_SERVER_ASAR_RESOURCE);
   yield* packWindowsServerAsar({ sourceDir, asarPath: generatedAsarPath, arch: "x64" });
@@ -532,6 +545,7 @@ it.layer(NodeServices.layer)("build-desktop-artifact", (it) => {
           "@ff-labs/fff-node": "0.9.4",
           "@opencode-ai/sdk": "^1.3.15",
           "@pierre/diffs": "1.3.0",
+          execa: "9.6.1",
           libsql: "0.5.29",
           "msgpackr-extract": "3.0.4",
           "node-pty": "1.1.0",
@@ -546,6 +560,7 @@ it.layer(NodeServices.layer)("build-desktop-artifact", (it) => {
       }),
       {
         "@ff-labs/fff-node": "0.9.4",
+        execa: "9.6.1",
         libsql: "0.5.29",
         "msgpackr-extract": "3.0.4",
         "node-pty": "1.1.0",
@@ -973,6 +988,25 @@ it.layer(NodeServices.layer)("build-desktop-artifact", (it) => {
 
         assert.instanceOf(error, BundleNotSelfContainedError);
         assert.include(error.output, "t3code-deliberately-missing-package");
+      }),
+    ),
+  );
+
+  it.effect("rejects a sidecar that omits a lazy runtime package", () =>
+    Effect.scoped(
+      Effect.gen(function* () {
+        const fixture = yield* makeWindowsPayloadFixture({
+          copyUnpackedNatives: true,
+          includeLazyRuntimePackage: false,
+        });
+        const error = yield* validateWindowsPackagedPayload({
+          stageDistDir: fixture.stageDistDir,
+          appExecutableName: fixture.appExecutableName,
+          targetArch: "x64",
+        }).pipe(Effect.flip);
+
+        assert.instanceOf(error, BundleNotSelfContainedError);
+        assert.include(error.output, "Cannot find package 'execa'");
       }),
     ),
   );

--- a/scripts/build-desktop-artifact.ts
+++ b/scripts/build-desktop-artifact.ts
@@ -26,6 +26,7 @@ import {
 } from "./lib/brand-assets.ts";
 import { getDefaultBuildArch } from "./lib/build-target-arch.ts";
 import {
+  CLI_LAZY_RUNTIME_PACKAGES,
   findInlinedExternalPackages,
   selectCliPackagedRuntimeDependencies,
 } from "./lib/cli-external-packages.ts";
@@ -1409,6 +1410,40 @@ const verifyPackagedBundleIsSelfContained = Effect.fn("verifyPackagedBundleIsSel
         ),
       ),
     );
+
+    for (const packageName of CLI_LAZY_RUNTIME_PACKAGES) {
+      yield* runCommand(
+        ChildProcess.make(
+          process.execPath,
+          [
+            "--no-global-search-paths",
+            "--input-type=module",
+            "--eval",
+            "await import(process.argv[1])",
+            packageName,
+          ],
+          {
+            cwd: probeApp,
+            stdout: "pipe",
+            stderr: "pipe",
+            env: { ...process.env, NODE_PATH: "" },
+          },
+        ),
+        {
+          label: `server sidecar lazy dependency check (${packageName})`,
+          verbose: input.verbose,
+        },
+      ).pipe(
+        Effect.catchTag("BuildCommandFailedError", (error) =>
+          Effect.fail(
+            new BundleNotSelfContainedError({
+              exitCode: error.exitCode,
+              output: `${error.stderrTail ?? ""}${error.stdoutTail ?? ""}`.trim(),
+            }),
+          ),
+        ),
+      );
+    }
   },
 );
 

--- a/scripts/lib/cli-external-packages.test.ts
+++ b/scripts/lib/cli-external-packages.test.ts
@@ -100,10 +100,12 @@ describe("selectCliPackagedRuntimeDependencies", () => {
     assert.deepStrictEqual(
       selectCliPackagedRuntimeDependencies({
         effect: "4.0.0",
+        execa: "9.6.1",
         libsql: "0.5.29",
         "node-pty": "1.1.0",
       }),
       {
+        execa: "9.6.1",
         libsql: "0.5.29",
         "node-pty": "1.1.0",
       },

--- a/scripts/lib/cli-external-packages.ts
+++ b/scripts/lib/cli-external-packages.ts
@@ -70,6 +70,11 @@ export const CLI_BUILD_ONLY_EXTERNAL_PREFIXES = [
 // the correct optional binding for the target OS and architecture.
 export const CLI_BUNDLED_NATIVE_RUNTIME_PACKAGES = ["libsql"] as const;
 
+// Mastra constructs this import at runtime to keep Node-only dependencies out
+// of Cloudflare Worker bundles. The CLI bundler cannot see it, so desktop
+// packaging must stage the package and its production dependency closure.
+export const CLI_LAZY_RUNTIME_PACKAGES = ["execa"] as const;
+
 export const CLI_EXTERNAL_PACKAGE_PREFIXES = [
   ...CLI_RUNTIME_EXTERNAL_PREFIXES,
   ...CLI_BUILD_ONLY_EXTERNAL_PREFIXES,
@@ -116,7 +121,8 @@ export function selectCliPackagedRuntimeDependencies(
     Object.entries(dependencies).filter(
       ([name]) =>
         isRuntimeExternalCliDependency(name) ||
-        CLI_BUNDLED_NATIVE_RUNTIME_PACKAGES.some((packageName) => name === packageName),
+        CLI_BUNDLED_NATIVE_RUNTIME_PACKAGES.some((packageName) => name === packageName) ||
+        CLI_LAZY_RUNTIME_PACKAGES.some((packageName) => name === packageName),
     ),
   );
 }


### PR DESCRIPTION
Packaged desktop sessions fail before an agent can use Hoplite because Mastra imports `execa` at runtime and the server sidecar omits that package.

Stage `execa` and its production dependency closure with the other packaged runtime dependencies. Verify every declared lazy dependency can load inside the isolated artifact, and cover the selection and artifact checks with focused tests.

Model: gpt-5.6-sol
Harness: Codex in T3 Code