### PR TITLE
fix(server): keep libsql native loader external to the CLI bundle

### DIFF
--- a/scripts/lib/cli-external-packages.test.ts
+++ b/scripts/lib/cli-external-packages.test.ts
@@ -33,7 +33,16 @@ const decodeManifest = Schema.decodeUnknownSync(Schema.fromJsonString(PackageMan
 
 describe("shouldBundleCliDependency", () => {
   it("bundles ordinary runtime dependencies", () => {
-    for (const id of ["effect", "@effect/platform", "hono", "@t3tools/shared/hostProcess"]) {
+    for (const id of [
+      "effect",
+      "@effect/platform",
+      "hono",
+      "@t3tools/shared/hostProcess",
+      "@libsql/client",
+      "@libsql/core",
+      "@libsql/hrana-client",
+      "@libsql/isomorphic-ws",
+    ]) {
       assert.strictEqual(shouldBundleCliDependency(id), true, id);
     }
   });
@@ -46,6 +55,13 @@ describe("shouldBundleCliDependency", () => {
     for (const id of [
       "playwright-core",
       "node-pty",
+      "libsql",
+      "libsql/promise",
+      "@neon-rs/load",
+      "@libsql/darwin-arm64",
+      "@libsql/linux-x64-gnu",
+      "@libsql/linux-x64-musl",
+      "@libsql/win32-x64-msvc",
       "ffi-rs",
       "@yuuang/ffi-rs-win32-x64-msvc",
       "@ff-labs/fff-node",
@@ -90,13 +106,13 @@ describe("selectCliRuntimeExternalDependencies", () => {
   it("selects every external root declared by the server", () => {
     assert.deepStrictEqual(
       Object.keys(selectCliRuntimeExternalDependencies(serverPackageJson.dependencies)).sort(),
-      ["@ff-labs/fff-node", "msgpackr-extract", "node-pty", "playwright-core"],
+      ["@ff-labs/fff-node", "libsql", "msgpackr-extract", "node-pty", "playwright-core"],
     );
   });
 });
 
 describe("selectCliPackagedRuntimeDependencies", () => {
-  it("stages bundled packages that load platform-native bindings", () => {
+  it("stages external native packages and lazy runtime packages", () => {
     assert.deepStrictEqual(
       selectCliPackagedRuntimeDependencies({
         effect: "4.0.0",
@@ -189,7 +205,13 @@ it.layer(NodeServices.layer)("external package dependency closure", (it) => {
       // Without this the closure check below can pass vacuously: if nothing is
       // read, nothing is checked. These are the packages whose closure actually
       // broke WSL, so require them by name.
-      for (const required of ["node-pty", "node-gyp-build-optional-packages", "detect-libc"]) {
+      for (const required of [
+        "node-pty",
+        "node-gyp-build-optional-packages",
+        "detect-libc",
+        "libsql",
+        "@neon-rs/load",
+      ]) {
         assert.ok(
           found.includes(required),
           `expected ${required} in the pnpm store; the closure check is only meaningful if it can read these (found ${found.length})`,
@@ -256,6 +278,14 @@ var x = 1;
 
     assert.deepStrictEqual(result.inlined, ["detect-libc", "msgpackr-extract"]);
     assert.strictEqual(result.regionCount, 2);
+  });
+
+  it("flags an inlined libsql loader before desktop packaging", () => {
+    const result = findInlinedExternalPackages(
+      region("../../node_modules/.pnpm/libsql@0.5.29/node_modules/libsql/index.js") +
+        region("../../node_modules/@neon-rs/load/dist/index.js"),
+    );
+    assert.deepStrictEqual(result.inlined, ["@neon-rs/load", "libsql"]);
   });
 
   it("flags scoped external packages", () => {

--- a/scripts/lib/cli-external-packages.test.ts
+++ b/scripts/lib/cli-external-packages.test.ts
@@ -10,8 +10,8 @@ import * as Schema from "effect/Schema";
 import serverPackageJson from "../../apps/server/package.json" with { type: "json" };
 
 import {
-  CLI_RUNTIME_EXTERNAL_PREFIXES,
   findInlinedExternalPackages,
+  isRuntimeExternalCliDependency,
   selectCliPackagedRuntimeDependencies,
   selectCliRuntimeExternalDependencies,
   shouldBundleCliDependency,
@@ -42,6 +42,8 @@ describe("shouldBundleCliDependency", () => {
       "@libsql/core",
       "@libsql/hrana-client",
       "@libsql/isomorphic-ws",
+      "libsqlite3",
+      "libsqlx",
     ]) {
       assert.strictEqual(shouldBundleCliDependency(id), true, id);
     }
@@ -194,8 +196,7 @@ it.layer(NodeServices.layer)("external package dependency closure", (it) => {
 
   // Runtime-external only. The build-only entries resolve `bun:*` and are never
   // loaded by Node, so their closure genuinely does not need to be external.
-  const isRuntimeExternal = (name: string) =>
-    CLI_RUNTIME_EXTERNAL_PREFIXES.some((prefix) => name.startsWith(prefix));
+  const isRuntimeExternal = (name: string) => isRuntimeExternalCliDependency(name);
 
   it.effect("finds the runtime-external packages on disk", () =>
     Effect.gen(function* () {

--- a/scripts/lib/cli-external-packages.ts
+++ b/scripts/lib/cli-external-packages.ts
@@ -30,6 +30,12 @@ export const CLI_RUNTIME_EXTERNAL_PREFIXES = [
   // Inlining it into the ESM server bundle removes that CommonJS binding.
   "playwright-core",
   "node-pty",
+  // Keep computed native imports and detect-libc resolution inside libsql.
+  "libsql",
+  "@libsql/darwin-",
+  "@libsql/linux-",
+  "@libsql/win32-",
+  "@neon-rs/load",
   "ffi-rs",
   "@yuuang/",
   "@ff-labs/",
@@ -64,11 +70,6 @@ export const CLI_BUILD_ONLY_EXTERNAL_PREFIXES = [
   "@effect/platform-bun",
   "@effect/sql-sqlite-bun",
 ] as const;
-
-// These packages stay bundled, but load target-specific native bindings with a
-// computed require. Ship their package roots so the staged install also brings
-// the correct optional binding for the target OS and architecture.
-export const CLI_BUNDLED_NATIVE_RUNTIME_PACKAGES = ["libsql"] as const;
 
 // Mastra constructs this import at runtime to keep Node-only dependencies out
 // of Cloudflare Worker bundles. The CLI bundler cannot see it, so desktop
@@ -121,7 +122,6 @@ export function selectCliPackagedRuntimeDependencies(
     Object.entries(dependencies).filter(
       ([name]) =>
         isRuntimeExternalCliDependency(name) ||
-        CLI_BUNDLED_NATIVE_RUNTIME_PACKAGES.some((packageName) => name === packageName) ||
         CLI_LAZY_RUNTIME_PACKAGES.some((packageName) => name === packageName),
     ),
   );

--- a/scripts/lib/cli-external-packages.ts
+++ b/scripts/lib/cli-external-packages.ts
@@ -31,7 +31,9 @@ export const CLI_RUNTIME_EXTERNAL_PREFIXES = [
   "playwright-core",
   "node-pty",
   // Keep computed native imports and detect-libc resolution inside libsql.
-  "libsql",
+  // The trailing slash keeps unrelated names such as libsqlite3 bundled;
+  // the bare package name is matched exactly below.
+  "libsql/",
   "@libsql/darwin-",
   "@libsql/linux-",
   "@libsql/win32-",
@@ -81,8 +83,16 @@ export const CLI_EXTERNAL_PACKAGE_PREFIXES = [
   ...CLI_BUILD_ONLY_EXTERNAL_PREFIXES,
 ] as const;
 
+function matchesExternalPrefix(id: string, prefixes: ReadonlyArray<string>): boolean {
+  return prefixes.some((prefix) =>
+    prefix.endsWith("/")
+      ? id === prefix.slice(0, -1) || id.startsWith(prefix)
+      : id.startsWith(prefix),
+  );
+}
+
 export function isRuntimeExternalCliDependency(id: string): boolean {
-  return CLI_RUNTIME_EXTERNAL_PREFIXES.some((prefix) => id.startsWith(prefix));
+  return matchesExternalPrefix(id, CLI_RUNTIME_EXTERNAL_PREFIXES);
 }
 
 /**
@@ -96,7 +106,7 @@ export function isRuntimeExternalCliDependency(id: string): boolean {
  * inlined while node-pty (a declared dependency) stayed external.
  */
 export function isExternalCliDependency(id: string): boolean {
-  return CLI_EXTERNAL_PACKAGE_PREFIXES.some((prefix) => id.startsWith(prefix));
+  return matchesExternalPrefix(id, CLI_EXTERNAL_PACKAGE_PREFIXES);
 }
 
 /** True when the CLI bundle should inline `id` rather than leave it external. */


### PR DESCRIPTION
## Why

The built desktop backend crashed at startup with `Cannot find module 'detect-libc'`. Bundling `libsql` inlined its native loader, whose `require` calls cannot resolve from `dist/bin.mjs` under pnpm isolation. `vp run build:desktop` succeeded, so the breakage only appeared at runtime.

## What changed

- Externalize `libsql`, `@neon-rs/load`, and the `@libsql/<platform>-` binding prefixes in `scripts/lib/cli-external-packages.ts`. `@libsql/client` and the other pure-JS `@libsql/*` packages stay bundled.
- Remove the obsolete bundled-native exception for `libsql`; packaging still stages the direct dependency through the runtime-external selection.
- Extend the closure test to require `libsql` and `@neon-rs/load` in the store, and add an artifact-scan case for an inlined libsql loader, so the check cannot pass vacuously.

## Testing

- `vp test run scripts/lib/cli-external-packages.test.ts scripts/build-desktop-artifact.test.ts` — 66 passed.
- Rebuilt with `vp run build:desktop`; all 68 emitted chunks contain no inlined external packages, and resolving `libsql` from the built entry path executed an in-memory `SELECT 1`.
- Launched the rebuilt app in an isolated raw Electron run: backend ready, main window created, renderer navigation and reload verified with browser automation.

## Notes

Part 1 of a 4-PR stack; the desktop smoke-test hardening in the next PR is what catches this class of failure automatically.

Model: gpt-6-astra and claude-fable-5-1-auto through the Grok harness in T3 Code.
