### PR TITLE
perf(server): yield between filtered workspace search pages

### DIFF
--- a/apps/server/src/workspace/WorkspaceSearchIndex.test.ts
+++ b/apps/server/src/workspace/WorkspaceSearchIndex.test.ts
@@ -7,8 +7,10 @@ import {
 } from "@ff-labs/fff-node";
 import { afterEach, expect, it } from "@effect/vitest";
 import * as Cause from "effect/Cause";
+import * as Deferred from "effect/Deferred";
 import * as Effect from "effect/Effect";
 import * as Exit from "effect/Exit";
+import * as Fiber from "effect/Fiber";
 import { vi } from "vite-plus/test";
 
 import * as WorkspaceSearchIndex from "./WorkspaceSearchIndex.ts";
@@ -27,6 +29,17 @@ function fileItem(relativePath: string): FileItem {
     modificationFrecencyScore: 0,
     totalFrecencyScore: 0,
     gitStatus: "clean",
+  };
+}
+
+function emptyGrepPage(): GrepResult {
+  return {
+    items: [],
+    totalMatched: 0,
+    totalFilesSearched: 1,
+    totalFiles: 2,
+    filteredFileCount: 2,
+    nextCursor: { __brand: "GrepCursor", _offset: 1 } as GrepCursor,
   };
 }
 
@@ -306,14 +319,19 @@ it.effect("continues whole-word searches after a filtered grep page", () =>
         filteredFileCount: 1,
         nextCursor: cursor,
       });
-      const grep = vi.fn((_query: string, options?: GrepOptions) =>
-        options?.cursor
-          ? { ok: true as const, value: grepResult("needle", [[0, 6]], null) }
-          : {
-              ok: true as const,
-              value: grepResult("needleSuffix", [[0, 6]], nextCursor),
-            },
-      );
+      const pageEvents: string[] = [];
+      const grep = vi.fn((_query: string, options?: GrepOptions) => {
+        if (options?.cursor) {
+          pageEvents.push("next page");
+          return { ok: true as const, value: grepResult("needle", [[0, 6]], null) };
+        }
+        pageEvents.push("first page");
+        setImmediate(() => pageEvents.push("other work"));
+        return {
+          ok: true as const,
+          value: grepResult("needleSuffix", [[0, 6]], nextCursor),
+        };
+      });
       const finder = {
         destroy: vi.fn(),
         waitForIndexReady: vi.fn(async () => ({ ok: true as const, value: true })),
@@ -343,6 +361,82 @@ it.effect("continues whole-word searches after a filtered grep page", () =>
       });
       expect(grep).toHaveBeenCalledTimes(2);
       expect(grep.mock.calls[1]?.[1]?.cursor).toBe(nextCursor);
+      expect(pageEvents).toEqual(["first page", "other work", "next page"]);
     }),
   ),
+);
+
+it.effect("does not start another grep page when the budget expires while yielding", () =>
+  Effect.scoped(
+    Effect.gen(function* () {
+      let now = 0;
+      vi.spyOn(performance, "now").mockImplementation(() => now);
+      const grep = vi
+        .fn<FileFinder["grep"]>(() => {
+          throw new Error("Unexpected grep after the search budget expired");
+        })
+        .mockImplementationOnce(() => {
+          setImmediate(() => {
+            now = 250;
+          });
+          return { ok: true as const, value: emptyGrepPage() };
+        });
+      const finder = {
+        destroy: vi.fn(),
+        waitForIndexReady: vi.fn(async () => ({ ok: true as const, value: true })),
+        grep,
+      } as unknown as FileFinder;
+      vi.spyOn(FileFinder, "create").mockReturnValueOnce({ ok: true, value: finder });
+
+      const searchIndex = yield* WorkspaceSearchIndex.make("/workspace/project", "content");
+      const result = yield* searchIndex.searchContents({
+        query: "needle",
+        limit: 1,
+        caseSensitive: true,
+        wholeWord: true,
+        useRegex: false,
+      });
+
+      expect(result).toEqual({ matches: [], truncated: true });
+      expect(grep).toHaveBeenCalledTimes(1);
+    }),
+  ),
+);
+
+it.effect("interrupts a paginated search before another native call and releases its finder", () =>
+  Effect.gen(function* () {
+    const firstPage = yield* Deferred.make<void>();
+    const grep = vi.fn(() => {
+      Deferred.doneUnsafe(firstPage, Effect.void);
+      return { ok: true as const, value: emptyGrepPage() };
+    });
+    const destroy = vi.fn();
+    const finder = {
+      destroy,
+      waitForIndexReady: vi.fn(async () => ({ ok: true as const, value: true })),
+      grep,
+    } as unknown as FileFinder;
+    vi.spyOn(FileFinder, "create").mockReturnValueOnce({ ok: true, value: finder });
+
+    yield* Effect.scoped(
+      Effect.gen(function* () {
+        const searchIndex = yield* WorkspaceSearchIndex.make("/workspace/project", "content");
+        const fiber = yield* searchIndex
+          .searchContents({
+            query: "needle",
+            limit: 1,
+            caseSensitive: true,
+            wholeWord: true,
+            useRegex: false,
+          })
+          .pipe(Effect.forkChild);
+        yield* Deferred.await(firstPage);
+        yield* Fiber.interrupt(fiber);
+
+        expect(grep).toHaveBeenCalledTimes(1);
+        expect(destroy).not.toHaveBeenCalled();
+      }),
+    );
+    expect(destroy).toHaveBeenCalledTimes(1);
+  }),
 );

--- a/apps/server/src/workspace/WorkspaceSearchIndex.ts
+++ b/apps/server/src/workspace/WorkspaceSearchIndex.ts
@@ -485,6 +485,11 @@ export const make = Effect.fn("WorkspaceSearchIndex.make")(function* (
     let regexFallbackError: string | undefined;
 
     do {
+      if (nextCursor !== null) {
+        // Filtered pages must not monopolize the server for the full search budget.
+        yield* Effect.yieldNow;
+        if (performance.now() >= deadline) break;
+      }
       const remainingTimeBudgetMs = Math.max(1, Math.ceil(deadline - performance.now()));
       const result = yield* runSearch(input.query, input.limit, "grep", () =>
         finder.grep(searchQuery, {


### PR DESCRIPTION
## Problem

Content searches can process many filtered native grep pages without yielding, delaying unrelated server work until the search budget expires.

## Changes

Yield between subsequent grep pages and recheck the deadline before starting another native call. Keep the first-page behavior and search results unchanged. Add regressions for concurrent work, budget expiration during the yield, interruption, and finder cleanup.

## Verification

- Parent verification passed all 41 tests across WorkspaceSearchIndex and WorkspaceEntries, including real native index/search behavior in isolated temporary workspaces.
- Targeted lint, focused TypeScript checking, and diff checks passed.
- No client, provider adapter, contract, or migration changes. No browser UI behavior or end-to-end latency percentage is claimed; the scheduling and cancellation regressions use deterministic test controls.
- Full repository and configured Effect compiler checks are left to CI.

Implemented and verified by gpt-6-astra in T3 Code through the Grok harness.
