### PR TITLE
perf(server): index projected thread lookups

### DIFF
--- a/apps/server/src/orchestration/commandInvariants.ts
+++ b/apps/server/src/orchestration/commandInvariants.ts
@@ -19,6 +19,7 @@ import { normalizeProjectPathForComparison } from "@t3tools/shared/path";
 import * as Effect from "effect/Effect";
 
 import { OrchestrationCommandInvariantError } from "./Errors.ts";
+import { findProjectedThread } from "./projector.ts";
 import type { OrchestrationDispatchActor } from "./Services/OrchestrationEngine.ts";
 
 function invariantError(commandType: string, detail: string): OrchestrationCommandInvariantError {
@@ -32,7 +33,7 @@ export function findThreadById(
   readModel: OrchestrationReadModel,
   threadId: ThreadId,
 ): OrchestrationThread | undefined {
-  return readModel.threads.find((thread) => thread.id === threadId);
+  return findProjectedThread(readModel.threads, threadId);
 }
 
 export function findProjectById(

--- a/apps/server/src/orchestration/projector.test.ts
+++ b/apps/server/src/orchestration/projector.test.ts
@@ -6,10 +6,11 @@ import {
   ThreadId,
   type OrchestrationEvent,
 } from "@t3tools/contracts";
+import { it } from "@effect/vitest";
 import * as Effect from "effect/Effect";
-import { describe, expect, it } from "vite-plus/test";
+import { describe, expect } from "vite-plus/test";
 
-import { createEmptyReadModel, projectEvent } from "./projector.ts";
+import { createEmptyReadModel, findProjectedThread, projectEvent } from "./projector.ts";
 
 function makeEvent(input: {
   sequence: number;
@@ -39,6 +40,71 @@ function makeEvent(input: {
 }
 
 describe("orchestration projector", () => {
+  it.effect(
+    "reuses keyed thread lookups across immutable patches without rescanning identities",
+    () =>
+      Effect.gen(function* () {
+        const now = "2026-01-01T00:00:00.000Z";
+        const seeded = yield* projectEvent(
+          createEmptyReadModel(now),
+          makeEvent({
+            sequence: 1,
+            type: "thread.created",
+            aggregateKind: "thread",
+            aggregateId: "template",
+            occurredAt: now,
+            commandId: null,
+            payload: {
+              threadId: "template",
+              projectId: "project",
+              title: "Before",
+              modelSelection: { provider: "codex", model: "gpt-5-codex" },
+              runtimeMode: "full-access",
+              branch: null,
+              worktreePath: null,
+              createdAt: now,
+              updatedAt: now,
+            },
+          }),
+        );
+        let identityReads = 0;
+        const threads = Array.from({ length: 2000 }, (_, i) => ({
+          ...seeded.threads[0]!,
+          get id() {
+            identityReads += 1;
+            return ThreadId.make(`indexed-${i}`);
+          },
+          deletedAt: i === 0 ? now : null,
+          archivedAt: i === 1 ? now : null,
+        }));
+        const target = ThreadId.make("indexed-1999");
+        expect(findProjectedThread(threads, target)).toBe(threads[1999]);
+        identityReads = 0;
+        const patched = yield* projectEvent(
+          { ...seeded, threads },
+          makeEvent({
+            sequence: 2,
+            type: "thread.meta-updated",
+            aggregateKind: "thread",
+            aggregateId: target,
+            occurredAt: now,
+            commandId: null,
+            payload: { threadId: target, title: "After", updatedAt: now },
+          }),
+        );
+        expect(findProjectedThread(patched.threads, target)?.title).toBe("After");
+        expect(findProjectedThread(patched.threads, ThreadId.make("indexed-0"))?.deletedAt).toBe(
+          now,
+        );
+        expect(findProjectedThread(patched.threads, ThreadId.make("indexed-1"))?.archivedAt).toBe(
+          now,
+        );
+        expect(identityReads).toBeLessThan(5);
+        expect(threads[1999]?.title).toBe("Before");
+        expect(patched.threads[0]).toBe(threads[0]);
+      }),
+  );
+
   it("applies thread.created events", async () => {
     const now = "2026-01-01T00:00:00.000Z";
     const model = createEmptyReadModel(now);
@@ -860,12 +926,12 @@ describe("orchestration projector", () => {
     ).toEqual([{ id: "assistant-keep", role: "assistant", turnId: "turn-1" }]);
   });
 
-  it("caps message and checkpoint retention for long-lived threads", async () => {
-    const createdAt = "2026-03-01T10:00:00.000Z";
-    const model = createEmptyReadModel(createdAt);
+  it.effect("caps message and checkpoint retention for long-lived threads", () =>
+    Effect.gen(function* () {
+      const createdAt = "2026-03-01T10:00:00.000Z";
+      const model = createEmptyReadModel(createdAt);
 
-    const afterCreate = await Effect.runPromise(
-      projectEvent(
+      const afterCreate = yield* projectEvent(
         model,
         makeEvent({
           sequence: 1,
@@ -889,75 +955,63 @@ describe("orchestration projector", () => {
             updatedAt: createdAt,
           },
         }),
-      ),
-    );
+      );
 
-    const messageEvents: ReadonlyArray<OrchestrationEvent> = Array.from(
-      { length: 2_100 },
-      (_, index) =>
-        makeEvent({
-          sequence: index + 2,
-          type: "thread.message-sent",
-          aggregateKind: "thread",
-          aggregateId: "thread-capped",
-          occurredAt: `2026-03-01T10:00:${String(index % 60).padStart(2, "0")}.000Z`,
-          commandId: `cmd-message-${index}`,
-          payload: {
-            threadId: "thread-capped",
-            messageId: `msg-${index}`,
-            role: "assistant",
-            text: `message-${index}`,
-            turnId: `turn-${index}`,
-            streaming: false,
-            createdAt: `2026-03-01T10:00:${String(index % 60).padStart(2, "0")}.000Z`,
-            updatedAt: `2026-03-01T10:00:${String(index % 60).padStart(2, "0")}.000Z`,
-          },
-        }),
-    );
-    const afterMessages = await messageEvents.reduce<
-      Promise<ReturnType<typeof createEmptyReadModel>>
-    >(
-      (statePromise, event) =>
-        statePromise.then((state) => Effect.runPromise(projectEvent(state, event))),
-      Promise.resolve(afterCreate),
-    );
+      const messageEvents: ReadonlyArray<OrchestrationEvent> = Array.from(
+        { length: 2_100 },
+        (_, index) =>
+          makeEvent({
+            sequence: index + 2,
+            type: "thread.message-sent",
+            aggregateKind: "thread",
+            aggregateId: "thread-capped",
+            occurredAt: `2026-03-01T10:00:${String(index % 60).padStart(2, "0")}.000Z`,
+            commandId: `cmd-message-${index}`,
+            payload: {
+              threadId: "thread-capped",
+              messageId: `msg-${index}`,
+              role: "assistant",
+              text: `message-${index}`,
+              turnId: `turn-${index}`,
+              streaming: false,
+              createdAt: `2026-03-01T10:00:${String(index % 60).padStart(2, "0")}.000Z`,
+              updatedAt: `2026-03-01T10:00:${String(index % 60).padStart(2, "0")}.000Z`,
+            },
+          }),
+      );
+      const afterMessages = yield* Effect.reduce(messageEvents, () => afterCreate, projectEvent);
 
-    const checkpointEvents: ReadonlyArray<OrchestrationEvent> = Array.from(
-      { length: 600 },
-      (_, index) =>
-        makeEvent({
-          sequence: index + 2_102,
-          type: "thread.turn-diff-completed",
-          aggregateKind: "thread",
-          aggregateId: "thread-capped",
-          occurredAt: `2026-03-01T10:30:${String(index % 60).padStart(2, "0")}.000Z`,
-          commandId: `cmd-checkpoint-${index}`,
-          payload: {
-            threadId: "thread-capped",
-            turnId: `turn-${index}`,
-            checkpointTurnCount: index + 1,
-            checkpointRef: `refs/t3/checkpoints/thread-capped/turn/${index + 1}`,
-            status: "ready",
-            files: [],
-            assistantMessageId: `msg-${index}`,
-            completedAt: `2026-03-01T10:30:${String(index % 60).padStart(2, "0")}.000Z`,
-          },
-        }),
-    );
-    const finalState = await checkpointEvents.reduce<
-      Promise<ReturnType<typeof createEmptyReadModel>>
-    >(
-      (statePromise, event) =>
-        statePromise.then((state) => Effect.runPromise(projectEvent(state, event))),
-      Promise.resolve(afterMessages),
-    );
+      const checkpointEvents: ReadonlyArray<OrchestrationEvent> = Array.from(
+        { length: 600 },
+        (_, index) =>
+          makeEvent({
+            sequence: index + 2_102,
+            type: "thread.turn-diff-completed",
+            aggregateKind: "thread",
+            aggregateId: "thread-capped",
+            occurredAt: `2026-03-01T10:30:${String(index % 60).padStart(2, "0")}.000Z`,
+            commandId: `cmd-checkpoint-${index}`,
+            payload: {
+              threadId: "thread-capped",
+              turnId: `turn-${index}`,
+              checkpointTurnCount: index + 1,
+              checkpointRef: `refs/t3/checkpoints/thread-capped/turn/${index + 1}`,
+              status: "ready",
+              files: [],
+              assistantMessageId: `msg-${index}`,
+              completedAt: `2026-03-01T10:30:${String(index % 60).padStart(2, "0")}.000Z`,
+            },
+          }),
+      );
+      const finalState = yield* Effect.reduce(checkpointEvents, () => afterMessages, projectEvent);
 
-    const thread = finalState.threads[0];
-    expect(thread?.messages).toHaveLength(2_000);
-    expect(thread?.messages[0]?.id).toBe("msg-100");
-    expect(thread?.messages.at(-1)?.id).toBe("msg-2099");
-    expect(thread?.checkpoints).toHaveLength(500);
-    expect(thread?.checkpoints[0]?.turnId).toBe("turn-100");
-    expect(thread?.checkpoints.at(-1)?.turnId).toBe("turn-599");
-  });
+      const thread = finalState.threads[0];
+      expect(thread?.messages).toHaveLength(2_000);
+      expect(thread?.messages[0]?.id).toBe("msg-100");
+      expect(thread?.messages.at(-1)?.id).toBe("msg-2099");
+      expect(thread?.checkpoints).toHaveLength(500);
+      expect(thread?.checkpoints[0]?.turnId).toBe("turn-100");
+      expect(thread?.checkpoints.at(-1)?.turnId).toBe("turn-599");
+    }),
+  );
 });

--- a/apps/server/src/orchestration/projector.ts
+++ b/apps/server/src/orchestration/projector.ts
@@ -123,12 +123,41 @@ function updateGroup(
   return groups.map((group) => (group.id === groupId ? { ...group, ...patch } : group));
 }
 
+const threadIndexes = new WeakMap<
+  ReadonlyArray<OrchestrationThread>,
+  ReadonlyMap<ThreadId, number>
+>();
+
+function threadIndex(threads: ReadonlyArray<OrchestrationThread>) {
+  let index = threadIndexes.get(threads);
+  if (!index) {
+    index = new Map(threads.map((thread, offset) => [thread.id, offset]));
+    threadIndexes.set(threads, index);
+  }
+  return index;
+}
+
+export function findProjectedThread(
+  threads: ReadonlyArray<OrchestrationThread>,
+  threadId: ThreadId,
+): OrchestrationThread | undefined {
+  const offset = threadIndex(threads).get(threadId);
+  return offset === undefined ? undefined : threads[offset];
+}
+
 function updateThread(
   threads: ReadonlyArray<OrchestrationThread>,
   threadId: ThreadId,
   patch: ThreadPatch,
-): OrchestrationThread[] {
-  return threads.map((thread) => (thread.id === threadId ? { ...thread, ...patch } : thread));
+): ReadonlyArray<OrchestrationThread> {
+  const index = threadIndex(threads);
+  const offset = index.get(threadId);
+  if (offset === undefined) return threads;
+  const next = threads.slice();
+  next[offset] = { ...threads[offset]!, ...patch };
+  // A patch preserves both identity and ordering, including archived/deleted rows.
+  threadIndexes.set(next, index);
+  return next;
 }
 
 function decodeForEvent<A>(
@@ -840,7 +869,7 @@ export function projectEvent(
     case "thread.unsettled":
       return decodeForEvent(ThreadUnsettledPayload, event.payload, event.type, "payload").pipe(
         Effect.map((payload) => {
-          const existing = nextBase.threads.find((thread) => thread.id === payload.threadId);
+          const existing = findProjectedThread(nextBase.threads, payload.threadId);
           return {
             ...nextBase,
             threads: updateThread(nextBase.threads, payload.threadId, {
@@ -977,7 +1006,7 @@ export function projectEvent(
           event.type,
           "payload",
         );
-        const thread = nextBase.threads.find((entry) => entry.id === payload.threadId);
+        const thread = findProjectedThread(nextBase.threads, payload.threadId);
         if (!thread) {
           return nextBase;
         }
@@ -1053,7 +1082,7 @@ export function projectEvent(
         "payload",
       ).pipe(
         Effect.map((payload) => {
-          const thread = nextBase.threads.find((entry) => entry.id === payload.threadId);
+          const thread = findProjectedThread(nextBase.threads, payload.threadId);
           if (!thread) return nextBase;
           const messages = thread.messages.map((message) => {
             if (message.id !== payload.messageId) return message;
@@ -1113,7 +1142,7 @@ export function projectEvent(
           event.type,
           "payload",
         );
-        const thread = nextBase.threads.find((entry) => entry.id === payload.threadId);
+        const thread = findProjectedThread(nextBase.threads, payload.threadId);
         if (!thread) {
           return nextBase;
         }
@@ -1177,7 +1206,7 @@ export function projectEvent(
           event.type,
           "payload",
         );
-        const thread = nextBase.threads.find((entry) => entry.id === payload.threadId);
+        const thread = findProjectedThread(nextBase.threads, payload.threadId);
         if (!thread) {
           return nextBase;
         }
@@ -1209,7 +1238,7 @@ export function projectEvent(
           event.type,
           "payload",
         );
-        const thread = nextBase.threads.find((entry) => entry.id === payload.threadId);
+        const thread = findProjectedThread(nextBase.threads, payload.threadId);
         if (!thread) {
           return nextBase;
         }
@@ -1280,7 +1309,7 @@ export function projectEvent(
     case "thread.reverted":
       return decodeForEvent(ThreadRevertedPayload, event.payload, event.type, "payload").pipe(
         Effect.map((payload) => {
-          const thread = nextBase.threads.find((entry) => entry.id === payload.threadId);
+          const thread = findProjectedThread(nextBase.threads, payload.threadId);
           if (!thread) {
             return nextBase;
           }
@@ -1336,7 +1365,7 @@ export function projectEvent(
         "payload",
       ).pipe(
         Effect.map((payload) => {
-          const thread = nextBase.threads.find((entry) => entry.id === payload.threadId);
+          const thread = findProjectedThread(nextBase.threads, payload.threadId);
           if (!thread) {
             return nextBase;
           }


### PR DESCRIPTION
## Problem

Projector updates and command invariants repeatedly scan the projected thread array to find the same record. Large environments pay that lookup cost for each update.

## Changes

Index thread identity lookups and preserve the index across immutable patches. Use the same lookup in command invariants. Keep thread ordering, prior snapshots, and archived/deleted row semantics unchanged.

## Verification

- Parent verification passed all 32 projector, command-invariant, and orchestration-engine tests on current main, including isolated SQLite migrations and command handling.
- The new 2,000-thread regression checks limited identity reads, immutable prior state, and archived/deleted records.
- Server package TypeScript checking, targeted lint, formatting, and diff checks passed. Additional configured Effect diagnostics remain a CI gate.
- This is a pure server lookup change with unchanged event and client contracts. No UI changes, provider calls, or measured end-to-end latency percentage are claimed.

Implemented and verified by gpt-6-astra in T3 Code through the Grok harness.
