### PR TITLE
fix(release): allow unsigned macOS builds

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -297,6 +297,10 @@ jobs:
           codesign --verify --deep --strict --verbose=2 "${apps[0]}"
           signature="$(codesign -dv --verbose=4 "${apps[0]}" 2>&1)"
           printf '%s\n' "$signature"
+          if ! printf '%s\n' "$signature" | grep -q '^Signature=adhoc$'; then
+            printf 'Packaged app does not use an ad-hoc signature.\n' >&2
+            exit 1
+          fi
           if ! printf '%s\n' "$signature" | grep -q 'Identifier=dev.leodoes.akeru$'; then
             printf 'Packaged app is missing the Akeru bundle identifier.\n' >&2
             exit 1

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -157,12 +157,15 @@ jobs:
           APPSTORE_ISSUER_ID: ${{ secrets.APPSTORE_ISSUER_ID }}
         run: |
           values=("$MACOS_CERTIFICATE_P12" "$MACOS_CERTIFICATE_PASSWORD" "$MACOS_SIGNING_IDENTITY" "$APPSTORE_API_KEY_P8" "$APPSTORE_API_KEY_ID" "$APPSTORE_ISSUER_ID")
-          for value in "${values[@]}"; do
-            if test -z "$value"; then
-              printf 'Stable macOS releases require complete signing and notarization credentials.\n' >&2
-              exit 1
-            fi
-          done
+          present=0
+          for value in "${values[@]}"; do test -n "$value" && present=$((present + 1)); done
+          if (( present != 0 && present != ${#values[@]} )); then
+            printf 'macOS signing credentials must be either complete or absent.\n' >&2
+            exit 1
+          fi
+          signed=false
+          if (( present > 0 )); then signed=true; fi
+          printf 'MACOS_SIGNED=%s\n' "$signed" >> "$GITHUB_ENV"
 
       - name: Validate Windows signing credentials
         if: matrix.platform == 'win'
@@ -188,14 +191,14 @@ jobs:
           printf 'SIGNED=%s\n' "$signed" >> "$GITHUB_ENV"
 
       - name: Import macOS signing certificate
-        if: matrix.platform == 'mac'
+        if: matrix.platform == 'mac' && env.MACOS_SIGNED == 'true'
         uses: apple-actions/import-codesign-certs@5142e029c445c10ffc7149d172e540235a065466 # v7.0.0
         with:
           p12-file-base64: ${{ secrets.MACOS_CERTIFICATE_P12 }}
           p12-password: ${{ secrets.MACOS_CERTIFICATE_PASSWORD }}
 
       - name: Configure macOS notarization
-        if: matrix.platform == 'mac'
+        if: matrix.platform == 'mac' && env.MACOS_SIGNED == 'true'
         shell: bash
         env:
           MACOS_SIGNING_IDENTITY: ${{ secrets.MACOS_SIGNING_IDENTITY }}
@@ -209,7 +212,7 @@ jobs:
           chmod 600 "$RUNNER_TEMP/notarytool-api-key.p8"
 
       - name: Build signed macOS artifact
-        if: matrix.platform == 'mac'
+        if: matrix.platform == 'mac' && env.MACOS_SIGNED == 'true'
         shell: bash
         env:
           APPLE_API_KEY: ${{ runner.temp }}/notarytool-api-key.p8
@@ -223,6 +226,17 @@ jobs:
             --arch arm64 \
             --build-version "$RELEASE_VERSION" \
             --signed \
+            --verbose
+
+      - name: Build unsigned macOS artifact
+        if: matrix.platform == 'mac' && env.MACOS_SIGNED != 'true'
+        shell: bash
+        run: |
+          vp run dist:desktop:artifact \
+            --platform mac \
+            --target dmg \
+            --arch arm64 \
+            --build-version "$RELEASE_VERSION" \
             --verbose
 
       - name: Build Windows artifact
@@ -247,7 +261,7 @@ jobs:
         run: vp run dist:desktop:artifact --platform linux --target AppImage --arch x64 --build-version "$RELEASE_VERSION" --verbose
 
       - name: Notarize and verify macOS DMG
-        if: matrix.platform == 'mac'
+        if: matrix.platform == 'mac' && env.MACOS_SIGNED == 'true'
         shell: bash
         env:
           APPLE_API_KEY: ${{ runner.temp }}/notarytool-api-key.p8
@@ -268,6 +282,25 @@ jobs:
           codesign --verify --deep --strict --verbose=2 "${apps[0]}"
           xcrun stapler validate "${apps[0]}"
           spctl --assess --type execute --verbose=2 "${apps[0]}"
+
+      - name: Verify unsigned macOS app signature
+        if: matrix.platform == 'mac' && env.MACOS_SIGNED != 'true'
+        shell: bash
+        run: |
+          dmg="release/Akeru-Bot-$RELEASE_VERSION-arm64.dmg"
+          mount_point="$RUNNER_TEMP/akeru-unsigned-dmg"
+          mkdir -p "$mount_point"
+          hdiutil attach "$dmg" -nobrowse -readonly -mountpoint "$mount_point"
+          trap 'hdiutil detach "$mount_point" >/dev/null 2>&1 || true' EXIT
+          apps=("$mount_point"/*.app)
+          test "${#apps[@]}" -eq 1
+          codesign --verify --deep --strict --verbose=2 "${apps[0]}"
+          signature="$(codesign -dv --verbose=4 "${apps[0]}" 2>&1)"
+          printf '%s\n' "$signature"
+          if ! printf '%s\n' "$signature" | grep -q 'Identifier=dev.leodoes.akeru$'; then
+            printf 'Packaged app is missing the Akeru bundle identifier.\n' >&2
+            exit 1
+          fi
 
       - name: Launch macOS DMG
         if: matrix.platform == 'mac'

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -301,7 +301,7 @@ jobs:
             printf 'Packaged app does not use an ad-hoc signature.\n' >&2
             exit 1
           fi
-          if ! printf '%s\n' "$signature" | grep -q 'Identifier=dev.leodoes.akeru$'; then
+          if ! printf '%s\n' "$signature" | grep -Fqx 'Identifier=dev.leodoes.akeru'; then
             printf 'Packaged app is missing the Akeru bundle identifier.\n' >&2
             exit 1
           fi

--- a/docs/operations/release.md
+++ b/docs/operations/release.md
@@ -41,7 +41,11 @@ the Apple Silicon macOS and Windows runners. The Tenki Runner GitHub App must ha
 
 ## macOS secrets
 
-Add these GitHub Actions secrets before running the workflow:
+The stable release builds a sealed, ad-hoc-signed DMG when all macOS secrets are absent. Users
+must approve that build through the macOS Gatekeeper installation flow. If any macOS secret is
+present, the workflow requires the complete set and stops on a partial configuration.
+
+Add these GitHub Actions secrets to publish a Developer ID signed and notarized DMG:
 
 - `MACOS_CERTIFICATE_P12` contains the base64-encoded `.p12` export of the Developer ID Application
   certificate and its private key.

--- a/scripts/ci-workflow-policy.test.ts
+++ b/scripts/ci-workflow-policy.test.ts
@@ -171,5 +171,8 @@ describe("CI workflow budget", () => {
     expect(
       steps.find((step) => step.name === "Verify unsigned macOS app signature")?.run,
     ).toContain("^Signature=adhoc$");
+    expect(
+      steps.find((step) => step.name === "Verify unsigned macOS app signature")?.run,
+    ).toContain("grep -Fqx 'Identifier=dev.leodoes.akeru'");
   });
 });

--- a/scripts/ci-workflow-policy.test.ts
+++ b/scripts/ci-workflow-policy.test.ts
@@ -5,6 +5,7 @@ import { describe, expect, it } from "vite-plus/test";
 import { parse } from "yaml";
 
 type Step = {
+  readonly name?: string;
   readonly id?: string;
   readonly if?: string;
   readonly run?: string;
@@ -143,5 +144,29 @@ describe("CI workflow budget", () => {
     expect(text).toContain("if: needs.preflight.outputs.publish == 'true'");
     expect(text).toContain('if test "$EVENT_NAME" != workflow_dispatch');
     expect(text).toContain("gh workflow run version-packages.yml --ref main");
+  });
+
+  it("builds an ad-hoc-signed macOS release when Apple credentials are absent", () => {
+    const release = workflow(".github/workflows/release.yml");
+    const steps = release.jobs.desktop?.steps ?? [];
+
+    expect(steps.find((step) => step.name === "Validate macOS signing credentials")?.run).toContain(
+      "present != 0 && present != ${#values[@]}",
+    );
+    expect(steps.find((step) => step.name === "Build signed macOS artifact")?.if).toBe(
+      "matrix.platform == 'mac' && env.MACOS_SIGNED == 'true'",
+    );
+    expect(steps.find((step) => step.name === "Build unsigned macOS artifact")?.if).toBe(
+      "matrix.platform == 'mac' && env.MACOS_SIGNED != 'true'",
+    );
+    expect(steps.find((step) => step.name === "Build unsigned macOS artifact")?.run).not.toContain(
+      "--signed",
+    );
+    expect(steps.find((step) => step.name === "Notarize and verify macOS DMG")?.if).toBe(
+      "matrix.platform == 'mac' && env.MACOS_SIGNED == 'true'",
+    );
+    expect(steps.find((step) => step.name === "Verify unsigned macOS app signature")?.if).toBe(
+      "matrix.platform == 'mac' && env.MACOS_SIGNED != 'true'",
+    );
   });
 });

--- a/scripts/ci-workflow-policy.test.ts
+++ b/scripts/ci-workflow-policy.test.ts
@@ -168,5 +168,8 @@ describe("CI workflow budget", () => {
     expect(steps.find((step) => step.name === "Verify unsigned macOS app signature")?.if).toBe(
       "matrix.platform == 'mac' && env.MACOS_SIGNED != 'true'",
     );
+    expect(
+      steps.find((step) => step.name === "Verify unsigned macOS app signature")?.run,
+    ).toContain("^Signature=adhoc$");
   });
 });

--- a/scripts/release-smoke.ts
+++ b/scripts/release-smoke.ts
@@ -112,10 +112,9 @@ for (const [needle, label] of [
   ["runner: macos-15", "GitHub-hosted Apple Silicon macOS runner"],
   ["runner: windows-2025", "GitHub-hosted Windows runner"],
   ["runner: tenki-standard-medium-4c-8g", "Tenki Linux runner"],
-  [
-    "Stable macOS releases require complete signing and notarization credentials.",
-    "required macOS signing credentials",
-  ],
+  ["macOS signing credentials must be either complete or absent.", "macOS signing mode"],
+  ["Build unsigned macOS artifact", "unsigned macOS fallback"],
+  ["Verify unsigned macOS app signature", "unsigned macOS signature verification"],
   ["--signed", "existing signed build path"],
   ["xcrun notarytool submit", "macOS notarization"],
   ["verify-release-assets.ts", "asset name and hash verification"],
@@ -127,11 +126,6 @@ for (const [needle, label] of [
 }
 
 assertContains(releaseWorkflow, "tag=v%s\\n", "Stable release workflow does not use a vX.Y.Z tag.");
-assertOmits(
-  releaseWorkflow,
-  "Verify unsigned macOS app signature",
-  "stable unsigned macOS artifact path",
-);
 for (const [needle, label] of [
   ["branches: [main]", "main branch trigger"],
   ["vp run release:version-pr", "version pull request command"],
@@ -175,7 +169,10 @@ const parsedReleaseWorkflow = parse(releaseWorkflow) as {
 };
 for (const step of parsedReleaseWorkflow.jobs?.desktop?.steps ?? []) {
   const secretInputs = JSON.stringify({ env: step.env, with: step.with });
-  if (/MACOS_|APPSTORE_|APPLE_API_/u.test(secretInputs) && step.if !== "matrix.platform == 'mac'") {
+  if (
+    /MACOS_|APPSTORE_|APPLE_API_/u.test(secretInputs) &&
+    !step.if?.startsWith("matrix.platform == 'mac'")
+  ) {
     throw new Error(`${step.name ?? "Unnamed step"} exposes macOS secrets outside the macOS job.`);
   }
   if (/AZURE_/u.test(secretInputs) && step.if !== "matrix.platform == 'win'") {

--- a/scripts/release-smoke.ts
+++ b/scripts/release-smoke.ts
@@ -167,12 +167,13 @@ const parsedReleaseWorkflow = parse(releaseWorkflow) as {
     };
   };
 };
+const macOSConditions = new Set([
+  "matrix.platform == 'mac'",
+  "matrix.platform == 'mac' && env.MACOS_SIGNED == 'true'",
+]);
 for (const step of parsedReleaseWorkflow.jobs?.desktop?.steps ?? []) {
   const secretInputs = JSON.stringify({ env: step.env, with: step.with });
-  if (
-    /MACOS_|APPSTORE_|APPLE_API_/u.test(secretInputs) &&
-    !step.if?.startsWith("matrix.platform == 'mac'")
-  ) {
+  if (/MACOS_|APPSTORE_|APPLE_API_/u.test(secretInputs) && !macOSConditions.has(step.if ?? "")) {
     throw new Error(`${step.name ?? "Unnamed step"} exposes macOS secrets outside the macOS job.`);
   }
   if (/AZURE_/u.test(secretInputs) && step.if !== "matrix.platform == 'win'") {


### PR DESCRIPTION
The stable release currently stops when Apple signing credentials are absent, which blocks v0.0.39 after the Windows and Linux artifacts pass.

Allow the macOS job to use the existing sealed ad-hoc signature when all Apple credentials are absent. Keep Developer ID signing and notarization when the complete secret set exists, reject partial configuration, and verify the unsigned app signature and bundle identifier before launch and publication.

Model: gpt-5.6-sol
Harness: Codex in T3 Code