### PR TITLE
fix(release): use available macOS runner

### DIFF
--- a/.github/workflows/release-smoke.yml
+++ b/.github/workflows/release-smoke.yml
@@ -53,7 +53,7 @@ jobs:
       matrix:
         include:
           - label: macOS arm64 DMG
-            runner: tenki-macos-15-medium
+            runner: macos-15
             platform: mac
             target: dmg
             arch: arm64

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -13,6 +13,7 @@ on:
       - packages/contracts/package.json
 
 permissions:
+  actions: write
   contents: write
 
 concurrency:
@@ -102,7 +103,7 @@ jobs:
       matrix:
         include:
           - label: macOS arm64 DMG
-            runner: tenki-macos-15-medium
+            runner: macos-15
             platform: mac
             target: dmg
             arch: arm64
@@ -303,3 +304,5 @@ jobs:
         run: node scripts/verify-release-assets.ts release "$RELEASE_VERSION"
       - name: Create stable tag and GitHub Release
         run: gh release create "$RELEASE_TAG" release/* --target "$GITHUB_SHA" --title "Akeru Bot $RELEASE_TAG" --generate-notes
+      - name: Update the next version PR
+        run: gh workflow run version-packages.yml --ref main

--- a/.github/workflows/version-packages.yml
+++ b/.github/workflows/version-packages.yml
@@ -5,6 +5,7 @@ name: Version packages
 on:
   push:
     branches: [main]
+  workflow_dispatch:
 
 permissions:
   actions: write

--- a/docs/internals/ci.md
+++ b/docs/internals/ci.md
@@ -25,8 +25,8 @@ This explicit dispatch is required because pushes made with the GitHub Actions t
 another pull-request workflow.
 
 [`.github/workflows/release-smoke.yml`](../../.github/workflows/release-smoke.yml) is a manual,
-non-publishing artifact smoke workflow. It uses 4-vCPU Tenki runners for Linux and Apple Silicon
-macOS, plus a GitHub-hosted Windows runner. It builds a Developer ID signed macOS arm64 app.
+non-publishing artifact smoke workflow. It uses a 4-vCPU Tenki runner for Linux and GitHub-hosted
+Apple Silicon macOS and Windows runners. It builds a Developer ID signed macOS arm64 app.
 Electron-builder notarizes and staples the
 app before it packages the DMG. The workflow then submits and staples the DMG as a separate object.
 It checks both objects with Apple's verification tools. Windows and Linux artifacts stay unsigned.
@@ -37,9 +37,11 @@ a site.
 Merging a stable version change to `main` starts
 [the stable release workflow](../../.github/workflows/release.yml). A push that changes a watched
 manifest without changing the stable version exits successfully before any release build starts.
-A manual dispatch for an existing stable tag still fails. Tenki macOS and Linux runners
-plus a GitHub-hosted Windows runner build the advertised desktop targets before the workflow creates
-the `vX.Y.Z` tag and GitHub Release. The final job verifies the exact asset names and `SHA256SUMS`.
+A manual dispatch for an existing stable tag still fails. A Tenki Linux runner plus GitHub-hosted
+Apple Silicon macOS and Windows runners build the advertised desktop targets before the workflow
+creates the `vX.Y.Z` tag and GitHub Release. The final job verifies the exact asset names and
+`SHA256SUMS`, then starts the next Version Packages update. Version automation waits for the current
+stable tag before it prepares another version.
 Missing signing credentials produce unsigned macOS and Windows artifacts.
 Unsigned macOS builds still replace Electron's linker-signed stub with a sealed ad-hoc signature
 and fail the release if `codesign --verify` fails or the identifier is not `dev.leodoes.akeru`.

--- a/docs/operations/release.md
+++ b/docs/operations/release.md
@@ -31,13 +31,13 @@ release announcements.
 
 ## Runner setup
 
-CI and release workflows run through GitHub Actions. Tenki provides Linux and Apple Silicon macOS
-runners. GitHub provides the Windows runner. The Tenki Runner GitHub App must have access to
+CI and release workflows run through GitHub Actions. Tenki provides Linux runners. GitHub provides
+the Apple Silicon macOS and Windows runners. The Tenki Runner GitHub App must have access to
 `opencoredev/akeru-bot`.
 
 - Linux uses the 4-vCPU `tenki-standard-medium-4c-8g` runner.
 - Windows uses the GitHub-hosted `windows-2025` runner.
-- macOS uses the 4-vCPU Apple Silicon `tenki-macos-15-medium` runner.
+- macOS uses the GitHub-hosted Apple Silicon `macos-15` runner.
 
 ## macOS secrets
 

--- a/scripts/ci-workflow-policy.test.ts
+++ b/scripts/ci-workflow-policy.test.ts
@@ -90,6 +90,7 @@ describe("CI workflow budget", () => {
     const versionPackages = workflow(".github/workflows/version-packages.yml");
     const versionJob = versionPackages.jobs.version;
 
+    expect(Object.keys(versionPackages.on)).toEqual(["push", "workflow_dispatch"]);
     expect(versionPackages.concurrency).toEqual({
       group: "version-packages",
       "cancel-in-progress": true,
@@ -121,7 +122,7 @@ describe("CI workflow budget", () => {
 
     expect(text).not.toContain("depot-");
     expect(text).toContain("tenki-standard-medium-4c-8g");
-    expect(text).toContain("tenki-macos-15-medium");
+    expect(text).toContain("runner: macos-15");
     expect(text).toContain("windows-2025");
     expect(Object.keys(releaseSmoke.jobs).length).toBeGreaterThan(0);
   });
@@ -141,5 +142,6 @@ describe("CI workflow budget", () => {
     expect(text).toContain("if: steps.version.outputs.publish == 'true'");
     expect(text).toContain("if: needs.preflight.outputs.publish == 'true'");
     expect(text).toContain('if test "$EVENT_NAME" != workflow_dispatch');
+    expect(text).toContain("gh workflow run version-packages.yml --ref main");
   });
 });

--- a/scripts/release-smoke.ts
+++ b/scripts/release-smoke.ts
@@ -67,7 +67,7 @@ for (const [needle, label] of [
   ["label: macOS arm64 DMG", "macOS arm64 DMG"],
   ["label: Windows x64 NSIS", "Windows x64 NSIS"],
   ["label: Linux x64 AppImage", "Linux x64 AppImage"],
-  ["runner: tenki-macos-15-medium", "Tenki macOS runner"],
+  ["runner: macos-15", "GitHub-hosted Apple Silicon macOS runner"],
   ["runner: windows-2025", "GitHub-hosted Windows runner"],
   ["runner: tenki-standard-medium-4c-8g", "4-vCPU Tenki Linux runner"],
   [
@@ -109,7 +109,7 @@ for (const [needle, label] of [
   ["label: macOS arm64 DMG", "macOS arm64 DMG"],
   ["label: Windows x64 NSIS", "Windows x64 NSIS"],
   ["label: Linux x64 AppImage", "Linux x64 AppImage"],
-  ["runner: tenki-macos-15-medium", "Tenki macOS runner"],
+  ["runner: macos-15", "GitHub-hosted Apple Silicon macOS runner"],
   ["runner: windows-2025", "GitHub-hosted Windows runner"],
   ["runner: tenki-standard-medium-4c-8g", "Tenki Linux runner"],
   [
@@ -120,6 +120,8 @@ for (const [needle, label] of [
   ["xcrun notarytool submit", "macOS notarization"],
   ["verify-release-assets.ts", "asset name and hash verification"],
   ["gh release create", "stable GitHub Release"],
+  ["actions: write", "next version workflow dispatch permission"],
+  ["gh workflow run version-packages.yml --ref main", "next version workflow dispatch"],
 ] as const) {
   assertContains(releaseWorkflow, needle, `Stable release workflow is missing ${label}.`);
 }

--- a/scripts/update-version-pull-request.test.ts
+++ b/scripts/update-version-pull-request.test.ts
@@ -4,6 +4,8 @@ import {
   isRecoverableVersionRequestFailure,
   nextPatchVersion,
   renderVersionPullRequestBody,
+  stableReleaseIsPublished,
+  stableReleaseTag,
 } from "./update-version-pull-request.ts";
 
 describe("version pull request automation", () => {
@@ -19,8 +21,12 @@ describe("version pull request automation", () => {
     expect(body).toContain("`akeru-bot`: `0.0.38` → `0.0.39`");
   });
 
-  it("increments only stable patch versions", () => {
+  it("increments only published stable patch versions", () => {
+    expect(stableReleaseTag("1.2.9")).toBe("v1.2.9");
+    expect(stableReleaseIsPublished("1.2.9", ["v1.2.8", "v1.2.9"])).toBe(true);
+    expect(stableReleaseIsPublished("1.2.9", ["v1.2.8"])).toBe(false);
     expect(nextPatchVersion("1.2.9")).toBe("1.2.10");
+    expect(() => stableReleaseTag("1.2.3-beta.1")).toThrow("Stable release version is invalid");
     expect(() => nextPatchVersion("1.2.3-beta.1")).toThrow("Stable release version is invalid");
   });
 

--- a/scripts/update-version-pull-request.ts
+++ b/scripts/update-version-pull-request.ts
@@ -43,6 +43,13 @@ function runOrThrow(command: string, args: ReadonlyArray<string>): string {
   return result.stdout.trim();
 }
 
+export function stableReleaseTag(version: string): string {
+  if (!/^\d+\.\d+\.\d+$/u.test(version)) {
+    throw new Error(`Stable release version is invalid: ${version}.`);
+  }
+  return `v${version}`;
+}
+
 export function nextPatchVersion(version: string): string {
   const match = /^(\d+)\.(\d+)\.(\d+)$/u.exec(version);
   if (!match) throw new Error(`Stable release version is invalid: ${version}.`);
@@ -121,6 +128,18 @@ function findVersionPullRequest(): number | undefined {
   return number;
 }
 
+export function stableReleaseIsPublished(version: string, tags: ReadonlyArray<string>): boolean {
+  return tags.includes(stableReleaseTag(version));
+}
+
+function currentStableReleaseIsPublished(version: string): boolean {
+  const tag = stableReleaseTag(version);
+  const result = NodeChildProcess.spawnSync("git", ["tag", "--list", tag], {
+    encoding: "utf8",
+  });
+  return result.status === 0 && stableReleaseIsPublished(version, result.stdout.trim().split("\n"));
+}
+
 function verifyVersionBranchIncludesMain(mainSha: string): void {
   runOrThrow("git", [
     "fetch",
@@ -144,13 +163,19 @@ function main(): void {
   const mainSha = process.env.GITHUB_SHA;
   if (!mainSha) throw new Error("GITHUB_SHA is required.");
 
+  const currentVersion = readCurrentVersion();
+  if (!currentStableReleaseIsPublished(currentVersion)) {
+    console.log(`Stable release ${stableReleaseTag(currentVersion)} is still pending.`);
+    return;
+  }
+
   const changes = readReleaseChanges();
   if (changes.length === 0) {
     console.log("No merged pull requests need a version pull request.");
     return;
   }
 
-  const body = renderVersionPullRequestBody(readCurrentVersion(), changes);
+  const body = renderVersionPullRequestBody(currentVersion, changes);
   const bodyPath = NodePath.join(
     process.env.RUNNER_TEMP ?? NodeOS.tmpdir(),
     "akeru-version-pull-request.md",


### PR DESCRIPTION
The v0.0.39 release could not start its macOS build because Tenki did not provision a macOS runner. Version packaging also prepared a duplicate follow-up while the stable tag was still pending.

Use GitHub's Apple Silicon `macos-15` runner for macOS artifacts. Wait for the current stable tag before preparing another version pull request, then start version packaging after a release publishes.

Verification:
- `vp test run scripts/update-version-pull-request.test.ts scripts/generate-release-changelog.test.ts scripts/ci-workflow-policy.test.ts scripts/tegami.test.ts`
- `vp run release:smoke`
- `vp run --filter @t3tools/scripts typecheck`
- targeted `vp fmt --check`

Model: gpt-5.6-sol
Harness: Grok Build