### PR TITLE
fix(server): prefer origin for project repository identity

### DIFF
--- a/apps/server/src/project/RepositoryIdentityResolver.test.ts
+++ b/apps/server/src/project/RepositoryIdentityResolver.test.ts
@@ -193,7 +193,7 @@ it.layer(NodeServices.layer)("RepositoryIdentityResolverLive", (it) => {
     }).pipe(Effect.provide(RepositoryIdentityResolver.layer)),
   );
 
-  it.effect("prefers upstream over origin when both remotes are configured", () =>
+  it.effect("prefers origin over upstream when both remotes are configured", () =>
     Effect.gen(function* () {
       const fileSystem = yield* FileSystem.FileSystem;
       const cwd = yield* fileSystem.makeTempDirectoryScoped({
@@ -201,16 +201,36 @@ it.layer(NodeServices.layer)("RepositoryIdentityResolverLive", (it) => {
       });
 
       yield* git(cwd, ["init"]);
-      yield* git(cwd, ["remote", "add", "origin", "git@github.com:julius/t3code.git"]);
-      yield* git(cwd, ["remote", "add", "upstream", "git@github.com:T3Tools/t3code.git"]);
+      yield* git(cwd, ["remote", "add", "origin", "git@github.com:OpenCoreDev/akeru-bot.git"]);
+      yield* git(cwd, ["remote", "add", "upstream", "git@github.com:pingdotgg/t3code.git"]);
+
+      const resolver = yield* RepositoryIdentityResolver.RepositoryIdentityResolver;
+      const identity = yield* resolver.resolve(cwd);
+
+      expect(identity).not.toBeNull();
+      expect(identity?.locator.remoteName).toBe("origin");
+      expect(identity?.canonicalKey).toBe("github.com/opencoredev/akeru-bot");
+      expect(identity?.displayName).toBe("opencoredev/akeru-bot");
+    }).pipe(Effect.provide(RepositoryIdentityResolver.layer)),
+  );
+
+  it.effect("uses upstream when origin is missing", () =>
+    Effect.gen(function* () {
+      const fileSystem = yield* FileSystem.FileSystem;
+      const cwd = yield* fileSystem.makeTempDirectoryScoped({
+        prefix: "t3-repository-identity-upstream-only-test-",
+      });
+
+      yield* git(cwd, ["init"]);
+      yield* git(cwd, ["remote", "add", "upstream", "git@github.com:pingdotgg/t3code.git"]);
 
       const resolver = yield* RepositoryIdentityResolver.RepositoryIdentityResolver;
       const identity = yield* resolver.resolve(cwd);
 
       expect(identity).not.toBeNull();
       expect(identity?.locator.remoteName).toBe("upstream");
-      expect(identity?.canonicalKey).toBe("github.com/t3tools/t3code");
-      expect(identity?.displayName).toBe("t3tools/t3code");
+      expect(identity?.canonicalKey).toBe("github.com/pingdotgg/t3code");
+      expect(identity?.displayName).toBe("pingdotgg/t3code");
     }).pipe(Effect.provide(RepositoryIdentityResolver.layer)),
   );
 

--- a/apps/server/src/project/RepositoryIdentityResolver.ts
+++ b/apps/server/src/project/RepositoryIdentityResolver.ts
@@ -48,7 +48,9 @@ function parseRemoteFetchUrls(stdout: string): Map<string, string> {
 function pickPrimaryRemote(
   remotes: ReadonlyMap<string, string>,
 ): { readonly remoteName: string; readonly remoteUrl: string } | null {
-  for (const preferredRemoteName of ["upstream", "origin"] as const) {
+  // Origin is the project's hosting remote. An `upstream` remote is often a
+  // separate product kept for porting and must not replace this repo's identity.
+  for (const preferredRemoteName of ["origin", "upstream"] as const) {
     const remoteUrl = remotes.get(preferredRemoteName);
     if (remoteUrl) {
       return { remoteName: preferredRemoteName, remoteUrl };


### PR DESCRIPTION
## Problem

Projects that keep T3 Code as an `upstream` remote were labeled `pingdotgg/t3code` in the project picker. Identity preferred `upstream` over `origin`, so Akeru's own checkout showed the porting remote instead of `opencoredev/akeru-bot`.

## Changes

Prefer `origin` when resolving repository identity. Keep using `upstream` when `origin` is missing, so a porting remote still works for fetch and merge. Git push and PR targeting already used `origin`.

## Verification

- `vp test run apps/server/src/project/RepositoryIdentityResolver.test.ts` passed, including origin-over-upstream and upstream-only cases.

This is a server identity string the existing picker already renders. No layout or client contract change.

Implemented and verified by Grok 4.6 in Akeru Bot through the Grok harness.
