### PR TITLE
ci: finish migration from Depot to Tenki

### DIFF
--- a/.depot/workflows/ci.yml
+++ b/.depot/workflows/ci.yml
@@ -19,7 +19,7 @@ jobs:
     timeout-minutes: 45
     steps:
       - name: Checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6
 
       - name: Reject repository-owned PR assets
         run: |
@@ -30,7 +30,7 @@ jobs:
           fi
 
       - name: Setup Vite+
-        uses: voidzero-dev/setup-vp@v1
+        uses: voidzero-dev/setup-vp@8a7496fd44e8a1b0a88a7459e36213b2fefc1d15 # v1
         with:
           node-version-file: package.json
           cache: true
@@ -86,7 +86,7 @@ jobs:
           --exclude integration/orchestrationEngine.integration.test.ts
 
       - name: Setup Rust
-        uses: dtolnay/rust-toolchain@stable
+        uses: dtolnay/rust-toolchain@4360b52568e2003a75bf9bc1d59f33a8e3fc893c # stable
         with:
           components: rustfmt
 

--- a/.depot/workflows/ci.yml
+++ b/.depot/workflows/ci.yml
@@ -1,0 +1,100 @@
+# Bootstrap PR #160 only. Remove this file after the Tenki workflow reaches main.
+
+name: CI
+
+on:
+  pull_request:
+    types: [opened, synchronize, reopened, ready_for_review]
+  workflow_dispatch:
+
+concurrency:
+  group: ci-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  check:
+    name: Repository checks
+    if: ${{ github.head_ref == 't3code/migrate-ci-off-depot' && github.event.pull_request.draft == false }}
+    runs-on: depot-ubuntu-24.04-4
+    timeout-minutes: 45
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+
+      - name: Reject repository-owned PR assets
+        run: |
+          files="$(git ls-files .github/pr-assets)"
+          if test -n "$files"; then
+            printf 'PR evidence must be uploaded to GitHub, not committed:\n%s\n' "$files" >&2
+            exit 1
+          fi
+
+      - name: Setup Vite+
+        uses: voidzero-dev/setup-vp@v1
+        with:
+          node-version-file: package.json
+          cache: true
+          run-install: false
+
+      - name: Reject dependencies outside the repository
+        run: node scripts/check-public-dependencies.ts
+
+      - name: Install from the committed lockfile
+        run: vp install --frozen-lockfile
+
+      - name: Ensure Electron runtime is installed
+        run: vp run --filter @t3tools/desktop ensure:electron
+
+      - name: Validate plugin catalog
+        run: node scripts/validate-plugin-catalog.ts
+
+      - name: Test plugin catalog and contribution policy
+        run: >-
+          vp test run
+          scripts/validate-plugin-catalog.test.ts
+          scripts/plugin-contribution-policy.test.ts
+          plugins/catalog.test.ts
+          plugins/schema.test.ts
+          plugins/lifecycle-matrix.test.ts
+
+      - name: Lint
+        run: vp run lint
+
+      - name: Check formatting
+        run: vp run fmt:check
+
+      - name: Typecheck
+        run: vp run typecheck
+
+      - name: Build desktop pipeline
+        run: vp run build:desktop
+
+      - name: Verify preload bundle output
+        run: |
+          test -f apps/desktop/dist-electron/preload.cjs
+          grep -nE "desktopBridge|getLocalEnvironmentBootstrap|PICK_FOLDER_CHANNEL|wsUrl" apps/desktop/dist-electron/preload.cjs
+
+      - name: Build marketing site
+        run: vp run build:marketing
+
+      - name: Test shipped desktop and shared packages
+        run: vp run --parallel --concurrency-limit 4 --filter '!akeru-bot' --filter '!t3code-relay' --filter '!@t3tools/monorepo' --filter '!@t3tools/mobile' test
+
+      - name: Test isolated server suite
+        run: >-
+          vp run --filter akeru-bot test
+          --exclude integration/orchestrationEngine.integration.test.ts
+
+      - name: Setup Rust
+        uses: dtolnay/rust-toolchain@stable
+        with:
+          components: rustfmt
+
+      - name: Check resource monitor formatting
+        run: cargo fmt --manifest-path native/resource-monitor/Cargo.toml -- --check
+
+      - name: Test resource monitor
+        run: cargo test --locked --manifest-path native/resource-monitor/Cargo.toml
+
+      - name: Exercise release-only configuration
+        run: vp run release:smoke

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,4 +1,4 @@
-# Depot CI validates pull requests before they reach main.
+# Tenki validates pull requests before they reach main.
 
 name: CI
 
@@ -15,7 +15,7 @@ jobs:
   check:
     name: Repository checks
     if: ${{ github.event_name == 'workflow_dispatch' || github.event.pull_request.draft == false }}
-    runs-on: depot-ubuntu-24.04-4
+    runs-on: tenki-standard-medium-4c-8g
     timeout-minutes: 45
     steps:
       - name: Checkout

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,7 +19,7 @@ jobs:
     timeout-minutes: 45
     steps:
       - name: Checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6
 
       - name: Reject repository-owned PR assets
         run: |
@@ -30,7 +30,7 @@ jobs:
           fi
 
       - name: Setup Vite+
-        uses: voidzero-dev/setup-vp@v1
+        uses: voidzero-dev/setup-vp@8a7496fd44e8a1b0a88a7459e36213b2fefc1d15 # v1
         with:
           node-version-file: package.json
           cache: true
@@ -86,7 +86,7 @@ jobs:
           --exclude integration/orchestrationEngine.integration.test.ts
 
       - name: Setup Rust
-        uses: dtolnay/rust-toolchain@stable
+        uses: dtolnay/rust-toolchain@4360b52568e2003a75bf9bc1d59f33a8e3fc893c # stable
         with:
           components: rustfmt
 

--- a/.github/workflows/release-smoke.yml
+++ b/.github/workflows/release-smoke.yml
@@ -1,4 +1,4 @@
-# Depot CI builds smoke artifacts. It does not publish or release them.
+# This workflow builds smoke artifacts. It does not publish or release them.
 
 name: Release artifact smoke
 
@@ -21,7 +21,7 @@ concurrency:
 jobs:
   release_smoke:
     name: Release configuration
-    runs-on: depot-ubuntu-24.04-4
+    runs-on: tenki-standard-medium-4c-8g
     timeout-minutes: 15
     steps:
       - name: Checkout
@@ -52,21 +52,21 @@ jobs:
       matrix:
         include:
           - label: macOS arm64 DMG
-            runner: depot-macos-15
+            runner: tenki-macos-15-small
             platform: mac
             target: dmg
             arch: arm64
             extension: dmg
             rust_target: aarch64-apple-darwin
           - label: Windows x64 NSIS
-            runner: depot-windows-2025-8
+            runner: windows-2025
             platform: win
             target: nsis
             arch: x64
             extension: exe
             rust_target: x86_64-pc-windows-msvc
           - label: Linux x64 AppImage
-            runner: depot-ubuntu-24.04-4
+            runner: tenki-standard-medium-4c-8g
             platform: linux
             target: AppImage
             arch: x64
@@ -232,7 +232,7 @@ jobs:
   cli:
     name: CLI package
     needs: release_smoke
-    runs-on: depot-ubuntu-24.04-4
+    runs-on: tenki-standard-medium-4c-8g
     timeout-minutes: 20
     env:
       RELEASE_VERSION: ${{ inputs.version }}
@@ -265,7 +265,7 @@ jobs:
   marketing:
     name: Marketing site
     needs: release_smoke
-    runs-on: depot-ubuntu-24.04-4
+    runs-on: tenki-standard-medium-4c-8g
     timeout-minutes: 15
     steps:
       - name: Checkout

--- a/.github/workflows/release-smoke.yml
+++ b/.github/workflows/release-smoke.yml
@@ -25,10 +25,10 @@ jobs:
     timeout-minutes: 15
     steps:
       - name: Checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6
 
       - name: Setup Vite+
-        uses: voidzero-dev/setup-vp@v1
+        uses: voidzero-dev/setup-vp@8a7496fd44e8a1b0a88a7459e36213b2fefc1d15 # v1
         with:
           node-version-file: package.json
           cache: true
@@ -74,10 +74,10 @@ jobs:
             rust_target: x86_64-unknown-linux-gnu
     steps:
       - name: Checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6
 
       - name: Setup Vite+
-        uses: voidzero-dev/setup-vp@v1
+        uses: voidzero-dev/setup-vp@8a7496fd44e8a1b0a88a7459e36213b2fefc1d15 # v1
         with:
           node-version-file: package.json
           cache: ${{ matrix.platform != 'win' }}
@@ -87,7 +87,7 @@ jobs:
         run: vp install --frozen-lockfile --filter=@t3tools/desktop... --filter=akeru-bot... --filter=@t3tools/scripts...
 
       - name: Setup Rust
-        uses: dtolnay/rust-toolchain@stable
+        uses: dtolnay/rust-toolchain@4360b52568e2003a75bf9bc1d59f33a8e3fc893c # stable
         with:
           targets: ${{ matrix.rust_target }}
 
@@ -238,10 +238,10 @@ jobs:
       RELEASE_VERSION: ${{ inputs.version }}
     steps:
       - name: Checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6
 
       - name: Setup Vite+
-        uses: voidzero-dev/setup-vp@v1
+        uses: voidzero-dev/setup-vp@8a7496fd44e8a1b0a88a7459e36213b2fefc1d15 # v1
         with:
           node-version-file: package.json
           cache: true
@@ -269,10 +269,10 @@ jobs:
     timeout-minutes: 15
     steps:
       - name: Checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6
 
       - name: Setup Vite+
-        uses: voidzero-dev/setup-vp@v1
+        uses: voidzero-dev/setup-vp@8a7496fd44e8a1b0a88a7459e36213b2fefc1d15 # v1
         with:
           node-version-file: package.json
           cache: true

--- a/.github/workflows/version-packages.yml
+++ b/.github/workflows/version-packages.yml
@@ -17,7 +17,7 @@ concurrency:
 jobs:
   version:
     name: Update version PR
-    runs-on: depot-ubuntu-24.04-4
+    runs-on: tenki-standard-medium-4c-8g
     timeout-minutes: 15
     steps:
       - name: Checkout

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -122,7 +122,7 @@ An empty database is a bad test. Seed your worktree's `.akeru` with a copy of re
 ## Pull requests
 
 - Never make a PR unless the developer explicitly asks you to do so.
-- Merge pull requests only after Depot's required `Repository checks` job passes. See [`docs/internals/ci.md`](docs/internals/ci.md) for CI behavior.
+- Merge pull requests only after the required `Repository checks` job passes. See [`docs/internals/ci.md`](docs/internals/ci.md) for CI behavior.
 - Conventional commit titles, plain language: `fix(web): new threads no longer spike CPU`.
 - Body: the problem in a sentence or two, then how you fixed it. End with the model and harness that did the work.
 - UI changes need before/after images. Motion or timing needs a short video.

--- a/docs/internals/ci.md
+++ b/docs/internals/ci.md
@@ -2,11 +2,12 @@
 
 > For Akeru Bot maintainers.
 
-[`.depot/workflows/ci.yml`](../../.depot/workflows/ci.yml) runs on each ready pull request revision.
-Draft pull requests do not use a Depot runner. A new revision cancels the older run for that pull
+[`.github/workflows/ci.yml`](../../.github/workflows/ci.yml) runs on each ready pull request revision.
+Draft pull requests do not use a runner. A new revision cancels the older run for that pull
 request. Maintainers can also dispatch the workflow manually for diagnostics. The workflow uses one
-4-vCPU `depot-ubuntu-24.04-4` runner.
-Issue-label, PR-vouch, and PR-size jobs stay in GitHub Actions on `ubuntu-24.04` because they write GitHub issue and pull-request labels.
+4-vCPU `tenki-standard-medium-4c-8g` runner.
+Issue-label, PR-vouch, and PR-size jobs use the 2-vCPU
+`tenki-standard-small-2c-4g` runner.
 
 - **Repository checks.** The job rejects external local dependencies, installs the committed
   lockfile once, checks lint and formatting, runs workspace type checks,
@@ -17,13 +18,14 @@ Issue-label, PR-vouch, and PR-size jobs stay in GitHub Actions on `ubuntu-24.04`
   `orchestrationEngine.integration.test.ts` until the executor stack
   restores its test adapter and stops the fixture from calling OpenAI with a test credential.
 
-The repository ruleset requires the Depot `Repository checks` result before a pull request can
+The repository ruleset requires the `Repository checks` result before a pull request can
 merge. Direct pushes to `main` cannot bypass this gate. Release workflows start after the validated
 revision lands on `main`; version packaging is separate from pull-request CI.
 
-[`.depot/workflows/release-smoke.yml`](../../.depot/workflows/release-smoke.yml) is a manual, non-publishing
-artifact smoke workflow. It uses 4-vCPU Depot runners for Linux, 8-vCPU Windows, plus Apple Silicon
-macOS. It builds a Developer ID signed macOS arm64 app. Electron-builder notarizes and staples the
+[`.github/workflows/release-smoke.yml`](../../.github/workflows/release-smoke.yml) is a manual,
+non-publishing artifact smoke workflow. It uses 4-vCPU Tenki runners for Linux and Apple Silicon
+macOS, plus GitHub's Windows runner. It builds a Developer ID signed macOS arm64 app.
+Electron-builder notarizes and staples the
 app before it packages the DMG. The workflow then submits and staples the DMG as a separate object.
 It checks both objects with Apple's verification tools. Windows and Linux artifacts stay unsigned.
 The workflow also builds and dry-runs the CLI package and checks the marketing site. It uploads

--- a/docs/operations/release.md
+++ b/docs/operations/release.md
@@ -5,8 +5,8 @@
 
 > For Akeru Bot maintainers.
 
-`.depot/workflows/release-smoke.yml` validates release inputs without publishing or releasing anything.
-Dispatch it from Depot with a version such as `0.0.0-smoke.0`.
+`.github/workflows/release-smoke.yml` validates release inputs without publishing or releasing
+anything. Dispatch it from GitHub Actions with a version such as `0.0.0-smoke.0`.
 
 ## What it checks
 
@@ -27,20 +27,18 @@ Each desktop job uploads its artifact to the workflow run for seven days. The wo
 create tags, create GitHub releases, publish npm packages, deploy a site, update AUR, or send
 release announcements.
 
-## Depot setup
+## Runner setup
 
-CI and release smoke run on Depot CI. Code Access is already installed for `opencoredev/akeru-bot`.
-GitHub Actions owns the publishing workflow because Depot does not provide the macOS runner and
-rejects the Windows runner needed for stable desktop artifacts. All Depot smoke jobs use a Depot
-runner label:
+CI and release smoke run through GitHub Actions. Tenki supplies the Linux and macOS runners.
+GitHub supplies the Windows runner because Tenki does not provide Windows runners:
 
-- Linux uses the 4-vCPU `depot-ubuntu-24.04-4` runner.
-- Windows uses the 8-vCPU `depot-windows-2025-8` runner.
-- macOS uses the Apple Silicon `depot-macos-15` image.
+- Linux uses the 4-vCPU `tenki-standard-medium-4c-8g` runner.
+- Windows uses the GitHub-hosted `windows-2025` runner.
+- macOS uses the 4-vCPU Apple Silicon `tenki-macos-15-small` runner.
 
 ## macOS secrets
 
-Add these Depot CI secrets before running the workflow:
+Add these GitHub Actions secrets before running the workflow:
 
 - `MACOS_CERTIFICATE_P12` contains the base64-encoded `.p12` export of the Developer ID Application
   certificate and its private key.

--- a/scripts/ci-workflow-policy.test.ts
+++ b/scripts/ci-workflow-policy.test.ts
@@ -29,9 +29,9 @@ function workflow(path: string): Workflow {
   return parse(NodeFS.readFileSync(new URL(`../${path}`, import.meta.url), "utf8")) as Workflow;
 }
 
-describe("Depot workflow budget", () => {
+describe("CI workflow budget", () => {
   it("validates ready pull requests in one 4-vCPU job", () => {
-    const ci = workflow(".depot/workflows/ci.yml");
+    const ci = workflow(".github/workflows/ci.yml");
     const commands = Object.values(ci.jobs).flatMap((job) =>
       job.steps.flatMap((step) => (step.run ? [step.run] : [])),
     );
@@ -48,7 +48,7 @@ describe("Depot workflow budget", () => {
     expect(ci.jobs.check?.if).toBe(
       "${{ github.event_name == 'workflow_dispatch' || github.event.pull_request.draft == false }}",
     );
-    expect(ci.jobs.check?.["runs-on"]).toBe("depot-ubuntu-24.04-4");
+    expect(ci.jobs.check?.["runs-on"]).toBe("tenki-standard-medium-4c-8g");
 
     for (const command of [
       "git ls-files .github/pr-assets",
@@ -86,28 +86,28 @@ describe("Depot workflow budget", () => {
   });
 
   it("coalesces version updates on a 4-vCPU runner", () => {
-    const versionPackages = workflow(".depot/workflows/version-packages.yml");
+    const versionPackages = workflow(".github/workflows/version-packages.yml");
     const versionJob = versionPackages.jobs.version;
 
     expect(versionPackages.concurrency).toEqual({
       group: "version-packages",
       "cancel-in-progress": true,
     });
-    expect(versionJob?.["runs-on"]).toBe("depot-ubuntu-24.04-4");
+    expect(versionJob?.["runs-on"]).toBe("tenki-standard-medium-4c-8g");
     expect(versionJob?.steps.find((step) => step.run)?.run).toContain(
       "vp run tegami version --no-checks",
     );
   });
 
   it("uses 4-vCPU Linux runners in the manual release smoke workflow", () => {
-    const releaseSmoke = workflow(".depot/workflows/release-smoke.yml");
+    const releaseSmoke = workflow(".github/workflows/release-smoke.yml");
     const text = NodeFS.readFileSync(
-      new URL("../.depot/workflows/release-smoke.yml", import.meta.url),
+      new URL("../.github/workflows/release-smoke.yml", import.meta.url),
       "utf8",
     );
 
-    expect(text).not.toContain("depot-ubuntu-24.04-8");
-    expect(text).toContain("depot-ubuntu-24.04-4");
+    expect(text).not.toContain("tenki-standard-large-8c-16g");
+    expect(text).toContain("tenki-standard-medium-4c-8g");
     expect(Object.keys(releaseSmoke.jobs).length).toBeGreaterThan(0);
   });
 });

--- a/scripts/plugin-contribution-policy.test.ts
+++ b/scripts/plugin-contribution-policy.test.ts
@@ -168,7 +168,7 @@ describe("plugin contribution policy", () => {
   });
 
   it("runs catalog validation and contribution policy tests in CI", () => {
-    const ci = yaml(".depot/workflows/ci.yml") as {
+    const ci = yaml(".github/workflows/ci.yml") as {
       jobs: Record<string, { steps?: Array<{ run?: string }> }>;
     };
     const commands = Object.values(ci.jobs).flatMap(

--- a/scripts/release-smoke.ts
+++ b/scripts/release-smoke.ts
@@ -31,7 +31,6 @@ const ciWorkflow = read(".github/workflows/ci.yml");
 const desktopArtifactBuilder = read("scripts/build-desktop-artifact.ts");
 const serverCli = read("apps/server/scripts/cli.ts");
 for (const relativePath of [
-  ".depot/workflows/ci.yml",
   ".depot/workflows/release-smoke.yml",
   ".depot/workflows/version-packages.yml",
 ] as const) {
@@ -39,6 +38,13 @@ for (const relativePath of [
     throw new Error(`Depot still owns ${relativePath}; move it to .github/workflows.`);
   }
 }
+
+const depotBootstrapWorkflow = read(".depot/workflows/ci.yml");
+assertContains(
+  depotBootstrapWorkflow,
+  "github.head_ref == 't3code/migrate-ci-off-depot'",
+  "Depot CI is not limited to the Tenki migration pull request.",
+);
 
 assertContains(
   desktopArtifactBuilder,

--- a/scripts/release-smoke.ts
+++ b/scripts/release-smoke.ts
@@ -25,24 +25,18 @@ function assertOmits(haystack: string, needle: string, message: string): void {
 }
 
 const releaseWorkflow = read(".github/workflows/release.yml");
-const versionPackagesWorkflow = read(".depot/workflows/version-packages.yml");
-const releaseSmokeWorkflow = read(".depot/workflows/release-smoke.yml");
-const ciWorkflow = read(".depot/workflows/ci.yml");
+const versionPackagesWorkflow = read(".github/workflows/version-packages.yml");
+const releaseSmokeWorkflow = read(".github/workflows/release-smoke.yml");
+const ciWorkflow = read(".github/workflows/ci.yml");
 const desktopArtifactBuilder = read("scripts/build-desktop-artifact.ts");
 const serverCli = read("apps/server/scripts/cli.ts");
-const depotWorkflowDirectory = NodePath.join(repoRoot, ".depot/workflows");
-
-for (const workflowFile of NodeFS.readdirSync(depotWorkflowDirectory)) {
-  if (!workflowFile.endsWith(".yml") && !workflowFile.endsWith(".yaml")) continue;
-  const workflow = read(NodePath.join(".depot/workflows", workflowFile));
-  if (/^\s*(?:runs-on|runner): (?:ubuntu|macos|windows)-/mu.test(workflow)) {
-    throw new Error(`Depot workflow still uses a GitHub-hosted runner: ${workflowFile}.`);
-  }
-}
-
-for (const relativePath of [".github/workflows/ci.yml"] as const) {
+for (const relativePath of [
+  ".depot/workflows/ci.yml",
+  ".depot/workflows/release-smoke.yml",
+  ".depot/workflows/version-packages.yml",
+] as const) {
   if (NodeFS.existsSync(NodePath.join(repoRoot, relativePath))) {
-    throw new Error(`GitHub Actions still owns ${relativePath}; move it to .depot/workflows.`);
+    throw new Error(`Depot still owns ${relativePath}; move it to .github/workflows.`);
   }
 }
 
@@ -72,9 +66,9 @@ for (const [needle, label] of [
   ["label: macOS arm64 DMG", "macOS arm64 DMG"],
   ["label: Windows x64 NSIS", "Windows x64 NSIS"],
   ["label: Linux x64 AppImage", "Linux x64 AppImage"],
-  ["runner: depot-macos-15", "Depot macOS runner"],
-  ["runner: depot-windows-2025-8", "8-vCPU Depot Windows runner"],
-  ["runner: depot-ubuntu-24.04-4", "4-vCPU Depot Linux runner"],
+  ["runner: tenki-macos-15-small", "4-vCPU Tenki macOS runner"],
+  ["runner: windows-2025", "GitHub-hosted Windows runner"],
+  ["runner: tenki-standard-medium-4c-8g", "4-vCPU Tenki Linux runner"],
   [
     "apple-actions/import-codesign-certs@5142e029c445c10ffc7149d172e540235a065466",
     "pinned Developer ID certificate import",
@@ -166,10 +160,10 @@ for (const [needle, label] of [
 
 assertContains(
   ciWorkflow,
-  "runs-on: depot-ubuntu-24.04-4",
-  "CI does not use 4-vCPU Depot runners.",
+  "runs-on: tenki-standard-medium-4c-8g",
+  "CI does not use 4-vCPU Tenki runners.",
 );
-assertOmits(ciWorkflow, "runs-on: ubuntu-24.04", "GitHub-hosted Linux runners");
+assertOmits(ciWorkflow, "runs-on: depot-", "Depot runners");
 assertOmits(releaseWorkflow, "runner: depot-macos-15", "unavailable Depot macOS runner");
 assertOmits(releaseWorkflow, "runner: depot-windows-2025-8", "unsupported Depot Windows runner");
 assertOmits(releaseWorkflow, "runner: depot-ubuntu-24.04-8", "Depot Linux runner");

--- a/scripts/release-smoke.ts
+++ b/scripts/release-smoke.ts
@@ -39,12 +39,14 @@ for (const relativePath of [
   }
 }
 
-const depotBootstrapWorkflow = read(".depot/workflows/ci.yml");
-assertContains(
-  depotBootstrapWorkflow,
-  "github.head_ref == 't3code/migrate-ci-off-depot'",
-  "Depot CI is not limited to the Tenki migration pull request.",
-);
+const depotBootstrapPath = NodePath.join(repoRoot, ".depot/workflows/ci.yml");
+if (NodeFS.existsSync(depotBootstrapPath)) {
+  assertContains(
+    NodeFS.readFileSync(depotBootstrapPath, "utf8"),
+    "github.head_ref == 't3code/migrate-ci-off-depot'",
+    "Depot CI is not limited to the Tenki migration pull request.",
+  );
+}
 
 assertContains(
   desktopArtifactBuilder,


### PR DESCRIPTION
PR #146 moved the existing GitHub Actions jobs to Tenki, but the required repository checks, version packaging, and release smoke workflows remained under Depot. New pull requests therefore continued to run the required CI job on Depot.

This moves the remaining workflows into GitHub Actions and assigns Tenki Linux and macOS runners. The release smoke matrix keeps GitHub's Windows runner because Tenki does not provide Windows runners. It also updates the workflow policy tests, release validator, and maintainer documentation.

GitHub does not run a newly added `pull_request` workflow until it exists on the default branch. The old Depot CI file is therefore retained as a bootstrap and limited to this branch. After this PR merges, Tenki owns `CI / Repository checks`; a follow-up removes the inactive bootstrap file.

Verification:
- `vp test run scripts/ci-workflow-policy.test.ts scripts/plugin-contribution-policy.test.ts`
- `vp run release:smoke`
- `actionlint` on the migrated workflows
- `git diff --check`

Model: gpt-5.6-sol
Harness: Codex in T3 Code