### PR TITLE
fix(provider): list muse-spark-1.3-contributor for OpenCode Go

### DIFF
--- a/apps/server/src/provider/AkeruOpenCodeGoProvider.test.ts
+++ b/apps/server/src/provider/AkeruOpenCodeGoProvider.test.ts
@@ -9,6 +9,7 @@ import {
 describe("AkeruOpenCodeGoProvider", () => {
   it("selects the protocol required by each model family", () => {
     expect(openCodeGoProtocol("gpt-5.6-luna")).toBe("responses");
+    expect(openCodeGoProtocol("muse-spark-1.3-contributor")).toBe("responses");
     expect(openCodeGoProtocol("qwen3.8-max")).toBe("anthropic");
     expect(openCodeGoProtocol("deepseek-v4-pro")).toBe("chat-completions");
   });

--- a/apps/server/src/provider/AkeruOpenCodeGoProvider.ts
+++ b/apps/server/src/provider/AkeruOpenCodeGoProvider.ts
@@ -11,6 +11,7 @@ const RESPONSES_MODELS = new Set([
   "grok-4.5",
   "grok-4.6",
   "muse-spark-1.2-contributor",
+  "muse-spark-1.3-contributor",
 ]);
 
 export type OpenCodeGoProtocol = "anthropic" | "chat-completions" | "responses";

--- a/apps/server/src/provider/Drivers/OpenCodeGoDriver.test.ts
+++ b/apps/server/src/provider/Drivers/OpenCodeGoDriver.test.ts
@@ -45,6 +45,7 @@ describe("OpenCodeGoDriver", () => {
             models: expect.arrayContaining([
               expect.objectContaining({ slug: "gpt-5.6-luna", isDefault: true }),
               expect.objectContaining({ slug: "grok-4.5" }),
+              expect.objectContaining({ slug: "muse-spark-1.3-contributor" }),
               expect.objectContaining({ slug: "qwen3.8-max" }),
             ]),
           });

--- a/apps/server/src/provider/Drivers/OpenCodeGoDriver.ts
+++ b/apps/server/src/provider/Drivers/OpenCodeGoDriver.ts
@@ -44,6 +44,7 @@ export const OPEN_CODE_GO_MODELS = [
   "minimax-m2.7",
   "minimax-m2.5",
   "muse-spark-1.2-contributor",
+  "muse-spark-1.3-contributor",
   "qwen3.8-max",
   "qwen3.8-flash",
   "qwen3.7-max",


### PR DESCRIPTION
## What

Adds `muse-spark-1.3-contributor` to the OpenCode Go model list (`OPEN_CODE_GO_MODELS`) and to the `RESPONSES_MODELS` protocol pin, so it routes over the responses protocol like 1.2 does. 4 insertions across 4 files, no other changes.

- [x] This PR is small and focused
- [x] I explained what changed and why
- [x] I linked the accepted plugin or provider proposal in Why, or this PR does not add one
- [ ] I included before/after screenshots for any UI changes
- [ ] I included a video for animation/interaction changes

No UI change (model becomes selectable in the existing picker).

## Why

Fixes #171. The picker showed Muse Spark 1.3 under Codex (resolved live via `codex app-server`) but only 1.2 under OpenCode Go (resolved from the hardcoded `OPEN_CODE_GO_MODELS` tuple), even though the live opencode-go API serves 1.3. Repo-wide grep confirms these were the only two `muse-spark-1.2` pins on the provider data path.

Verified locally: server typecheck clean, oxlint clean, format clean, both touched suites pass (6/6), full server suite passes (309/309).