### PR TITLE
ci: migrate Depot workflows to Tenki

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,4 +1,4 @@
-# Depot CI validates pull requests before they reach main.
+# Tenki CI validates pull requests before they reach main.
 
 name: CI
 
@@ -15,7 +15,7 @@ jobs:
   check:
     name: Repository checks
     if: ${{ github.event_name == 'workflow_dispatch' || github.event.pull_request.draft == false }}
-    runs-on: depot-ubuntu-24.04-4
+    runs-on: tenki-standard-medium-4c-8g
     timeout-minutes: 45
     steps:
       - name: Checkout

--- a/.github/workflows/release-smoke.yml
+++ b/.github/workflows/release-smoke.yml
@@ -1,4 +1,5 @@
-# Depot CI builds smoke artifacts. It does not publish or release them.
+# GitHub Actions builds smoke artifacts on Tenki and GitHub-hosted runners.
+# It does not publish or release them.
 
 name: Release artifact smoke
 
@@ -21,7 +22,7 @@ concurrency:
 jobs:
   release_smoke:
     name: Release configuration
-    runs-on: depot-ubuntu-24.04-4
+    runs-on: tenki-standard-medium-4c-8g
     timeout-minutes: 15
     steps:
       - name: Checkout
@@ -52,21 +53,21 @@ jobs:
       matrix:
         include:
           - label: macOS arm64 DMG
-            runner: depot-macos-15
+            runner: tenki-macos-15-medium
             platform: mac
             target: dmg
             arch: arm64
             extension: dmg
             rust_target: aarch64-apple-darwin
           - label: Windows x64 NSIS
-            runner: depot-windows-2025-8
+            runner: windows-2025
             platform: win
             target: nsis
             arch: x64
             extension: exe
             rust_target: x86_64-pc-windows-msvc
           - label: Linux x64 AppImage
-            runner: depot-ubuntu-24.04-4
+            runner: tenki-standard-medium-4c-8g
             platform: linux
             target: AppImage
             arch: x64
@@ -232,7 +233,7 @@ jobs:
   cli:
     name: CLI package
     needs: release_smoke
-    runs-on: depot-ubuntu-24.04-4
+    runs-on: tenki-standard-medium-4c-8g
     timeout-minutes: 20
     env:
       RELEASE_VERSION: ${{ inputs.version }}
@@ -265,7 +266,7 @@ jobs:
   marketing:
     name: Marketing site
     needs: release_smoke
-    runs-on: depot-ubuntu-24.04-4
+    runs-on: tenki-standard-medium-4c-8g
     timeout-minutes: 15
     steps:
       - name: Checkout

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,6 +1,6 @@
-# Native GitHub runners build every stable asset before the final job creates the tag and release.
+# Tenki and GitHub-hosted runners build every stable asset before the final job creates the tag and release.
 
-name: Stable release native
+name: Stable release
 
 on:
   workflow_dispatch:
@@ -81,7 +81,7 @@ jobs:
       matrix:
         include:
           - label: macOS arm64 DMG
-            runner: macos-15
+            runner: tenki-macos-15-medium
             platform: mac
             target: dmg
             arch: arm64
@@ -93,7 +93,7 @@ jobs:
             arch: x64
             rust_target: x86_64-pc-windows-msvc
           - label: Linux x64 AppImage
-            runner: ubuntu-24.04
+            runner: tenki-standard-medium-4c-8g
             platform: linux
             target: AppImage
             arch: x64

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -123,7 +123,8 @@ jobs:
           sudo apt-get update
           sudo apt-get install -y imagemagick
 
-      - name: Validate signing credentials
+      - name: Validate macOS signing credentials
+        if: matrix.platform == 'mac'
         shell: bash
         env:
           MACOS_CERTIFICATE_P12: ${{ secrets.MACOS_CERTIFICATE_P12 }}
@@ -132,6 +133,19 @@ jobs:
           APPSTORE_API_KEY_P8: ${{ secrets.APPSTORE_API_KEY_P8 }}
           APPSTORE_API_KEY_ID: ${{ secrets.APPSTORE_API_KEY_ID }}
           APPSTORE_ISSUER_ID: ${{ secrets.APPSTORE_ISSUER_ID }}
+        run: |
+          values=("$MACOS_CERTIFICATE_P12" "$MACOS_CERTIFICATE_PASSWORD" "$MACOS_SIGNING_IDENTITY" "$APPSTORE_API_KEY_P8" "$APPSTORE_API_KEY_ID" "$APPSTORE_ISSUER_ID")
+          for value in "${values[@]}"; do
+            if test -z "$value"; then
+              printf 'Stable macOS releases require complete signing and notarization credentials.\n' >&2
+              exit 1
+            fi
+          done
+
+      - name: Validate Windows signing credentials
+        if: matrix.platform == 'win'
+        shell: bash
+        env:
           AZURE_TRUSTED_SIGNING_PUBLISHER_NAME: ${{ secrets.AZURE_TRUSTED_SIGNING_PUBLISHER_NAME }}
           AZURE_TRUSTED_SIGNING_ENDPOINT: ${{ secrets.AZURE_TRUSTED_SIGNING_ENDPOINT }}
           AZURE_TRUSTED_SIGNING_CERTIFICATE_PROFILE_NAME: ${{ secrets.AZURE_TRUSTED_SIGNING_CERTIFICATE_PROFILE_NAME }}
@@ -140,24 +154,14 @@ jobs:
           AZURE_TENANT_ID: ${{ secrets.AZURE_TENANT_ID }}
           AZURE_CLIENT_SECRET: ${{ secrets.AZURE_CLIENT_SECRET }}
         run: |
-          signed=false
-          if test "${{ matrix.platform }}" = mac; then
-            values=("$MACOS_CERTIFICATE_P12" "$MACOS_CERTIFICATE_PASSWORD" "$MACOS_SIGNING_IDENTITY" "$APPSTORE_API_KEY_P8" "$APPSTORE_API_KEY_ID" "$APPSTORE_ISSUER_ID")
-          elif test "${{ matrix.platform }}" = win; then
-            values=("$AZURE_TRUSTED_SIGNING_PUBLISHER_NAME" "$AZURE_TRUSTED_SIGNING_ENDPOINT" "$AZURE_TRUSTED_SIGNING_CERTIFICATE_PROFILE_NAME" "$AZURE_TRUSTED_SIGNING_ACCOUNT_NAME" "$AZURE_CLIENT_ID" "$AZURE_TENANT_ID" "$AZURE_CLIENT_SECRET")
-          else
-            values=()
-          fi
+          values=("$AZURE_TRUSTED_SIGNING_PUBLISHER_NAME" "$AZURE_TRUSTED_SIGNING_ENDPOINT" "$AZURE_TRUSTED_SIGNING_CERTIFICATE_PROFILE_NAME" "$AZURE_TRUSTED_SIGNING_ACCOUNT_NAME" "$AZURE_CLIENT_ID" "$AZURE_TENANT_ID" "$AZURE_CLIENT_SECRET")
           present=0
           for value in "${values[@]}"; do test -n "$value" && present=$((present + 1)); done
-          if test "${{ matrix.platform }}" = mac && (( present != ${#values[@]} )); then
-            printf 'Stable macOS releases require complete signing and notarization credentials.\n' >&2
-            exit 1
-          fi
-          if test "${{ matrix.platform }}" != mac && (( present != 0 && present != ${#values[@]} )); then
+          if (( present != 0 && present != ${#values[@]} )); then
             printf 'Signing credentials must be either complete or absent.\n' >&2
             exit 1
           fi
+          signed=false
           if (( present > 0 )); then signed=true; fi
           printf 'SIGNED=%s\n' "$signed" >> "$GITHUB_ENV"
 
@@ -182,13 +186,27 @@ jobs:
           printf '%s' "$APPSTORE_API_KEY_P8" > "$RUNNER_TEMP/notarytool-api-key.p8"
           chmod 600 "$RUNNER_TEMP/notarytool-api-key.p8"
 
-      - name: Build desktop artifact
+      - name: Build signed macOS artifact
+        if: matrix.platform == 'mac'
         shell: bash
         env:
           APPLE_API_KEY: ${{ runner.temp }}/notarytool-api-key.p8
           APPLE_API_KEY_ID: ${{ secrets.APPSTORE_API_KEY_ID }}
           APPLE_API_ISSUER: ${{ secrets.APPSTORE_ISSUER_ID }}
           CSC_NAME: ${{ secrets.MACOS_SIGNING_IDENTITY }}
+        run: |
+          vp run dist:desktop:artifact \
+            --platform mac \
+            --target dmg \
+            --arch arm64 \
+            --build-version "$RELEASE_VERSION" \
+            --signed \
+            --verbose
+
+      - name: Build Windows artifact
+        if: matrix.platform == 'win'
+        shell: bash
+        env:
           AZURE_TRUSTED_SIGNING_PUBLISHER_NAME: ${{ secrets.AZURE_TRUSTED_SIGNING_PUBLISHER_NAME }}
           AZURE_TRUSTED_SIGNING_ENDPOINT: ${{ secrets.AZURE_TRUSTED_SIGNING_ENDPOINT }}
           AZURE_TRUSTED_SIGNING_CERTIFICATE_PROFILE_NAME: ${{ secrets.AZURE_TRUSTED_SIGNING_CERTIFICATE_PROFILE_NAME }}
@@ -197,9 +215,14 @@ jobs:
           AZURE_TENANT_ID: ${{ secrets.AZURE_TENANT_ID }}
           AZURE_CLIENT_SECRET: ${{ secrets.AZURE_CLIENT_SECRET }}
         run: |
-          args=(--platform "${{ matrix.platform }}" --target "${{ matrix.target }}" --arch "${{ matrix.arch }}" --build-version "$RELEASE_VERSION" --verbose)
+          args=(--platform win --target nsis --arch x64 --build-version "$RELEASE_VERSION" --verbose)
           if test "$SIGNED" = true; then args+=(--signed); fi
           vp run dist:desktop:artifact "${args[@]}"
+
+      - name: Build Linux artifact
+        if: matrix.platform == 'linux'
+        shell: bash
+        run: vp run dist:desktop:artifact --platform linux --target AppImage --arch x64 --build-version "$RELEASE_VERSION" --verbose
 
       - name: Notarize and verify macOS DMG
         if: matrix.platform == 'mac'

--- a/.github/workflows/version-packages.yml
+++ b/.github/workflows/version-packages.yml
@@ -17,7 +17,7 @@ concurrency:
 jobs:
   version:
     name: Update version PR
-    runs-on: depot-ubuntu-24.04-4
+    runs-on: tenki-standard-medium-4c-8g
     timeout-minutes: 15
     steps:
       - name: Checkout

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -122,7 +122,7 @@ An empty database is a bad test. Seed your worktree's `.akeru` with a copy of re
 ## Pull requests
 
 - Never make a PR unless the developer explicitly asks you to do so.
-- Merge pull requests only after Depot's required `Repository checks` job passes. See [`docs/internals/ci.md`](docs/internals/ci.md) for CI behavior.
+- Merge pull requests only after the required `Repository checks` job passes. See [`docs/internals/ci.md`](docs/internals/ci.md) for CI behavior.
 - Conventional commit titles, plain language: `fix(web): new threads no longer spike CPU`.
 - Body: the problem in a sentence or two, then how you fixed it. End with the model and harness that did the work.
 - UI changes need before/after images. Motion or timing needs a short video.

--- a/docs/internals/ci.md
+++ b/docs/internals/ci.md
@@ -2,11 +2,11 @@
 
 > For Akeru Bot maintainers.
 
-[`.depot/workflows/ci.yml`](../../.depot/workflows/ci.yml) runs on each ready pull request revision.
-Draft pull requests do not use a Depot runner. A new revision cancels the older run for that pull
-request. Maintainers can also dispatch the workflow manually for diagnostics. The workflow uses one
-4-vCPU `depot-ubuntu-24.04-4` runner.
-Issue-label, PR-vouch, and PR-size jobs stay in GitHub Actions on `ubuntu-24.04` because they write GitHub issue and pull-request labels.
+[`.github/workflows/ci.yml`](../../.github/workflows/ci.yml) runs on each ready pull request revision.
+Draft pull requests do not use a runner. A new revision cancels the older run for that pull request.
+Maintainers can also dispatch the workflow manually for diagnostics. The workflow uses one 4-vCPU
+`tenki-standard-medium-4c-8g` Linux runner.
+Issue-label, PR-vouch, and PR-size jobs also use Tenki Linux runners through GitHub Actions.
 
 - **Repository checks.** The job rejects external local dependencies, installs the committed
   lockfile once, checks lint and formatting, runs workspace type checks,
@@ -17,23 +17,25 @@ Issue-label, PR-vouch, and PR-size jobs stay in GitHub Actions on `ubuntu-24.04`
   `orchestrationEngine.integration.test.ts` until the executor stack
   restores its test adapter and stops the fixture from calling OpenAI with a test credential.
 
-The repository ruleset requires the Depot `Repository checks` result before a pull request can
+The repository ruleset requires the `Repository checks` result before a pull request can
 merge. Direct pushes to `main` cannot bypass this gate. Release workflows start after the validated
 revision lands on `main`; version packaging is separate from pull-request CI.
 
-[`.depot/workflows/release-smoke.yml`](../../.depot/workflows/release-smoke.yml) is a manual, non-publishing
-artifact smoke workflow. It uses 4-vCPU Depot runners for Linux, 8-vCPU Windows, plus Apple Silicon
-macOS. It builds a Developer ID signed macOS arm64 app. Electron-builder notarizes and staples the
+[`.github/workflows/release-smoke.yml`](../../.github/workflows/release-smoke.yml) is a manual,
+non-publishing artifact smoke workflow. It uses 4-vCPU Tenki runners for Linux and Apple Silicon
+macOS, plus a GitHub-hosted Windows runner. It builds a Developer ID signed macOS arm64 app.
+Electron-builder notarizes and staples the
 app before it packages the DMG. The workflow then submits and staples the DMG as a separate object.
 It checks both objects with Apple's verification tools. Windows and Linux artifacts stay unsigned.
 The workflow also builds and dry-runs the CLI package and checks the marketing site. It uploads
 desktop artifacts for seven days. It does not create a GitHub release, publish a package, or deploy
 a site.
 
-Merging a stable version change to `main` starts [the native stable workflow](../../.github/workflows/release.yml).
-GitHub-hosted macOS, Windows, and Linux runners build the advertised desktop targets before the
-workflow creates the `vX.Y.Z` tag and GitHub Release. The final job verifies the exact asset names
-and `SHA256SUMS`. Missing signing credentials produce unsigned macOS and Windows artifacts.
+Merging a stable version change to `main` starts
+[the stable release workflow](../../.github/workflows/release.yml). Tenki macOS and Linux runners
+plus a GitHub-hosted Windows runner build the advertised desktop targets before the workflow creates
+the `vX.Y.Z` tag and GitHub Release. The final job verifies the exact asset names and `SHA256SUMS`.
+Missing signing credentials produce unsigned macOS and Windows artifacts.
 Unsigned macOS builds still replace Electron's linker-signed stub with a sealed ad-hoc signature
 and fail the release if `codesign --verify` fails or the identifier is not `dev.leodoes.akeru`.
 Complete credentials use the existing Developer ID, notarization, and Azure Trusted Signing paths.

--- a/docs/operations/release.md
+++ b/docs/operations/release.md
@@ -5,8 +5,8 @@
 
 > For Akeru Bot maintainers.
 
-`.depot/workflows/release-smoke.yml` validates release inputs without publishing or releasing anything.
-Dispatch it from Depot with a version such as `0.0.0-smoke.0`.
+`.github/workflows/release-smoke.yml` validates release inputs without publishing or releasing
+anything. Dispatch it from GitHub Actions with a version such as `0.0.0-smoke.0`.
 
 ## What it checks
 
@@ -29,20 +29,19 @@ Each desktop job uploads its artifact to the workflow run for seven days. The wo
 create tags, create GitHub releases, publish npm packages, deploy a site, update AUR, or send
 release announcements.
 
-## Depot setup
+## Runner setup
 
-CI and release smoke run on Depot CI. Code Access is already installed for `opencoredev/akeru-bot`.
-GitHub Actions owns the publishing workflow because Depot does not provide the macOS runner and
-rejects the Windows runner needed for stable desktop artifacts. All Depot smoke jobs use a Depot
-runner label:
+CI and release workflows run through GitHub Actions. Tenki provides Linux and Apple Silicon macOS
+runners. GitHub provides the Windows runner. The Tenki Runner GitHub App must have access to
+`opencoredev/akeru-bot`.
 
-- Linux uses the 4-vCPU `depot-ubuntu-24.04-4` runner.
-- Windows uses the 8-vCPU `depot-windows-2025-8` runner.
-- macOS uses the Apple Silicon `depot-macos-15` image.
+- Linux uses the 4-vCPU `tenki-standard-medium-4c-8g` runner.
+- Windows uses the GitHub-hosted `windows-2025` runner.
+- macOS uses the 4-vCPU Apple Silicon `tenki-macos-15-medium` runner.
 
 ## macOS secrets
 
-Add these Depot CI secrets before running the workflow:
+Add these GitHub Actions secrets before running the workflow:
 
 - `MACOS_CERTIFICATE_P12` contains the base64-encoded `.p12` export of the Developer ID Application
   certificate and its private key.

--- a/scripts/ci-workflow-policy.test.ts
+++ b/scripts/ci-workflow-policy.test.ts
@@ -29,9 +29,9 @@ function workflow(path: string): Workflow {
   return parse(NodeFS.readFileSync(new URL(`../${path}`, import.meta.url), "utf8")) as Workflow;
 }
 
-describe("Depot workflow budget", () => {
+describe("CI workflow budget", () => {
   it("validates ready pull requests in one 4-vCPU job", () => {
-    const ci = workflow(".depot/workflows/ci.yml");
+    const ci = workflow(".github/workflows/ci.yml");
     const commands = Object.values(ci.jobs).flatMap((job) =>
       job.steps.flatMap((step) => (step.run ? [step.run] : [])),
     );
@@ -48,7 +48,7 @@ describe("Depot workflow budget", () => {
     expect(ci.jobs.check?.if).toBe(
       "${{ github.event_name == 'workflow_dispatch' || github.event.pull_request.draft == false }}",
     );
-    expect(ci.jobs.check?.["runs-on"]).toBe("depot-ubuntu-24.04-4");
+    expect(ci.jobs.check?.["runs-on"]).toBe("tenki-standard-medium-4c-8g");
 
     for (const command of [
       "git ls-files .github/pr-assets",
@@ -86,28 +86,30 @@ describe("Depot workflow budget", () => {
   });
 
   it("coalesces version updates on a 4-vCPU runner", () => {
-    const versionPackages = workflow(".depot/workflows/version-packages.yml");
+    const versionPackages = workflow(".github/workflows/version-packages.yml");
     const versionJob = versionPackages.jobs.version;
 
     expect(versionPackages.concurrency).toEqual({
       group: "version-packages",
       "cancel-in-progress": true,
     });
-    expect(versionJob?.["runs-on"]).toBe("depot-ubuntu-24.04-4");
+    expect(versionJob?.["runs-on"]).toBe("tenki-standard-medium-4c-8g");
     expect(versionJob?.steps.find((step) => step.run)?.run).toContain(
       "vp run tegami version --no-checks",
     );
   });
 
   it("uses 4-vCPU Linux runners in the manual release smoke workflow", () => {
-    const releaseSmoke = workflow(".depot/workflows/release-smoke.yml");
+    const releaseSmoke = workflow(".github/workflows/release-smoke.yml");
     const text = NodeFS.readFileSync(
-      new URL("../.depot/workflows/release-smoke.yml", import.meta.url),
+      new URL("../.github/workflows/release-smoke.yml", import.meta.url),
       "utf8",
     );
 
-    expect(text).not.toContain("depot-ubuntu-24.04-8");
-    expect(text).toContain("depot-ubuntu-24.04-4");
+    expect(text).not.toContain("depot-");
+    expect(text).toContain("tenki-standard-medium-4c-8g");
+    expect(text).toContain("tenki-macos-15-medium");
+    expect(text).toContain("windows-2025");
     expect(Object.keys(releaseSmoke.jobs).length).toBeGreaterThan(0);
   });
 });

--- a/scripts/plugin-contribution-policy.test.ts
+++ b/scripts/plugin-contribution-policy.test.ts
@@ -168,7 +168,7 @@ describe("plugin contribution policy", () => {
   });
 
   it("runs catalog validation and contribution policy tests in CI", () => {
-    const ci = yaml(".depot/workflows/ci.yml") as {
+    const ci = yaml(".github/workflows/ci.yml") as {
       jobs: Record<string, { steps?: Array<{ run?: string }> }>;
     };
     const commands = Object.values(ci.jobs).flatMap(

--- a/scripts/release-smoke.ts
+++ b/scripts/release-smoke.ts
@@ -25,24 +25,18 @@ function assertOmits(haystack: string, needle: string, message: string): void {
 }
 
 const releaseWorkflow = read(".github/workflows/release.yml");
-const versionPackagesWorkflow = read(".depot/workflows/version-packages.yml");
-const releaseSmokeWorkflow = read(".depot/workflows/release-smoke.yml");
-const ciWorkflow = read(".depot/workflows/ci.yml");
+const versionPackagesWorkflow = read(".github/workflows/version-packages.yml");
+const releaseSmokeWorkflow = read(".github/workflows/release-smoke.yml");
+const ciWorkflow = read(".github/workflows/ci.yml");
 const desktopArtifactBuilder = read("scripts/build-desktop-artifact.ts");
 const serverCli = read("apps/server/scripts/cli.ts");
 const depotWorkflowDirectory = NodePath.join(repoRoot, ".depot/workflows");
-
-for (const workflowFile of NodeFS.readdirSync(depotWorkflowDirectory)) {
-  if (!workflowFile.endsWith(".yml") && !workflowFile.endsWith(".yaml")) continue;
-  const workflow = read(NodePath.join(".depot/workflows", workflowFile));
-  if (/^\s*(?:runs-on|runner): (?:ubuntu|macos|windows)-/mu.test(workflow)) {
-    throw new Error(`Depot workflow still uses a GitHub-hosted runner: ${workflowFile}.`);
-  }
-}
-
-for (const relativePath of [".github/workflows/ci.yml"] as const) {
-  if (NodeFS.existsSync(NodePath.join(repoRoot, relativePath))) {
-    throw new Error(`GitHub Actions still owns ${relativePath}; move it to .depot/workflows.`);
+if (NodeFS.existsSync(depotWorkflowDirectory)) {
+  const depotWorkflows = NodeFS.readdirSync(depotWorkflowDirectory).filter(
+    (workflowFile) => workflowFile.endsWith(".yml") || workflowFile.endsWith(".yaml"),
+  );
+  if (depotWorkflows.length > 0) {
+    throw new Error(`Retired Depot workflows still exist: ${depotWorkflows.join(", ")}.`);
   }
 }
 
@@ -72,9 +66,9 @@ for (const [needle, label] of [
   ["label: macOS arm64 DMG", "macOS arm64 DMG"],
   ["label: Windows x64 NSIS", "Windows x64 NSIS"],
   ["label: Linux x64 AppImage", "Linux x64 AppImage"],
-  ["runner: depot-macos-15", "Depot macOS runner"],
-  ["runner: depot-windows-2025-8", "8-vCPU Depot Windows runner"],
-  ["runner: depot-ubuntu-24.04-4", "4-vCPU Depot Linux runner"],
+  ["runner: tenki-macos-15-medium", "Tenki macOS runner"],
+  ["runner: windows-2025", "GitHub-hosted Windows runner"],
+  ["runner: tenki-standard-medium-4c-8g", "4-vCPU Tenki Linux runner"],
   [
     "apple-actions/import-codesign-certs@5142e029c445c10ffc7149d172e540235a065466",
     "pinned Developer ID certificate import",
@@ -114,9 +108,9 @@ for (const [needle, label] of [
   ["label: macOS arm64 DMG", "macOS arm64 DMG"],
   ["label: Windows x64 NSIS", "Windows x64 NSIS"],
   ["label: Linux x64 AppImage", "Linux x64 AppImage"],
-  ["runner: macos-15", "GitHub-hosted macOS runner"],
+  ["runner: tenki-macos-15-medium", "Tenki macOS runner"],
   ["runner: windows-2025", "GitHub-hosted Windows runner"],
-  ["runner: ubuntu-24.04", "GitHub-hosted Linux runner"],
+  ["runner: tenki-standard-medium-4c-8g", "Tenki Linux runner"],
   [
     "Stable macOS releases require complete signing and notarization credentials.",
     "required macOS signing credentials",
@@ -174,13 +168,13 @@ for (const [needle, label] of [
 
 assertContains(
   ciWorkflow,
-  "runs-on: depot-ubuntu-24.04-4",
-  "CI does not use 4-vCPU Depot runners.",
+  "runs-on: tenki-standard-medium-4c-8g",
+  "CI does not use 4-vCPU Tenki runners.",
 );
 assertOmits(ciWorkflow, "runs-on: ubuntu-24.04", "GitHub-hosted Linux runners");
-assertOmits(releaseWorkflow, "runner: depot-macos-15", "unavailable Depot macOS runner");
-assertOmits(releaseWorkflow, "runner: depot-windows-2025-8", "unsupported Depot Windows runner");
-assertOmits(releaseWorkflow, "runner: depot-ubuntu-24.04-8", "Depot Linux runner");
+assertOmits(ciWorkflow, "depot-", "Depot runners");
+assertOmits(releaseSmokeWorkflow, "depot-", "Depot runners");
+assertOmits(releaseWorkflow, "depot-", "Depot runners");
 assertOmits(
   desktopArtifactBuilder,
   'const DESKTOP_APP_ID = "com.t3tools.t3code"',

--- a/scripts/release-smoke.ts
+++ b/scripts/release-smoke.ts
@@ -7,6 +7,7 @@ import * as NodeURL from "node:url";
 
 import * as Console from "effect/Console";
 import * as Effect from "effect/Effect";
+import { parse } from "yaml";
 
 import { checkPublicDependencies } from "./check-public-dependencies.ts";
 
@@ -157,6 +158,30 @@ const desktopJobHeader = /\n  desktop:\n([\s\S]*?)\n    strategy:/u.exec(release
 if (!desktopJobHeader) throw new Error("Stable release workflow is missing the desktop job.");
 assertOmits(desktopJobHeader, "secrets.", "Desktop signing secrets are scoped at the job level");
 assertOmits(releaseWorkflow, "macOS x64", "unadvertised macOS x64 build");
+
+const parsedReleaseWorkflow = parse(releaseWorkflow) as {
+  readonly jobs?: {
+    readonly desktop?: {
+      readonly steps?: ReadonlyArray<{
+        readonly name?: string;
+        readonly if?: string;
+        readonly env?: Readonly<Record<string, string>>;
+        readonly with?: Readonly<Record<string, string>>;
+      }>;
+    };
+  };
+};
+for (const step of parsedReleaseWorkflow.jobs?.desktop?.steps ?? []) {
+  const secretInputs = JSON.stringify({ env: step.env, with: step.with });
+  if (/MACOS_|APPSTORE_|APPLE_API_/u.test(secretInputs) && step.if !== "matrix.platform == 'mac'") {
+    throw new Error(`${step.name ?? "Unnamed step"} exposes macOS secrets outside the macOS job.`);
+  }
+  if (/AZURE_/u.test(secretInputs) && step.if !== "matrix.platform == 'win'") {
+    throw new Error(
+      `${step.name ?? "Unnamed step"} exposes Windows secrets outside the Windows job.`,
+    );
+  }
+}
 
 for (const [needle, label] of [
   ["blacksmith", "private CI runners"],


### PR DESCRIPTION
Depot still owned the required pull-request checks, release smoke builds, and version-package workflow after the first Tenki migration. Stable releases also kept Linux and macOS on GitHub-hosted runners.

Move all active Depot workflows into GitHub Actions. Run Linux and Apple Silicon macOS jobs on Tenki, keep Windows on the native GitHub runner, and preserve the existing checks, signing, notarization, and artifact paths. Update the workflow policy tests, release smoke validation, and maintainer documentation to enforce the new runner split.

Verification:
- `vp test run scripts/ci-workflow-policy.test.ts scripts/plugin-contribution-policy.test.ts scripts/check-public-dependencies.test.ts scripts/resolve-previous-release-tag.test.ts`
- `vp run release:smoke`
- targeted `vp fmt --check`
- `actionlint` with Tenki custom runner labels allowed

Model: gpt-5.6-sol
Harness: Codex harness in T3 Code