### PR TITLE
chore(release): version packages for v0.0.39

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -25,6 +25,7 @@ jobs:
     runs-on: tenki-standard-small-2c-4g
     timeout-minutes: 15
     outputs:
+      publish: ${{ steps.version.outputs.publish }}
       version: ${{ steps.version.outputs.version }}
       tag: ${{ steps.version.outputs.tag }}
     steps:
@@ -36,6 +37,8 @@ jobs:
       - name: Read stable version
         id: version
         shell: bash
+        env:
+          EVENT_NAME: ${{ github.event_name }}
         run: |
           version="$(node -p "require('./apps/server/package.json').version")"
           if ! [[ "$version" =~ ^[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
@@ -49,13 +52,29 @@ jobs:
               exit 1
             fi
           done
+          if test "$EVENT_NAME" != workflow_dispatch; then
+            previous_version="$(git show "HEAD^:apps/server/package.json" | node -e "let data=''; process.stdin.on('data', chunk => data += chunk).on('end', () => console.log(JSON.parse(data).version))")"
+            for manifest in apps/desktop/package.json apps/web/package.json packages/contracts/package.json; do
+              previous="$(git show "HEAD^:$manifest" | node -e "let data=''; process.stdin.on('data', chunk => data += chunk).on('end', () => console.log(JSON.parse(data).version))")"
+              if test "$previous" != "$previous_version"; then
+                printf 'Previous package versions were not synchronized.\n' >&2
+                exit 1
+              fi
+            done
+            if test "$previous_version" = "$version"; then
+              printf 'publish=false\n' >> "$GITHUB_OUTPUT"
+              printf 'Stable version did not change; this push is not a release.\n'
+              exit 0
+            fi
+          fi
           if git rev-parse --verify --quiet "refs/tags/v$version"; then
             printf 'Stable tag v%s already exists.\n' "$version" >&2
             exit 1
           fi
-          printf 'version=%s\ntag=v%s\n' "$version" "$version" >> "$GITHUB_OUTPUT"
+          printf 'publish=true\nversion=%s\ntag=v%s\n' "$version" "$version" >> "$GITHUB_OUTPUT"
 
       - name: Setup Vite+
+        if: steps.version.outputs.publish == 'true'
         uses: voidzero-dev/setup-vp@v1
         with:
           node-version-file: package.json
@@ -63,6 +82,7 @@ jobs:
           run-install: true
 
       - name: Run release checks
+        if: steps.version.outputs.publish == 'true'
         run: |
           vp run check:public-dependencies
           vp run release:smoke
@@ -71,6 +91,7 @@ jobs:
   desktop:
     name: ${{ matrix.label }}
     needs: preflight
+    if: needs.preflight.outputs.publish == 'true'
     runs-on: ${{ matrix.runner }}
     timeout-minutes: 45
     env:
@@ -264,6 +285,7 @@ jobs:
   release:
     name: Publish stable release
     needs: [preflight, desktop]
+    if: needs.preflight.outputs.publish == 'true'
     runs-on: tenki-standard-small-2c-4g
     timeout-minutes: 15
     env:

--- a/.github/workflows/version-packages.yml
+++ b/.github/workflows/version-packages.yml
@@ -7,6 +7,7 @@ on:
     branches: [main]
 
 permissions:
+  actions: write
   contents: write
   pull-requests: write
 
@@ -34,7 +35,6 @@ jobs:
 
       - name: Update version PR
         env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        run: |
-          vp run release:changelog
-          vp run tegami version --no-checks
+        run: vp run release:version-pr

--- a/.tegami/publish-lock.yaml
+++ b/.tegami/publish-lock.yaml
@@ -1,5 +1,5 @@
 core:changelogs:
-  - content: "---\npackages:\n  group:akeru:\n    type: patch\n---\n\n### Changes\n\n- [#126](https://github.com/opencoredev/akeru-bot/pull/126) fix(web): replace sidebar footer labels with icons\n- [#109](https://github.com/opencoredev/akeru-bot/pull/109) docs: update user guides for subscription runtimes\n- [#127](https://github.com/opencoredev/akeru-bot/pull/127) feat(web): switch bots with number shortcuts\n- [#129](https://github.com/opencoredev/akeru-bot/pull/129) fix(web): show Grok models during limited probes\n- [#135](https://github.com/opencoredev/akeru-bot/pull/135) docs: align agent guidance with Akeru Bot\n- [#138](https://github.com/opencoredev/akeru-bot/pull/138) ci: validate merge queue candidates with Depot\n- [#139](https://github.com/opencoredev/akeru-bot/pull/139) feat(bots): move model controls to sidebar\n- [#136](https://github.com/opencoredev/akeru-bot/pull/136) fix(channels): restore settings and delivery\n- [#140](https://github.com/opencoredev/akeru-bot/pull/140) feat(bots): personalize Akeru prompts\n- [#144](https://github.com/opencoredev/akeru-bot/pull/144) ci: run Depot checks on pull requests\n- [#146](https://github.com/opencoredev/akeru-bot/pull/146) ci: migrate workflows to tenki\n- [#142](https://github.com/opencoredev/akeru-bot/pull/142) feat(plugins): add Hoplite MCP integration\n- [#147](https://github.com/opencoredev/akeru-bot/pull/147) fix(brand): use the Akeru icon in development\n- [#143](https://github.com/opencoredev/akeru-bot/pull/143) perf(server): reduce streaming and tool update overhead\n- [#148](https://github.com/opencoredev/akeru-bot/pull/148) perf(ui): replace class merging with cn\n- [#137](https://github.com/opencoredev/akeru-bot/pull/137) feat(providers): add OpenCode Go support\n- [#145](https://github.com/opencoredev/akeru-bot/pull/145) feat(web): add first-install bot onboarding\n- [#123](https://github.com/opencoredev/akeru-bot/pull/123) fix(macos): install unsigned Mac builds from a checksummed GitHub DMG\n- [#133](https://github.com/opencoredev/akeru-bot/pull/133) feat(approvals): add auto review and bot prompts\n"
+  - content: "---\npackages:\n  group:akeru:\n    type: patch\n---\n\n### Changes\n\n- [#141](https://github.com/opencoredev/akeru-bot/pull/141) fix(web): mute routine notices and update actions\n- [#151](https://github.com/opencoredev/akeru-bot/pull/151) feat(marketing): add feedback.md, versioned metadata API, rate-limit headers\n- [#153](https://github.com/opencoredev/akeru-bot/pull/153) fix(desktop): recover failed update installs\n- [#154](https://github.com/opencoredev/akeru-bot/pull/154) fix(release): require signed macOS builds\n- [#155](https://github.com/opencoredev/akeru-bot/pull/155) fix(desktop): package lazy server dependencies\n- [#156](https://github.com/opencoredev/akeru-bot/pull/156) fix(mcp): open OAuth authorization requests\n- [#149](https://github.com/opencoredev/akeru-bot/pull/149) feat(marketing): report page requests to Notra GEO\n- [#158](https://github.com/opencoredev/akeru-bot/pull/158) ci: migrate Depot workflows to Tenki\n- [#150](https://github.com/opencoredev/akeru-bot/pull/150) fix(settings): remove obsolete thread controls\n- [#159](https://github.com/opencoredev/akeru-bot/pull/159) fix(chat): improve bot conversation usability\n- [#157](https://github.com/opencoredev/akeru-bot/pull/157) feat(plugins): add Composio integrations\n- [#162](https://github.com/opencoredev/akeru-bot/pull/162) fix(plugins): complete OAuth connections\n- [#163](https://github.com/opencoredev/akeru-bot/pull/163) feat(marketing): add Grok search pages\n"
     filename: stable-release.md
     v: 0.0.0
 core:packages:
@@ -8,6 +8,8 @@ core:packages:
   - id: npm:@t3tools/oxlint-plugin-t3code
     updated: false
   - id: npm:@t3tools/scripts
+    updated: false
+  - id: npm:akeru-feedback
     updated: false
   - changelogIds:
       - stable-release.md
@@ -23,8 +25,6 @@ core:packages:
       - stable-release.md
     id: npm:@t3tools/web
     updated: true
-  - id: npm:akeru-feedback
-    updated: false
   - id: npm:@t3tools/client-runtime
     updated: false
   - changelogIds:
@@ -37,23 +37,23 @@ core:packages:
     updated: false
   - id: npm:@t3tools/shared
     updated: false
-  - id: npm:@t3tools/tailscale
-    updated: false
   - id: npm:@t3tools/ssh
+    updated: false
+  - id: npm:@t3tools/tailscale
     updated: false
 npm:packages:
   - id: npm:@t3tools/monorepo
   - id: npm:@t3tools/oxlint-plugin-t3code
   - id: npm:@t3tools/scripts
+  - id: npm:akeru-feedback
   - id: npm:@t3tools/desktop
   - id: npm:@t3tools/marketing
   - id: npm:akeru-bot
   - id: npm:@t3tools/web
-  - id: npm:akeru-feedback
   - id: npm:@t3tools/client-runtime
   - id: npm:@t3tools/contracts
   - id: npm:effect-acp
   - id: npm:effect-codex-app-server
   - id: npm:@t3tools/shared
-  - id: npm:@t3tools/tailscale
   - id: npm:@t3tools/ssh
+  - id: npm:@t3tools/tailscale

--- a/apps/desktop/CHANGELOG.md
+++ b/apps/desktop/CHANGELOG.md
@@ -1,3 +1,21 @@
+## @t3tools/desktop@0.0.39
+
+### Changes
+
+- [#141](https://github.com/opencoredev/akeru-bot/pull/141) fix(web): mute routine notices and update actions
+- [#151](https://github.com/opencoredev/akeru-bot/pull/151) feat(marketing): add feedback.md, versioned metadata API, rate-limit headers
+- [#153](https://github.com/opencoredev/akeru-bot/pull/153) fix(desktop): recover failed update installs
+- [#154](https://github.com/opencoredev/akeru-bot/pull/154) fix(release): require signed macOS builds
+- [#155](https://github.com/opencoredev/akeru-bot/pull/155) fix(desktop): package lazy server dependencies
+- [#156](https://github.com/opencoredev/akeru-bot/pull/156) fix(mcp): open OAuth authorization requests
+- [#149](https://github.com/opencoredev/akeru-bot/pull/149) feat(marketing): report page requests to Notra GEO
+- [#158](https://github.com/opencoredev/akeru-bot/pull/158) ci: migrate Depot workflows to Tenki
+- [#150](https://github.com/opencoredev/akeru-bot/pull/150) fix(settings): remove obsolete thread controls
+- [#159](https://github.com/opencoredev/akeru-bot/pull/159) fix(chat): improve bot conversation usability
+- [#157](https://github.com/opencoredev/akeru-bot/pull/157) feat(plugins): add Composio integrations
+- [#162](https://github.com/opencoredev/akeru-bot/pull/162) fix(plugins): complete OAuth connections
+- [#163](https://github.com/opencoredev/akeru-bot/pull/163) feat(marketing): add Grok search pages
+
 ## @t3tools/desktop@0.0.38
 
 ### Changes

--- a/apps/desktop/package.json
+++ b/apps/desktop/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@t3tools/desktop",
-  "version": "0.0.38",
+  "version": "0.0.39",
   "private": true,
   "type": "module",
   "main": "dist-electron/main.cjs",

--- a/apps/server/CHANGELOG.md
+++ b/apps/server/CHANGELOG.md
@@ -1,3 +1,21 @@
+## akeru-bot@0.0.39
+
+### Changes
+
+- [#141](https://github.com/opencoredev/akeru-bot/pull/141) fix(web): mute routine notices and update actions
+- [#151](https://github.com/opencoredev/akeru-bot/pull/151) feat(marketing): add feedback.md, versioned metadata API, rate-limit headers
+- [#153](https://github.com/opencoredev/akeru-bot/pull/153) fix(desktop): recover failed update installs
+- [#154](https://github.com/opencoredev/akeru-bot/pull/154) fix(release): require signed macOS builds
+- [#155](https://github.com/opencoredev/akeru-bot/pull/155) fix(desktop): package lazy server dependencies
+- [#156](https://github.com/opencoredev/akeru-bot/pull/156) fix(mcp): open OAuth authorization requests
+- [#149](https://github.com/opencoredev/akeru-bot/pull/149) feat(marketing): report page requests to Notra GEO
+- [#158](https://github.com/opencoredev/akeru-bot/pull/158) ci: migrate Depot workflows to Tenki
+- [#150](https://github.com/opencoredev/akeru-bot/pull/150) fix(settings): remove obsolete thread controls
+- [#159](https://github.com/opencoredev/akeru-bot/pull/159) fix(chat): improve bot conversation usability
+- [#157](https://github.com/opencoredev/akeru-bot/pull/157) feat(plugins): add Composio integrations
+- [#162](https://github.com/opencoredev/akeru-bot/pull/162) fix(plugins): complete OAuth connections
+- [#163](https://github.com/opencoredev/akeru-bot/pull/163) feat(marketing): add Grok search pages
+
 ## akeru-bot@0.0.38
 
 ### Changes

--- a/apps/server/package.json
+++ b/apps/server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "akeru-bot",
-  "version": "0.0.38",
+  "version": "0.0.39",
   "license": "MIT",
   "repository": {
     "type": "git",

--- a/apps/web/CHANGELOG.md
+++ b/apps/web/CHANGELOG.md
@@ -1,3 +1,21 @@
+## @t3tools/web@0.0.39
+
+### Changes
+
+- [#141](https://github.com/opencoredev/akeru-bot/pull/141) fix(web): mute routine notices and update actions
+- [#151](https://github.com/opencoredev/akeru-bot/pull/151) feat(marketing): add feedback.md, versioned metadata API, rate-limit headers
+- [#153](https://github.com/opencoredev/akeru-bot/pull/153) fix(desktop): recover failed update installs
+- [#154](https://github.com/opencoredev/akeru-bot/pull/154) fix(release): require signed macOS builds
+- [#155](https://github.com/opencoredev/akeru-bot/pull/155) fix(desktop): package lazy server dependencies
+- [#156](https://github.com/opencoredev/akeru-bot/pull/156) fix(mcp): open OAuth authorization requests
+- [#149](https://github.com/opencoredev/akeru-bot/pull/149) feat(marketing): report page requests to Notra GEO
+- [#158](https://github.com/opencoredev/akeru-bot/pull/158) ci: migrate Depot workflows to Tenki
+- [#150](https://github.com/opencoredev/akeru-bot/pull/150) fix(settings): remove obsolete thread controls
+- [#159](https://github.com/opencoredev/akeru-bot/pull/159) fix(chat): improve bot conversation usability
+- [#157](https://github.com/opencoredev/akeru-bot/pull/157) feat(plugins): add Composio integrations
+- [#162](https://github.com/opencoredev/akeru-bot/pull/162) fix(plugins): complete OAuth connections
+- [#163](https://github.com/opencoredev/akeru-bot/pull/163) feat(marketing): add Grok search pages
+
 ## @t3tools/web@0.0.38
 
 ### Changes

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@t3tools/web",
-  "version": "0.0.38",
+  "version": "0.0.39",
   "private": true,
   "type": "module",
   "scripts": {

--- a/docs/internals/ci.md
+++ b/docs/internals/ci.md
@@ -19,7 +19,10 @@ Issue-label, PR-vouch, and PR-size jobs also use Tenki Linux runners through Git
 
 The repository ruleset requires the `Repository checks` result before a pull request can
 merge. Direct pushes to `main` cannot bypass this gate. Release workflows start after the validated
-revision lands on `main`; version packaging is separate from pull-request CI.
+revision lands on `main`; version packaging is separate from pull-request CI. The version workflow
+updates the pull request body after Tegami updates its branch, then dispatches CI for that branch.
+This explicit dispatch is required because pushes made with the GitHub Actions token do not start
+another pull-request workflow.
 
 [`.github/workflows/release-smoke.yml`](../../.github/workflows/release-smoke.yml) is a manual,
 non-publishing artifact smoke workflow. It uses 4-vCPU Tenki runners for Linux and Apple Silicon
@@ -32,7 +35,9 @@ desktop artifacts for seven days. It does not create a GitHub release, publish a
 a site.
 
 Merging a stable version change to `main` starts
-[the stable release workflow](../../.github/workflows/release.yml). Tenki macOS and Linux runners
+[the stable release workflow](../../.github/workflows/release.yml). A push that changes a watched
+manifest without changing the stable version exits successfully before any release build starts.
+A manual dispatch for an existing stable tag still fails. Tenki macOS and Linux runners
 plus a GitHub-hosted Windows runner build the advertised desktop targets before the workflow creates
 the `vX.Y.Z` tag and GitHub Release. The final job verifies the exact asset names and `SHA256SUMS`.
 Missing signing credentials produce unsigned macOS and Windows artifacts.

--- a/package.json
+++ b/package.json
@@ -44,6 +44,7 @@
     "dist:desktop:win:x64": "node scripts/build-desktop-artifact.ts --platform win --target nsis --arch x64",
     "release:smoke": "node scripts/release-smoke.ts",
     "release:changelog": "node scripts/generate-release-changelog.ts",
+    "release:version-pr": "node scripts/update-version-pull-request.ts",
     "tegami": "node scripts/tegami.ts",
     "release:verify": "node scripts/verify-release-candidate.ts",
     "release:verify-assets": "node scripts/verify-release-assets.ts",

--- a/packages/contracts/CHANGELOG.md
+++ b/packages/contracts/CHANGELOG.md
@@ -1,3 +1,21 @@
+## @t3tools/contracts@0.0.39
+
+### Changes
+
+- [#141](https://github.com/opencoredev/akeru-bot/pull/141) fix(web): mute routine notices and update actions
+- [#151](https://github.com/opencoredev/akeru-bot/pull/151) feat(marketing): add feedback.md, versioned metadata API, rate-limit headers
+- [#153](https://github.com/opencoredev/akeru-bot/pull/153) fix(desktop): recover failed update installs
+- [#154](https://github.com/opencoredev/akeru-bot/pull/154) fix(release): require signed macOS builds
+- [#155](https://github.com/opencoredev/akeru-bot/pull/155) fix(desktop): package lazy server dependencies
+- [#156](https://github.com/opencoredev/akeru-bot/pull/156) fix(mcp): open OAuth authorization requests
+- [#149](https://github.com/opencoredev/akeru-bot/pull/149) feat(marketing): report page requests to Notra GEO
+- [#158](https://github.com/opencoredev/akeru-bot/pull/158) ci: migrate Depot workflows to Tenki
+- [#150](https://github.com/opencoredev/akeru-bot/pull/150) fix(settings): remove obsolete thread controls
+- [#159](https://github.com/opencoredev/akeru-bot/pull/159) fix(chat): improve bot conversation usability
+- [#157](https://github.com/opencoredev/akeru-bot/pull/157) feat(plugins): add Composio integrations
+- [#162](https://github.com/opencoredev/akeru-bot/pull/162) fix(plugins): complete OAuth connections
+- [#163](https://github.com/opencoredev/akeru-bot/pull/163) feat(marketing): add Grok search pages
+
 ## @t3tools/contracts@0.0.38
 
 ### Changes

--- a/packages/contracts/package.json
+++ b/packages/contracts/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@t3tools/contracts",
-  "version": "0.0.38",
+  "version": "0.0.39",
   "private": true,
   "files": [
     "dist"

--- a/scripts/ci-workflow-policy.test.ts
+++ b/scripts/ci-workflow-policy.test.ts
@@ -18,6 +18,7 @@ type Job = {
 
 type Workflow = {
   readonly on: Record<string, unknown>;
+  readonly permissions?: Readonly<Record<string, string>>;
   readonly concurrency?: {
     readonly group?: string;
     readonly "cancel-in-progress"?: boolean;
@@ -93,10 +94,22 @@ describe("CI workflow budget", () => {
       group: "version-packages",
       "cancel-in-progress": true,
     });
+    expect(versionPackages.permissions).toEqual({
+      actions: "write",
+      contents: "write",
+      "pull-requests": "write",
+    });
     expect(versionJob?.["runs-on"]).toBe("tenki-standard-medium-4c-8g");
-    expect(versionJob?.steps.find((step) => step.run)?.run).toContain(
-      "vp run tegami version --no-checks",
+    expect(versionJob?.steps.find((step) => step.run)?.run).toBe("vp run release:version-pr");
+
+    const updater = NodeFS.readFileSync(
+      new URL("../scripts/update-version-pull-request.ts", import.meta.url),
+      "utf8",
     );
+    expect(updater).toContain('"merge-base",');
+    expect(updater).toContain('"--is-ancestor",');
+    expect(updater).toContain('"pr",\n    "edit",');
+    expect(updater).toContain('"workflow", "run", "ci.yml"');
   });
 
   it("uses 4-vCPU Linux runners in the manual release smoke workflow", () => {
@@ -111,5 +124,22 @@ describe("CI workflow budget", () => {
     expect(text).toContain("tenki-macos-15-medium");
     expect(text).toContain("windows-2025");
     expect(Object.keys(releaseSmoke.jobs).length).toBeGreaterThan(0);
+  });
+
+  it("skips stable release builds for non-version manifest pushes", () => {
+    const text = NodeFS.readFileSync(
+      new URL("../.github/workflows/release.yml", import.meta.url),
+      "utf8",
+    );
+
+    expect(text).toContain("printf 'publish=false\\n'");
+    expect(text).toContain('git show "HEAD^:apps/server/package.json"');
+    const unchangedVersion = text.indexOf('if test "$previous_version" = "$version"');
+    const existingTag = text.indexOf('if git rev-parse --verify --quiet "refs/tags/v$version"');
+    expect(unchangedVersion).toBeGreaterThan(-1);
+    expect(existingTag).toBeGreaterThan(unchangedVersion);
+    expect(text).toContain("if: steps.version.outputs.publish == 'true'");
+    expect(text).toContain("if: needs.preflight.outputs.publish == 'true'");
+    expect(text).toContain('if test "$EVENT_NAME" != workflow_dispatch');
   });
 });

--- a/scripts/release-smoke.ts
+++ b/scripts/release-smoke.ts
@@ -132,8 +132,8 @@ assertOmits(
 );
 for (const [needle, label] of [
   ["branches: [main]", "main branch trigger"],
-  ["vp run release:changelog", "merged pull request changelog"],
-  ["vp run tegami version --no-checks", "Tegami version command"],
+  ["vp run release:version-pr", "version pull request command"],
+  ["actions: write", "CI dispatch permission"],
   ["contents: write", "version branch permission"],
   ["pull-requests: write", "version pull request permission"],
 ] as const) {

--- a/scripts/update-version-pull-request.test.ts
+++ b/scripts/update-version-pull-request.test.ts
@@ -1,0 +1,42 @@
+import { describe, expect, it } from "vite-plus/test";
+
+import {
+  isRecoverableVersionRequestFailure,
+  nextPatchVersion,
+  renderVersionPullRequestBody,
+} from "./update-version-pull-request.ts";
+
+describe("version pull request automation", () => {
+  it("renders every merged pull request in the next patch release", () => {
+    const body = renderVersionPullRequestBody("0.0.38", [
+      { number: 141, title: "fix(web): mute routine notices" },
+      { number: 163, title: "feat(marketing): add Grok search pages" },
+    ]);
+
+    expect(body).toContain("Prepare Akeru Bot v0.0.39.");
+    expect(body).toContain("[#141](https://github.com/opencoredev/akeru-bot/pull/141)");
+    expect(body).toContain("[#163](https://github.com/opencoredev/akeru-bot/pull/163)");
+    expect(body).toContain("`akeru-bot`: `0.0.38` → `0.0.39`");
+  });
+
+  it("increments only stable patch versions", () => {
+    expect(nextPatchVersion("1.2.9")).toBe("1.2.10");
+    expect(() => nextPatchVersion("1.2.3-beta.1")).toThrow("Stable release version is invalid");
+  });
+
+  it("recovers only from version pull request creation conflicts", () => {
+    expect(
+      isRecoverableVersionRequestFailure(
+        'Plugin "github:version-request" failed:\nA pull request already exists',
+      ),
+    ).toBe(true);
+    expect(
+      isRecoverableVersionRequestFailure(
+        'Plugin "github:version-request" failed: GitHub Actions is not permitted to create or approve pull requests',
+      ),
+    ).toBe(true);
+    expect(isRecoverableVersionRequestFailure("Tegami failed to push the version branch")).toBe(
+      false,
+    );
+  });
+});

--- a/scripts/update-version-pull-request.ts
+++ b/scripts/update-version-pull-request.ts
@@ -1,0 +1,194 @@
+// @effect-diagnostics nodeBuiltinImport:off globalConsole:off - Release automation runs before an Effect runtime exists.
+import * as NodeChildProcess from "node:child_process";
+import * as NodeFS from "node:fs";
+import * as NodeOS from "node:os";
+import * as NodePath from "node:path";
+import * as NodeURL from "node:url";
+
+import {
+  headIsVersionRelease,
+  readReleaseChanges,
+  type ReleaseChange,
+} from "./generate-release-changelog.ts";
+
+const repository = "opencoredev/akeru-bot";
+const versionBranch = "tegami/version-packages";
+const versionTitle = "Version Packages";
+
+interface CommandResult {
+  readonly status: number;
+  readonly output: string;
+}
+
+function run(command: string, args: ReadonlyArray<string>): CommandResult {
+  const result = NodeChildProcess.spawnSync(command, args, {
+    encoding: "utf8",
+    env: process.env,
+  });
+  const output = `${result.stdout ?? ""}${result.stderr ?? ""}`;
+  process.stdout.write(output);
+  return { status: result.status ?? 1, output };
+}
+
+function runOrThrow(command: string, args: ReadonlyArray<string>): string {
+  const result = NodeChildProcess.spawnSync(command, args, {
+    encoding: "utf8",
+    env: process.env,
+  });
+  if (result.status !== 0) {
+    throw new Error(
+      `${command} ${args.join(" ")} failed with code ${result.status ?? 1}:\n${result.stderr || result.stdout}`,
+    );
+  }
+  return result.stdout.trim();
+}
+
+export function nextPatchVersion(version: string): string {
+  const match = /^(\d+)\.(\d+)\.(\d+)$/u.exec(version);
+  if (!match) throw new Error(`Stable release version is invalid: ${version}.`);
+  const [, major, minor, patch] = match;
+  return `${major}.${minor}.${Number(patch) + 1}`;
+}
+
+export function renderVersionPullRequestBody(
+  currentVersion: string,
+  changes: ReadonlyArray<ReleaseChange>,
+): string {
+  const nextVersion = nextPatchVersion(currentVersion);
+  const entries = changes.map(
+    ({ number, title }) =>
+      `- [#${number}](https://github.com/opencoredev/akeru-bot/pull/${number}) ${title}`,
+  );
+
+  return [
+    "## Summary",
+    "",
+    `Prepare Akeru Bot v${nextVersion}.`,
+    "",
+    "## Changes",
+    "",
+    ...entries,
+    "",
+    "## Packages",
+    "",
+    `- \`@t3tools/desktop\`: \`${currentVersion}\` → \`${nextVersion}\``,
+    `- \`akeru-bot\`: \`${currentVersion}\` → \`${nextVersion}\``,
+    `- \`@t3tools/web\`: \`${currentVersion}\` → \`${nextVersion}\``,
+    `- \`@t3tools/contracts\`: \`${currentVersion}\` → \`${nextVersion}\``,
+    "",
+  ].join("\n");
+}
+
+export function isRecoverableVersionRequestFailure(output: string): boolean {
+  const normalized = output.replace(/\s+/gu, " ");
+  return (
+    normalized.includes('Plugin "github:version-request" failed') &&
+    (normalized.includes("A pull request already exists") ||
+      normalized.includes("GitHub Actions is not permitted to create or approve pull requests"))
+  );
+}
+
+function readCurrentVersion(): string {
+  const manifest = JSON.parse(NodeFS.readFileSync("apps/server/package.json", "utf8")) as {
+    readonly version?: unknown;
+  };
+  if (typeof manifest.version !== "string") {
+    throw new Error("apps/server/package.json does not contain a version.");
+  }
+  return manifest.version;
+}
+
+function findVersionPullRequest(): number | undefined {
+  const value = runOrThrow("gh", [
+    "pr",
+    "list",
+    "--repo",
+    repository,
+    "--state",
+    "open",
+    "--head",
+    versionBranch,
+    "--json",
+    "number",
+    "--jq",
+    ".[0].number // empty",
+  ]);
+  if (value === "") return undefined;
+  const number = Number(value);
+  if (!Number.isSafeInteger(number)) {
+    throw new Error(`GitHub returned an invalid version pull request number: ${value}.`);
+  }
+  return number;
+}
+
+function verifyVersionBranchIncludesMain(mainSha: string): void {
+  runOrThrow("git", [
+    "fetch",
+    "origin",
+    `refs/heads/${versionBranch}:refs/remotes/origin/${versionBranch}`,
+  ]);
+  runOrThrow("git", [
+    "merge-base",
+    "--is-ancestor",
+    mainSha,
+    `refs/remotes/origin/${versionBranch}`,
+  ]);
+}
+
+function main(): void {
+  if (headIsVersionRelease()) {
+    console.log("The version pull request merge does not need another version pull request.");
+    return;
+  }
+
+  const mainSha = process.env.GITHUB_SHA;
+  if (!mainSha) throw new Error("GITHUB_SHA is required.");
+
+  const changes = readReleaseChanges();
+  if (changes.length === 0) {
+    console.log("No merged pull requests need a version pull request.");
+    return;
+  }
+
+  const body = renderVersionPullRequestBody(readCurrentVersion(), changes);
+  const bodyPath = NodePath.join(
+    process.env.RUNNER_TEMP ?? NodeOS.tmpdir(),
+    "akeru-version-pull-request.md",
+  );
+  NodeFS.writeFileSync(bodyPath, body);
+
+  const changelog = run("vp", ["run", "release:changelog"]);
+  if (changelog.status !== 0) {
+    throw new Error("Failed to generate the stable release changelog.");
+  }
+
+  const tegami = run("vp", ["run", "tegami", "version", "--no-checks"]);
+  const pullRequest = findVersionPullRequest();
+  if (!pullRequest) {
+    throw new Error(
+      tegami.status === 0
+        ? "Tegami completed without an open version pull request."
+        : `Tegami failed before it created the version pull request:\n${tegami.output}`,
+    );
+  }
+  if (tegami.status !== 0 && !isRecoverableVersionRequestFailure(tegami.output)) {
+    throw new Error(`Tegami failed while updating the version pull request:\n${tegami.output}`);
+  }
+
+  verifyVersionBranchIncludesMain(mainSha);
+  runOrThrow("gh", [
+    "pr",
+    "edit",
+    String(pullRequest),
+    "--repo",
+    repository,
+    "--title",
+    versionTitle,
+    "--body-file",
+    bodyPath,
+  ]);
+  runOrThrow("gh", ["workflow", "run", "ci.yml", "--repo", repository, "--ref", versionBranch]);
+  console.log(`Updated version pull request #${pullRequest} and started Repository checks.`);
+}
+
+if (import.meta.url === NodeURL.pathToFileURL(process.argv[1] ?? "").href) main();


### PR DESCRIPTION
## Summary

Prepare Akeru Bot v0.0.39.

## Changes

- [#141](https://github.com/opencoredev/akeru-bot/pull/141) fix(web): mute routine notices and update actions
- [#151](https://github.com/opencoredev/akeru-bot/pull/151) feat(marketing): add feedback.md, versioned metadata API, rate-limit headers
- [#153](https://github.com/opencoredev/akeru-bot/pull/153) fix(desktop): recover failed update installs
- [#154](https://github.com/opencoredev/akeru-bot/pull/154) fix(release): require signed macOS builds
- [#155](https://github.com/opencoredev/akeru-bot/pull/155) fix(desktop): package lazy server dependencies
- [#156](https://github.com/opencoredev/akeru-bot/pull/156) fix(mcp): open OAuth authorization requests
- [#149](https://github.com/opencoredev/akeru-bot/pull/149) feat(marketing): report page requests to Notra GEO
- [#158](https://github.com/opencoredev/akeru-bot/pull/158) ci: migrate Depot workflows to Tenki
- [#150](https://github.com/opencoredev/akeru-bot/pull/150) fix(settings): remove obsolete thread controls
- [#159](https://github.com/opencoredev/akeru-bot/pull/159) fix(chat): improve bot conversation usability
- [#157](https://github.com/opencoredev/akeru-bot/pull/157) feat(plugins): add Composio integrations
- [#162](https://github.com/opencoredev/akeru-bot/pull/162) fix(plugins): complete OAuth connections
- [#163](https://github.com/opencoredev/akeru-bot/pull/163) feat(marketing): add Grok search pages

## Packages

- `@t3tools/desktop`: `0.0.38` → `0.0.39`
- `akeru-bot`: `0.0.38` → `0.0.39`
- `@t3tools/web`: `0.0.38` → `0.0.39`
- `@t3tools/contracts`: `0.0.38` → `0.0.39`


## Release automation

- Future Version Packages pull requests are created and updated automatically.
- Each automated update starts the required Repository checks.
- Ordinary package manifest edits do not start a stable release.
