### PR TITLE
fix(desktop): stop claiming legacy t3code:// protocol schemes

### DIFF
--- a/apps/desktop/scripts/electron-launcher.mjs
+++ b/apps/desktop/scripts/electron-launcher.mjs
@@ -19,8 +19,8 @@ export const APP_DISPLAY_NAME = isDevelopment ? "Akeru Bot (Dev)" : "Akeru Bot (
 export const APP_BUNDLE_ID = isDevelopment
   ? `dev.leodoes.akeru.dev.${devBundleIdSuffix || "local"}`
   : "dev.leodoes.akeru";
-const APP_PROTOCOL_SCHEMES = isDevelopment ? ["akeru-dev", "t3code-dev"] : ["akeru", "t3code"];
-const LAUNCHER_VERSION = 15;
+const APP_PROTOCOL_SCHEMES = isDevelopment ? ["akeru-dev"] : ["akeru"];
+const LAUNCHER_VERSION = 16;
 const productionMacIconPngPath = NodePath.join(repoRoot, "assets", "prod", "akeru-macos-1024.png");
 // oxlint-disable-next-line t3code/no-global-process-runtime -- Standalone launcher script has no Effect runtime.
 const hostPlatform = NodeOS.platform();

--- a/apps/desktop/src/app/DesktopApp.ts
+++ b/apps/desktop/src/app/DesktopApp.ts
@@ -178,19 +178,11 @@ const bootstrap = Effect.gen(function* () {
   const rendererTarget = environment.isDevelopment
     ? Option.getOrThrow(environment.devServerUrl)
     : backendConfig.httpBaseUrl;
-  yield* Effect.all(
-    [
-      ElectronProtocol.getDesktopScheme(environment.isDevelopment),
-      ElectronProtocol.getLegacyDesktopScheme(environment.isDevelopment),
-    ].map((scheme) =>
-      electronProtocol.registerDesktopProtocol({
-        scheme,
-        targetOrigin: rendererTarget,
-        backendOrigin: backendConfig.httpBaseUrl,
-      }),
-    ),
-    { concurrency: "unbounded" },
-  );
+  yield* electronProtocol.registerDesktopProtocol({
+    scheme: ElectronProtocol.getDesktopScheme(environment.isDevelopment),
+    targetOrigin: rendererTarget,
+    backendOrigin: backendConfig.httpBaseUrl,
+  });
   yield* logBootstrapInfo("bootstrap resolved backend endpoint", {
     baseUrl: backendConfig.httpBaseUrl.href,
   });

--- a/apps/desktop/src/app/DesktopLinuxUrlHandler.test.ts
+++ b/apps/desktop/src/app/DesktopLinuxUrlHandler.test.ts
@@ -196,7 +196,7 @@ describe("DesktopLinuxUrlHandler", () => {
       [
         "[Default Applications]",
         "x-scheme-handler/t3code=akeru-url-handler.desktop",
-        "x-scheme-handler/t3code-dev=akeru-url-handler.desktop;",
+        "x-scheme-handler/t3code-dev=akeru-url-handler.desktop;other.desktop;",
         "x-scheme-handler/akeru=akeru-url-handler.desktop",
         "x-scheme-handler/t3code=t3code-url-handler.desktop",
         "text/html=firefox.desktop",
@@ -207,6 +207,7 @@ describe("DesktopLinuxUrlHandler", () => {
       cleaned,
       [
         "[Default Applications]",
+        "x-scheme-handler/t3code-dev=other.desktop;",
         "x-scheme-handler/akeru=akeru-url-handler.desktop",
         "x-scheme-handler/t3code=t3code-url-handler.desktop",
         "text/html=firefox.desktop",

--- a/apps/desktop/src/app/DesktopLinuxUrlHandler.test.ts
+++ b/apps/desktop/src/app/DesktopLinuxUrlHandler.test.ts
@@ -107,7 +107,7 @@ describe("DesktopLinuxUrlHandler", () => {
     const entry = DesktopLinuxUrlHandler.renderUrlHandlerDesktopEntry({
       displayName: "Akeru Bot (Dev)",
       execTarget: '/home/al ice/Apps/T3 "100%" $HOME\\x.AppImage',
-      schemes: ["akeru", "t3code"],
+      schemes: ["akeru"],
     });
 
     assert.include(entry, "[Desktop Entry]");
@@ -122,7 +122,6 @@ describe("DesktopLinuxUrlHandler", () => {
     assert.include(entry, "NoDisplay=true");
     assert.notInclude(entry, "StartupWMClass=");
     assert.include(entry, "MimeType=x-scheme-handler/akeru;");
-    assert.include(entry, "x-scheme-handler/t3code;");
   });
 
   it("carries structured context on registration errors", () => {
@@ -169,15 +168,10 @@ describe("DesktopLinuxUrlHandler", () => {
         'Exec="/home/alice/Applications/T3-Code.AppImage" %U',
       );
       assert.include(recorded.files[0]?.content, "MimeType=x-scheme-handler/akeru;");
-      assert.include(recorded.files[0]?.content, "x-scheme-handler/t3code;");
       assert.deepEqual(recorded.commands, [
         {
           command: "xdg-mime",
           args: ["default", "akeru-url-handler.desktop", "x-scheme-handler/akeru"],
-        },
-        {
-          command: "xdg-mime",
-          args: ["default", "akeru-url-handler.desktop", "x-scheme-handler/t3code"],
         },
       ]);
     });

--- a/apps/desktop/src/app/DesktopLinuxUrlHandler.test.ts
+++ b/apps/desktop/src/app/DesktopLinuxUrlHandler.test.ts
@@ -25,6 +25,7 @@ const makeEnvironment = (overrides: Record<string, unknown> = {}) =>
     displayName: "Akeru Bot (Alpha)",
     linuxWmClass: "akeru-bot",
     linuxApplicationsDir: "/home/alice/.local/share/applications",
+    appDataDirectory: "/home/alice/.config",
     appImagePath: Option.some("/home/alice/Applications/T3-Code.AppImage"),
     path: { join: (...parts: ReadonlyArray<string>) => parts.join("/") },
     ...overrides,
@@ -51,6 +52,7 @@ const makeHandlerLayer = (
     readonly environment?: Record<string, unknown>;
     readonly xdgMimeExitCode?: number;
     readonly writeError?: PlatformError.PlatformError;
+    readonly mimeappsContent?: string;
   } = {},
 ) =>
   DesktopLinuxUrlHandler.layer.pipe(
@@ -62,6 +64,18 @@ const makeHandlerLayer = (
             Effect.sync(() => {
               recorded.directories.push(path);
             }),
+          readFileString: (path) =>
+            input.mimeappsContent === undefined
+              ? Effect.fail(
+                  PlatformError.systemError({
+                    _tag: "NotFound",
+                    module: "FileSystem",
+                    method: "readFileString",
+                    description: "no mimeapps.list",
+                    pathOrDescriptor: path,
+                  }),
+                )
+              : Effect.succeed(input.mimeappsContent),
           writeFileString: (path, content) =>
             input.writeError
               ? Effect.fail(input.writeError)
@@ -174,6 +188,70 @@ describe("DesktopLinuxUrlHandler", () => {
           args: ["default", "akeru-url-handler.desktop", "x-scheme-handler/akeru"],
         },
       ]);
+    });
+  });
+
+  it("releases only retired schemes that point at our handler entry", () => {
+    const cleaned = DesktopLinuxUrlHandler.removeRetiredSchemeAssociations(
+      [
+        "[Default Applications]",
+        "x-scheme-handler/t3code=akeru-url-handler.desktop",
+        "x-scheme-handler/t3code-dev=akeru-url-handler.desktop;",
+        "x-scheme-handler/akeru=akeru-url-handler.desktop",
+        "x-scheme-handler/t3code=t3code-url-handler.desktop",
+        "text/html=firefox.desktop",
+      ].join("\n"),
+    );
+
+    assert.equal(
+      cleaned,
+      [
+        "[Default Applications]",
+        "x-scheme-handler/akeru=akeru-url-handler.desktop",
+        "x-scheme-handler/t3code=t3code-url-handler.desktop",
+        "text/html=firefox.desktop",
+      ].join("\n"),
+    );
+    assert.isNull(
+      DesktopLinuxUrlHandler.removeRetiredSchemeAssociations(
+        "x-scheme-handler/akeru=akeru-url-handler.desktop\n",
+      ),
+    );
+  });
+
+  it.effect("rewrites mimeapps.list when a retired scheme still points at Akeru", () => {
+    const recorded = emptyRecording();
+
+    return Effect.gen(function* () {
+      yield* runRegister(recorded, {
+        mimeappsContent: [
+          "[Default Applications]",
+          "x-scheme-handler/t3code=akeru-url-handler.desktop",
+          "x-scheme-handler/akeru=akeru-url-handler.desktop",
+        ].join("\n"),
+      });
+
+      const mimeappsWrite = recorded.files.find(
+        (file) => file.path === "/home/alice/.config/mimeapps.list",
+      );
+      assert.equal(
+        mimeappsWrite?.content,
+        ["[Default Applications]", "x-scheme-handler/akeru=akeru-url-handler.desktop"].join("\n"),
+      );
+    });
+  });
+
+  it.effect("leaves mimeapps.list alone when no retired scheme points at Akeru", () => {
+    const recorded = emptyRecording();
+
+    return Effect.gen(function* () {
+      yield* runRegister(recorded, {
+        mimeappsContent: "x-scheme-handler/t3code=t3code-url-handler.desktop\n",
+      });
+
+      assert.isUndefined(
+        recorded.files.find((file) => file.path === "/home/alice/.config/mimeapps.list"),
+      );
     });
   });
 

--- a/apps/desktop/src/app/DesktopLinuxUrlHandler.ts
+++ b/apps/desktop/src/app/DesktopLinuxUrlHandler.ts
@@ -22,6 +22,27 @@ import { makeComponentLogger } from "./DesktopObservability.ts";
 // default" checkbox would record in mimeapps.list.
 export const URL_HANDLER_DESKTOP_ENTRY_NAME = "akeru-url-handler.desktop";
 
+// Schemes older releases claimed for this same handler entry. Their defaults
+// must be released on upgrade or t3code:// links keep launching Akeru.
+export const RETIRED_URL_HANDLER_SCHEMES = ["t3code", "t3code-dev"] as const;
+
+// Drops mimeapps.list association lines that point a retired scheme at our
+// handler entry, leaving every other application's claims untouched. Returns
+// null when nothing changed.
+export function removeRetiredSchemeAssociations(mimeappsContent: string): string | null {
+  const lines = mimeappsContent.split("\n");
+  const retained = lines.filter((line) => {
+    const match = /^x-scheme-handler\/([^=]+)=(.*)$/.exec(line.trim());
+    if (match === null) return true;
+    const [, scheme, handlers] = match;
+    return !(
+      (RETIRED_URL_HANDLER_SCHEMES as readonly string[]).includes(scheme!) &&
+      handlers!.split(";").includes(URL_HANDLER_DESKTOP_ENTRY_NAME)
+    );
+  });
+  return retained.length === lines.length ? null : retained.join("\n");
+}
+
 const { logInfo, logWarning } = makeComponentLogger("desktop-linux-url-handler");
 
 export class DesktopLinuxUrlHandlerRegistrationError extends Schema.TaggedErrorClass<DesktopLinuxUrlHandlerRegistrationError>()(
@@ -163,12 +184,33 @@ export const make = Effect.gen(function* () {
       ),
     );
 
+  // On Linux, appDataDirectory is XDG_CONFIG_HOME — where xdg-mime records
+  // per-user defaults. Only associations that point at our own handler entry
+  // are removed, so a real T3 install's claims stay intact.
+  const releaseRetiredSchemes = Effect.gen(function* () {
+    const mimeappsPath = environment.path.join(environment.appDataDirectory, "mimeapps.list");
+    const content = yield* fileSystem.readFileString(mimeappsPath);
+    const cleaned = removeRetiredSchemeAssociations(content);
+    if (cleaned === null) {
+      return;
+    }
+    yield* fileSystem.writeFileString(mimeappsPath, cleaned);
+    yield* logInfo("released retired URL scheme defaults", {
+      schemes: RETIRED_URL_HANDLER_SCHEMES,
+    });
+  }).pipe(
+    // Best-effort like the rest of registration; a missing mimeapps.list is
+    // the common case on fresh installs.
+    Effect.ignore,
+  );
+
   const register = Effect.gen(function* () {
     if (environment.platform !== "linux" || !environment.isPackaged) {
       return;
     }
     yield* writeDesktopEntry;
     yield* Effect.forEach(schemes, setDefaultHandler, { discard: true });
+    yield* releaseRetiredSchemes;
     yield* logInfo("registered URL scheme handlers", { schemes });
   }).pipe(
     // Registration is best-effort: a missing xdg-mime or read-only home must

--- a/apps/desktop/src/app/DesktopLinuxUrlHandler.ts
+++ b/apps/desktop/src/app/DesktopLinuxUrlHandler.ts
@@ -98,7 +98,7 @@ export const make = Effect.gen(function* () {
   const spawner = yield* ChildProcessSpawner.ChildProcessSpawner;
 
   const scheme = ElectronProtocol.getDesktopScheme(environment.isDevelopment);
-  const schemes = [scheme, ElectronProtocol.getLegacyDesktopScheme(environment.isDevelopment)];
+  const schemes = [scheme];
   const desktopEntryPath = environment.path.join(
     environment.linuxApplicationsDir,
     URL_HANDLER_DESKTOP_ENTRY_NAME,

--- a/apps/desktop/src/app/DesktopLinuxUrlHandler.ts
+++ b/apps/desktop/src/app/DesktopLinuxUrlHandler.ts
@@ -26,21 +26,28 @@ export const URL_HANDLER_DESKTOP_ENTRY_NAME = "akeru-url-handler.desktop";
 // must be released on upgrade or t3code:// links keep launching Akeru.
 export const RETIRED_URL_HANDLER_SCHEMES = ["t3code", "t3code-dev"] as const;
 
-// Drops mimeapps.list association lines that point a retired scheme at our
-// handler entry, leaving every other application's claims untouched. Returns
-// null when nothing changed.
+// Removes our handler entry from mimeapps.list associations for retired
+// schemes, keeping any other application's handlers on the same line and
+// dropping the line only when ours was the last one. Returns null when
+// nothing changed.
 export function removeRetiredSchemeAssociations(mimeappsContent: string): string | null {
-  const lines = mimeappsContent.split("\n");
-  const retained = lines.filter((line) => {
+  let changed = false;
+  const retained = mimeappsContent.split("\n").flatMap((line) => {
     const match = /^x-scheme-handler\/([^=]+)=(.*)$/.exec(line.trim());
-    if (match === null) return true;
+    if (match === null) return [line];
     const [, scheme, handlers] = match;
-    return !(
-      (RETIRED_URL_HANDLER_SCHEMES as readonly string[]).includes(scheme!) &&
-      handlers!.split(";").includes(URL_HANDLER_DESKTOP_ENTRY_NAME)
-    );
+    if (!(RETIRED_URL_HANDLER_SCHEMES as readonly string[]).includes(scheme!)) {
+      return [line];
+    }
+    const entries = handlers!.split(";").filter((handler) => handler.length > 0);
+    const others = entries.filter((handler) => handler !== URL_HANDLER_DESKTOP_ENTRY_NAME);
+    if (others.length === entries.length) {
+      return [line];
+    }
+    changed = true;
+    return others.length === 0 ? [] : [`x-scheme-handler/${scheme}=${others.join(";")};`];
   });
-  return retained.length === lines.length ? null : retained.join("\n");
+  return changed ? retained.join("\n") : null;
 }
 
 const { logInfo, logWarning } = makeComponentLogger("desktop-linux-url-handler");

--- a/apps/desktop/src/electron/ElectronProtocol.test.ts
+++ b/apps/desktop/src/electron/ElectronProtocol.test.ts
@@ -87,26 +87,6 @@ describe("ElectronProtocol", () => {
     }).pipe(Effect.provide(ElectronProtocol.layer)),
   );
 
-  it.effect("registers current and legacy renderer schemes together", () =>
-    Effect.scoped(
-      Effect.gen(function* () {
-        const protocol = yield* ElectronProtocol.ElectronProtocol;
-        yield* Effect.all(
-          ["akeru", "t3code"].map((scheme) =>
-            protocol.registerDesktopProtocol({
-              scheme,
-              targetOrigin: new URL("http://127.0.0.1:3773/"),
-              backendOrigin: new URL("http://127.0.0.1:3773/"),
-            }),
-          ),
-          { concurrency: "unbounded" },
-        );
-
-        assert.deepEqual(handleMock.mock.calls.map((call) => call[0]).sort(), ["akeru", "t3code"]);
-      }),
-    ).pipe(Effect.provide(ElectronProtocol.layer)),
-  );
-
   it.effect("rejects custom protocol requests for another host", () =>
     Effect.gen(function* () {
       let handler: ((request: Request) => Promise<Response>) | undefined;

--- a/apps/desktop/src/electron/ElectronProtocol.ts
+++ b/apps/desktop/src/electron/ElectronProtocol.ts
@@ -11,15 +11,9 @@ import * as Electron from "electron";
 export const DESKTOP_HOST = "app";
 export const DESKTOP_PRODUCTION_SCHEME = "akeru";
 export const DESKTOP_DEVELOPMENT_SCHEME = "akeru-dev";
-export const LEGACY_DESKTOP_PRODUCTION_SCHEME = "t3code";
-export const LEGACY_DESKTOP_DEVELOPMENT_SCHEME = "t3code-dev";
 
 export function getDesktopScheme(isDevelopment: boolean): string {
   return isDevelopment ? DESKTOP_DEVELOPMENT_SCHEME : DESKTOP_PRODUCTION_SCHEME;
-}
-
-export function getLegacyDesktopScheme(isDevelopment: boolean): string {
-  return isDevelopment ? LEGACY_DESKTOP_DEVELOPMENT_SCHEME : LEGACY_DESKTOP_PRODUCTION_SCHEME;
 }
 
 export function getDesktopOrigin(isDevelopment: boolean): string {
@@ -116,24 +110,6 @@ export function registerDesktopSchemePrivilegesSync(): void {
     },
     {
       scheme: DESKTOP_DEVELOPMENT_SCHEME,
-      privileges: {
-        standard: true,
-        secure: true,
-        supportFetchAPI: true,
-        corsEnabled: true,
-      },
-    },
-    {
-      scheme: LEGACY_DESKTOP_PRODUCTION_SCHEME,
-      privileges: {
-        standard: true,
-        secure: true,
-        supportFetchAPI: true,
-        corsEnabled: true,
-      },
-    },
-    {
-      scheme: LEGACY_DESKTOP_DEVELOPMENT_SCHEME,
       privileges: {
         standard: true,
         secure: true,

--- a/apps/mobile/app.config.ts
+++ b/apps/mobile/app.config.ts
@@ -160,10 +160,7 @@ const config: ExpoConfig = {
   name: variant.appName,
   slug: "akeru-bot",
   platforms: ["ios", "android"],
-  scheme:
-    variant.scheme === "akeru"
-      ? ["akeru", "t3code"]
-      : [variant.scheme, "t3code-dev", "akeru", "t3code"],
+  scheme: variant.scheme === "akeru" ? ["akeru"] : [variant.scheme, "akeru"],
   version: "1.0.4",
   runtimeVersion: {
     // Fingerprint (not appVersion) so an OTA only reaches binaries whose native

--- a/apps/mobile/src/App.tsx
+++ b/apps/mobile/src/App.tsx
@@ -35,7 +35,7 @@ void SplashScreen.preventAutoHideAsync().catch(() => {
 });
 
 const appLinking = {
-  prefixes: [Linking.createURL("/"), "akeru://", "akeru-dev://", "t3code://", "t3code-dev://"],
+  prefixes: [Linking.createURL("/"), "akeru://", "akeru-dev://"],
   // The Expo dev client launches the app via
   // <scheme>://expo-development-client/?url=<packager> — that URL addresses
   // the launcher, not app navigation. Without this filter it falls through

--- a/apps/mobile/src/features/connection/pairing.test.ts
+++ b/apps/mobile/src/features/connection/pairing.test.ts
@@ -42,14 +42,6 @@ describe("extractPairingUrlFromQrPayload", () => {
     ).toBe("https://remote.example.com/pair#token=pairing-token");
   });
 
-  it("keeps accepting legacy T3 Code pairing deep links", () => {
-    expect(
-      extractPairingUrlFromQrPayload(
-        "t3code://pair?pairingUrl=https%3A%2F%2Fremote.example.com%2Fpair%23token%3Dpairing-token",
-      ),
-    ).toBe("https://remote.example.com/pair#token=pairing-token");
-  });
-
   it("unwraps development pairing deep links", () => {
     expect(
       extractPairingUrlFromQrPayload(

--- a/apps/mobile/src/features/connection/pairing.ts
+++ b/apps/mobile/src/features/connection/pairing.ts
@@ -78,12 +78,7 @@ export function extractPairingUrlFromQrPayload(payload: string): string {
 
   try {
     const url = new URL(trimmed);
-    if (
-      url.protocol === "akeru:" ||
-      url.protocol === "akeru-dev:" ||
-      url.protocol === "t3code:" ||
-      url.protocol === "t3code-dev:"
-    ) {
+    if (url.protocol === "akeru:" || url.protocol === "akeru-dev:") {
       const pairingUrl = url.searchParams.get(MOBILE_PAIRING_URL_PARAM)?.trim() ?? "";
       if (pairingUrl.length > 0) {
         return pairingUrl;

--- a/apps/server/src/http.ts
+++ b/apps/server/src/http.ts
@@ -46,12 +46,7 @@ import { browserApiCorsAllowedHeaders, browserApiCorsAllowedMethods } from "./ht
 
 const OTLP_TRACES_PROXY_PATH = "/api/observability/v1/traces";
 const LOOPBACK_HOSTNAMES = new Set(["127.0.0.1", "::1", "localhost"]);
-const DESKTOP_RENDERER_ORIGINS = [
-  "akeru://app",
-  "akeru-dev://app",
-  "t3code://app",
-  "t3code-dev://app",
-];
+const DESKTOP_RENDERER_ORIGINS = ["akeru://app", "akeru-dev://app"];
 const SVG_CONTENT_SECURITY_POLICY = "default-src 'none'; style-src 'unsafe-inline'; sandbox";
 
 export function assetResponseHeaders(filePath: string): Record<string, string> {

--- a/apps/server/src/server.test.ts
+++ b/apps/server/src/server.test.ts
@@ -1913,12 +1913,7 @@ it.layer(NodeServices.layer)("server router seam", (it) => {
     }).pipe(Effect.provide(NodeHttpServer.layerTest)),
   );
 
-  for (const desktopOrigin of [
-    "akeru://app",
-    "akeru-dev://app",
-    "t3code://app",
-    "t3code-dev://app",
-  ]) {
+  for (const desktopOrigin of ["akeru://app", "akeru-dev://app"]) {
     it.effect(`allows credentialed preflights from ${desktopOrigin} in development`, () =>
       Effect.gen(function* () {
         yield* buildAppUnderTest({

--- a/scripts/build-desktop-artifact.test.ts
+++ b/scripts/build-desktop-artifact.test.ts
@@ -482,12 +482,13 @@ it.layer(NodeServices.layer)("build-desktop-artifact", (it) => {
         ...WINDOWS_SERVER_EXTRA_RESOURCES,
       ]);
       assert.deepStrictEqual(win.nsis, { differentialPackage: true });
-      // Windows registers the akeru:// schemes through the installer so the
-      // OS routes activations here instead of an older T3 Code install.
+      // Windows registers akeru:// through the installer so the OS routes
+      // activations here instead of an older T3 Code install. Production
+      // packages never claim the development scheme.
       assert.deepStrictEqual(win.protocols, [
         {
           name: "Akeru Bot",
-          schemes: ["akeru", "akeru-dev"],
+          schemes: ["akeru"],
         },
       ]);
       // Native binaries and helper executables cannot load from inside an

--- a/scripts/build-desktop-artifact.test.ts
+++ b/scripts/build-desktop-artifact.test.ts
@@ -482,6 +482,14 @@ it.layer(NodeServices.layer)("build-desktop-artifact", (it) => {
         ...WINDOWS_SERVER_EXTRA_RESOURCES,
       ]);
       assert.deepStrictEqual(win.nsis, { differentialPackage: true });
+      // Windows registers the akeru:// schemes through the installer so the
+      // OS routes activations here instead of an older T3 Code install.
+      assert.deepStrictEqual(win.protocols, [
+        {
+          name: "Akeru Bot",
+          schemes: ["akeru", "akeru-dev"],
+        },
+      ]);
       // Native binaries and helper executables cannot load from inside an
       // asar; everything else stays packed. The Claude SDK platform packages
       // and .bin shims never ship.
@@ -511,7 +519,7 @@ it.layer(NodeServices.layer)("build-desktop-artifact", (it) => {
       assert.deepStrictEqual((linux.linux as Record<string, unknown>).protocols, [
         {
           name: "Akeru Bot",
-          schemes: ["akeru", "akeru-dev", "t3code", "t3code-dev"],
+          schemes: ["akeru", "akeru-dev"],
         },
       ]);
       assert.deepStrictEqual(mac.files, [...DESKTOP_FILE_EXCLUSIONS, ...MAC_FILE_EXCLUSIONS]);
@@ -1097,7 +1105,7 @@ it.layer(NodeServices.layer)("build-desktop-artifact", (it) => {
       assert.deepStrictEqual(mac.protocols, [
         {
           name: "Akeru Bot",
-          schemes: ["akeru", "akeru-dev", "t3code", "t3code-dev"],
+          schemes: ["akeru", "akeru-dev"],
         },
       ]);
     }).pipe(Effect.provide(ConfigProvider.layer(ConfigProvider.fromEnv({ env: {} })))),

--- a/scripts/build-desktop-artifact.ts
+++ b/scripts/build-desktop-artifact.ts
@@ -1939,10 +1939,12 @@ export const createBuildConfig = Effect.fn("createBuildConfig")(function* (
     // electron-builder writes HKCU URL-protocol registry entries from this
     // list, so the OS hands akeru:// activations to this install instead of
     // whatever app (for example an old T3 build) registered a scheme earlier.
+    // Only the production scheme: packaged builds never run as development,
+    // and claiming akeru-dev would steal it from a developer's local build.
     buildConfig.protocols = [
       {
         name: "Akeru Bot",
-        schemes: ["akeru", "akeru-dev"],
+        schemes: ["akeru"],
       },
     ];
     const winConfig: Record<string, unknown> = {

--- a/scripts/build-desktop-artifact.ts
+++ b/scripts/build-desktop-artifact.ts
@@ -1865,7 +1865,7 @@ export const createBuildConfig = Effect.fn("createBuildConfig")(function* (
       protocols: [
         {
           name: "Akeru Bot",
-          schemes: ["akeru", "akeru-dev", "t3code", "t3code-dev"],
+          schemes: ["akeru", "akeru-dev"],
         },
       ],
       // Unsigned builds opt into identity "-" so electron-builder replaces
@@ -1919,7 +1919,7 @@ export const createBuildConfig = Effect.fn("createBuildConfig")(function* (
       protocols: [
         {
           name: "Akeru Bot",
-          schemes: ["akeru", "akeru-dev", "t3code", "t3code-dev"],
+          schemes: ["akeru", "akeru-dev"],
         },
       ],
       desktop: {
@@ -1936,6 +1936,15 @@ export const createBuildConfig = Effect.fn("createBuildConfig")(function* (
     // installed file topology. The optimization is in the payload shape, not
     // in trading update bandwidth for install speed.
     buildConfig.nsis = { differentialPackage: true };
+    // electron-builder writes HKCU URL-protocol registry entries from this
+    // list, so the OS hands akeru:// activations to this install instead of
+    // whatever app (for example an old T3 build) registered a scheme earlier.
+    buildConfig.protocols = [
+      {
+        name: "Akeru Bot",
+        schemes: ["akeru", "akeru-dev"],
+      },
+    ];
     const winConfig: Record<string, unknown> = {
       target: [target],
       icon: "icon.ico",


### PR DESCRIPTION
## Why
A user on Windows reported that opening the app from search launched T3 Nightly instead of Akeru Bot. Akeru still registered T3 Code's `t3code://` and `t3code-dev://` URL schemes on every surface, so a coexisting T3 Code install could take over the shared scheme registrations.

## What changed
- Remove the legacy `t3code`/`t3code-dev` scheme constants, privileges, and renderer protocol registration from the desktop runtime (`ElectronProtocol`, `DesktopApp` bootstrap).
- Register only `akeru` in the Linux URL-handler desktop entry and `xdg-mime` default claim.
- Drop the legacy schemes from the macOS dev launcher bundle (bumped `LAUNCHER_VERSION` so existing dev bundles rebuild) and from the macOS/Linux installer configs.
- Add a `protocols` block to the Windows build config so the NSIS installer writes the `akeru://` registry entries itself; previously Windows had no protocol entry at all.
- Drop `t3code://app` and `t3code-dev://app` from server desktop-renderer CORS origins.
- Drop the legacy schemes from mobile native schemes, linking prefixes, and QR pairing deep-link parsing.

## Testing
- `vp test run` on ElectronProtocol, DesktopLinuxUrlHandler, electron-launcher, build-desktop-artifact, mobile pairing, and server tests: all pass.
- Typecheck for `apps/desktop`, `apps/server`, `apps/mobile`: clean.
- Not run: end-to-end Windows registry verification (needs a packaged Windows build alongside a T3 install).

Written by claude-fable-5-1 via the Grok harness in T3 Code.