### PR TITLE
fix(release): recover version PR updates from Tegami's boxed errors

### DIFF
--- a/scripts/update-version-pull-request.test.ts
+++ b/scripts/update-version-pull-request.test.ts
@@ -36,6 +36,21 @@ describe("version pull request automation", () => {
         'Plugin "github:version-request" failed:\nA pull request already exists',
       ),
     ).toBe(true);
+    // Tegami's boxed CLI output wraps the message across bordered lines.
+    expect(
+      isRecoverableVersionRequestFailure(
+        [
+          "◇  Error ──────────────────────────────╮",
+          "│                                      │",
+          '│  Plugin "github:version-request" failed during applyCliDraft:  │',
+          '│  Failed to create the version pull request: {"message":"Validation  │',
+          '│  Failed","errors":[{"resource":"PullRequest","code":"custom","message":"A    │',
+          "│  pull request already exists for      │",
+          "│  opencoredev:tegami/version-packages.  │",
+          "├──────────────────────────────────────╯",
+        ].join("\n"),
+      ),
+    ).toBe(true);
     expect(
       isRecoverableVersionRequestFailure(
         'Plugin "github:version-request" failed: GitHub Actions is not permitted to create or approve pull requests',

--- a/scripts/update-version-pull-request.ts
+++ b/scripts/update-version-pull-request.ts
@@ -87,7 +87,9 @@ export function renderVersionPullRequestBody(
 }
 
 export function isRecoverableVersionRequestFailure(output: string): boolean {
-  const normalized = output.replace(/\s+/gu, " ");
+  // Tegami wraps errors in a box whose border characters split words across
+  // lines, so strip the decoration before collapsing whitespace.
+  const normalized = output.replace(/[│├┤╮╯╭╰─◇└┌]/gu, " ").replace(/\s+/gu, " ");
   return (
     normalized.includes('Plugin "github:version-request" failed') &&
     (normalized.includes("A pull request already exists") ||


### PR DESCRIPTION
## Why

The `Version packages` workflow failed on every push to `main` since #178 merged, so the Version Packages PR body stopped listing new changes. Tegami exits nonzero when the version PR already exists, and the recoverable-failure matcher missed the message because Tegami's boxed CLI output splits "A pull request already exists" across bordered lines.

## What changed

- Strip Tegami's box-drawing characters before collapsing whitespace in `isRecoverableVersionRequestFailure`, so the pull-request-exists and Actions-permission cases match again.
- Add a regression test using the wrapped output shape from the failed workflow runs.

## Testing

- `vp test run scripts/update-version-pull-request.test.ts scripts/generate-release-changelog.test.ts` — 5 passed.
- Reproduced first: the exact wrapped output from run 33937509955 returned false before the fix and true after.

## Notes

PR #177's body was refreshed manually in the meantime; the next push to `main` (this PR's merge) exercises the fixed path for real.

Model: claude-fable-5-1-auto through the Grok harness in T3 Code.
