### PR TITLE
test(ci): verify Tenki pull request checks

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,4 +1,4 @@
-# Tenki CI validates pull requests before they reach main.
+# Tenki runs the required checks before pull requests reach main.
 
 name: CI
 


### PR DESCRIPTION
The Depot-to-Tenki migration is merged, but it needs one live pull-request run to prove that the required check uses the new runner.

This comment-only change triggers `CI / Repository checks` without changing runtime behavior. The PR will close after the check passes and the runner source is verified.

Verification:
- `actionlint` with the Tenki custom runner label allowed
- `git diff --check`

Model: gpt-5.6-sol
Harness: Codex in T3 Code