### PR TITLE
fix(server): bound OpenCode CLI probes and serialize inventory

### DIFF
--- a/apps/server/src/provider/Layers/OpenCodeProvider.test.ts
+++ b/apps/server/src/provider/Layers/OpenCodeProvider.test.ts
@@ -3,8 +3,10 @@ import * as NodeAssert from "node:assert/strict";
 import * as NodeServices from "@effect/platform-node/NodeServices";
 import { it } from "@effect/vitest";
 import * as Effect from "effect/Effect";
+import * as Fiber from "effect/Fiber";
 import * as Layer from "effect/Layer";
 import * as Schema from "effect/Schema";
+import * as TestClock from "effect/testing/TestClock";
 import { beforeEach } from "vite-plus/test";
 
 import { OpenCodeSettings } from "@t3tools/contracts";
@@ -32,6 +34,7 @@ const DEFAULT_VERSION_STDOUT = "opencode 1.14.19\n";
 const runtimeMock = {
   state: {
     runVersionError: null as Error | null,
+    runVersionPending: false,
     versionStdout: DEFAULT_VERSION_STDOUT,
     inventoryError: null as Error | null,
     inventoryCwd: null as string | null,
@@ -44,6 +47,7 @@ const runtimeMock = {
   },
   reset() {
     this.state.runVersionError = null;
+    this.state.runVersionPending = false;
     this.state.versionStdout = DEFAULT_VERSION_STDOUT;
     this.state.inventoryError = null;
     this.state.inventoryCwd = null;
@@ -78,15 +82,17 @@ const OpenCodeRuntimeTestDouble: OpenCodeRuntimeShape = {
       };
     }),
   runOpenCodeCommand: () =>
-    runtimeMock.state.runVersionError
-      ? Effect.fail(
-          new OpenCodeRuntimeError({
-            operation: "runOpenCodeCommand",
-            detail: runtimeMock.state.runVersionError.message,
-            cause: runtimeMock.state.runVersionError,
-          }),
-        )
-      : Effect.succeed({ stdout: runtimeMock.state.versionStdout, stderr: "", code: 0 }),
+    runtimeMock.state.runVersionPending
+      ? Effect.never
+      : runtimeMock.state.runVersionError
+        ? Effect.fail(
+            new OpenCodeRuntimeError({
+              operation: "runOpenCodeCommand",
+              detail: runtimeMock.state.runVersionError.message,
+              cause: runtimeMock.state.runVersionError,
+            }),
+          )
+        : Effect.succeed({ stdout: runtimeMock.state.versionStdout, stderr: "", code: 0 }),
   createOpenCodeSdkClient: () =>
     ({}) as unknown as ReturnType<OpenCodeRuntimeShape["createOpenCodeSdkClient"]>,
   loadOpenCodeInventory: () =>
@@ -156,6 +162,27 @@ it.layer(testLayer)("checkOpenCodeProviderStatus", (it) => {
       NodeAssert.equal(snapshot.installed, true);
       NodeAssert.equal(snapshot.message, "Failed to execute OpenCode CLI health check.");
     }),
+  );
+
+  it.effect("times out a hanging local CLI version probe", () =>
+    Effect.gen(function* () {
+      runtimeMock.state.runVersionPending = true;
+      const probeFiber = yield* checkOpenCodeProviderStatus(
+        makeOpenCodeSettings(),
+        process.cwd(),
+      ).pipe(Effect.forkChild);
+
+      yield* Effect.yieldNow;
+      yield* TestClock.adjust("4 seconds");
+      const snapshot = yield* Fiber.join(probeFiber);
+
+      NodeAssert.equal(snapshot.status, "error");
+      NodeAssert.equal(snapshot.installed, true);
+      NodeAssert.equal(
+        snapshot.message,
+        "Failed to execute OpenCode CLI health check: OpenCode CLI version probe timed out after 4 seconds.",
+      );
+    }).pipe(Effect.provide(TestClock.layer())),
   );
 
   it.effect("emits OpenCode variant defaults so trait picker can resolve a visible selection", () =>

--- a/apps/server/src/provider/Layers/OpenCodeProvider.ts
+++ b/apps/server/src/provider/Layers/OpenCodeProvider.ts
@@ -30,9 +30,10 @@ const OPENCODE_PRESENTATION = {
   showInteractionModeToggle: false,
 } as const;
 const MINIMUM_OPENCODE_VERSION = "1.14.19";
+const OPENCODE_VERSION_PROBE_TIMEOUT = "4 seconds";
 
 class OpenCodeProbeError extends Data.TaggedError("OpenCodeProbeError")<{
-  readonly cause: unknown;
+  readonly cause?: unknown;
   readonly detail: string;
 }> {}
 
@@ -385,6 +386,15 @@ export const checkOpenCodeProviderStatus = Effect.fn("checkOpenCodeProviderStatu
           Effect.mapError(
             (cause) => new OpenCodeProbeError({ cause, detail: openCodeRuntimeErrorDetail(cause) }),
           ),
+          Effect.timeoutOrElse({
+            duration: OPENCODE_VERSION_PROBE_TIMEOUT,
+            orElse: () =>
+              Effect.fail(
+                new OpenCodeProbeError({
+                  detail: `OpenCode CLI version probe timed out after ${OPENCODE_VERSION_PROBE_TIMEOUT}.`,
+                }),
+              ),
+          }),
         ),
     );
     if (versionExit._tag === "Failure") {

--- a/apps/server/src/provider/opencodeRuntime.inventory.test.ts
+++ b/apps/server/src/provider/opencodeRuntime.inventory.test.ts
@@ -255,19 +255,16 @@ it.layer(testLayer)("OpenCodeRuntime inventory", (it) => {
       const isWindows = hostPlatform === "win32";
       const binaryPath = path.join(tempDir, isWindows ? "opencode.cmd" : "opencode");
       const scriptPath = path.join(tempDir, "opencode.mjs");
-      const lockPath = path.join(tempDir, "lock");
-      const overlapPath = path.join(tempDir, "overlap");
+      const intervalPath = path.join(tempDir, "intervals");
 
       yield* fs.writeFileString(
         scriptPath,
         [
           'import * as fs from "node:fs";',
-          "const lock = process.env.T3_TEST_OPENCODE_LOCK;",
-          "const overlap = process.env.T3_TEST_OPENCODE_OVERLAP;",
-          "if (lock && overlap && fs.existsSync(lock)) fs.writeFileSync(overlap, process.pid.toString());",
-          "if (lock) fs.writeFileSync(lock, process.pid.toString());",
+          "const intervals = process.env.T3_TEST_OPENCODE_INTERVALS;",
+          "const started = Date.now();",
           "Atomics.wait(new Int32Array(new SharedArrayBuffer(4)), 0, 0, 80);",
-          "if (lock) fs.unlinkSync(lock);",
+          "if (intervals) fs.appendFileSync(intervals, `${started} ${Date.now()}\\n`);",
           'if (process.argv[2] === "models") {',
           '  process.stdout.write(`openai/gpt-test\\n{"id":"gpt-test","providerID":"openai","name":"GPT Test"}\\n`);',
           "} else {",
@@ -291,23 +288,36 @@ it.layer(testLayer)("OpenCodeRuntime inventory", (it) => {
       }
 
       const runtime = yield* OpenCodeRuntime;
-      const load = runtime.loadInventoryFromCli({
+      const loadInventory = runtime.loadInventoryFromCli({
         binaryPath,
         cwd: tempDir,
         environment: {
           ...hostEnvironment,
           T3_TEST_NODE_BINARY: executablePath,
           T3_TEST_OPENCODE_SCRIPT: scriptPath,
-          T3_TEST_OPENCODE_LOCK: lockPath,
-          T3_TEST_OPENCODE_OVERLAP: overlapPath,
+          T3_TEST_OPENCODE_INTERVALS: intervalPath,
         },
       });
-      const [first, second] = yield* Effect.all([load, load], { concurrency: "unbounded" });
+
+      const [first, second] = yield* Effect.all([loadInventory, loadInventory], {
+        concurrency: "unbounded",
+      });
       NodeAssert.deepEqual(first.providerList.connected, ["openai"]);
       NodeAssert.deepEqual(second.providerList.connected, ["openai"]);
-      const overlapExists = yield* fs.exists(overlapPath);
-      NodeAssert.equal(overlapExists, false);
-    }),
+
+      const intervals = (yield* fs.readFileString(intervalPath))
+        .trim()
+        .split("\n")
+        .map((line) => {
+          const [startText, endText] = line.split(" ");
+          return { start: Number(startText), end: Number(endText) };
+        })
+        .toSorted((left, right) => left.start - right.start);
+      NodeAssert.equal(intervals.length, 6);
+      for (let index = 1; index < intervals.length; index += 1) {
+        NodeAssert.ok(intervals[index - 1]!.end <= intervals[index]!.start);
+      }
+    }).pipe(TestClock.withLive),
   );
 
   it.effect("kills a hanging command process group when the command is interrupted", () =>

--- a/apps/server/src/provider/opencodeRuntime.inventory.test.ts
+++ b/apps/server/src/provider/opencodeRuntime.inventory.test.ts
@@ -244,6 +244,72 @@ it.layer(testLayer)("OpenCodeRuntime inventory", (it) => {
     }),
   );
 
+  it.effect("serializes concurrent inventory CLI refreshes against the shared database", () =>
+    Effect.gen(function* () {
+      const fs = yield* FileSystem.FileSystem;
+      const path = yield* Path.Path;
+      const hostEnvironment = yield* HostProcessEnvironment;
+      const executablePath = yield* HostProcessExecutablePath;
+      const hostPlatform = yield* HostProcessPlatform;
+      const tempDir = yield* fs.makeTempDirectoryScoped({ prefix: "t3-opencode-singleflight-" });
+      const isWindows = hostPlatform === "win32";
+      const binaryPath = path.join(tempDir, isWindows ? "opencode.cmd" : "opencode");
+      const scriptPath = path.join(tempDir, "opencode.mjs");
+      const lockPath = path.join(tempDir, "lock");
+      const overlapPath = path.join(tempDir, "overlap");
+
+      yield* fs.writeFileString(
+        scriptPath,
+        [
+          'import * as fs from "node:fs";',
+          "const lock = process.env.T3_TEST_OPENCODE_LOCK;",
+          "const overlap = process.env.T3_TEST_OPENCODE_OVERLAP;",
+          "if (lock && overlap && fs.existsSync(lock)) fs.writeFileSync(overlap, process.pid.toString());",
+          "if (lock) fs.writeFileSync(lock, process.pid.toString());",
+          "Atomics.wait(new Int32Array(new SharedArrayBuffer(4)), 0, 0, 80);",
+          "if (lock) fs.unlinkSync(lock);",
+          'if (process.argv[2] === "models") {',
+          '  process.stdout.write(`openai/gpt-test\\n{"id":"gpt-test","providerID":"openai","name":"GPT Test"}\\n`);',
+          "} else {",
+          '  process.stdout.write("[]\\n");',
+          "}",
+          "",
+        ].join("\n"),
+      );
+      yield* fs.writeFileString(
+        binaryPath,
+        [
+          ...(isWindows ? ["@echo off"] : ["#!/bin/sh"]),
+          isWindows
+            ? '"%T3_TEST_NODE_BINARY%" "%T3_TEST_OPENCODE_SCRIPT%" %*'
+            : 'exec "$T3_TEST_NODE_BINARY" "$T3_TEST_OPENCODE_SCRIPT" "$@"',
+          "",
+        ].join("\n"),
+      );
+      if (!isWindows) {
+        yield* fs.chmod(binaryPath, 0o755);
+      }
+
+      const runtime = yield* OpenCodeRuntime;
+      const load = runtime.loadInventoryFromCli({
+        binaryPath,
+        cwd: tempDir,
+        environment: {
+          ...hostEnvironment,
+          T3_TEST_NODE_BINARY: executablePath,
+          T3_TEST_OPENCODE_SCRIPT: scriptPath,
+          T3_TEST_OPENCODE_LOCK: lockPath,
+          T3_TEST_OPENCODE_OVERLAP: overlapPath,
+        },
+      });
+      const [first, second] = yield* Effect.all([load, load], { concurrency: "unbounded" });
+      NodeAssert.deepEqual(first.providerList.connected, ["openai"]);
+      NodeAssert.deepEqual(second.providerList.connected, ["openai"]);
+      const overlapExists = yield* fs.exists(overlapPath);
+      NodeAssert.equal(overlapExists, false);
+    }),
+  );
+
   it.effect("kills a hanging command process group when the command is interrupted", () =>
     Effect.gen(function* () {
       const fs = yield* FileSystem.FileSystem;

--- a/apps/server/src/provider/opencodeRuntime.inventory.test.ts
+++ b/apps/server/src/provider/opencodeRuntime.inventory.test.ts
@@ -3,10 +3,15 @@ import * as NodeAssert from "node:assert/strict";
 import * as NodeServices from "@effect/platform-node/NodeServices";
 import type { OpencodeClient } from "@opencode-ai/sdk/v2";
 import { it } from "@effect/vitest";
+import * as Data from "effect/Data";
 import * as Effect from "effect/Effect";
+import * as Fiber from "effect/Fiber";
 import * as FileSystem from "effect/FileSystem";
 import * as Layer from "effect/Layer";
+import * as Option from "effect/Option";
 import * as Path from "effect/Path";
+import * as Schedule from "effect/Schedule";
+import * as TestClock from "effect/testing/TestClock";
 import {
   HostProcessEnvironment,
   HostProcessExecutablePath,
@@ -16,6 +21,8 @@ import {
 import { OpenCodeRuntime, OpenCodeRuntimeLive } from "./opencodeRuntime.ts";
 
 const testLayer = OpenCodeRuntimeLive.pipe(Layer.provideMerge(NodeServices.layer));
+
+class OpenCodeCommandStillAliveError extends Data.TaggedError("OpenCodeCommandStillAliveError") {}
 
 it.layer(testLayer)("OpenCodeRuntime inventory", (it) => {
   it.effect("keeps provider inventory when skill discovery fails", () =>
@@ -161,5 +168,155 @@ it.layer(testLayer)("OpenCodeRuntime inventory", (it) => {
       NodeAssert.equal(result.stderr, "e".repeat(64));
       NodeAssert.equal(result.code, 0);
     }),
+  );
+
+  it.effect("runs inventory CLI commands one at a time", () =>
+    Effect.gen(function* () {
+      const fs = yield* FileSystem.FileSystem;
+      const path = yield* Path.Path;
+      const hostEnvironment = yield* HostProcessEnvironment;
+      const executablePath = yield* HostProcessExecutablePath;
+      const hostPlatform = yield* HostProcessPlatform;
+      const tempDir = yield* fs.makeTempDirectoryScoped({ prefix: "t3-opencode-serial-" });
+      const isWindows = hostPlatform === "win32";
+      const binaryPath = path.join(tempDir, isWindows ? "opencode.cmd" : "opencode");
+      const scriptPath = path.join(tempDir, "opencode.mjs");
+      const lockPath = path.join(tempDir, "lock");
+      const overlapPath = path.join(tempDir, "overlap");
+      const logPath = path.join(tempDir, "log");
+
+      yield* fs.writeFileString(
+        scriptPath,
+        [
+          'import * as fs from "node:fs";',
+          'const command = process.argv[2] ?? "unknown";',
+          "const lock = process.env.T3_TEST_OPENCODE_LOCK;",
+          "const overlap = process.env.T3_TEST_OPENCODE_OVERLAP;",
+          "const log = process.env.T3_TEST_OPENCODE_LOG;",
+          "if (lock && overlap && fs.existsSync(lock)) fs.writeFileSync(overlap, command);",
+          "if (lock) fs.writeFileSync(lock, command);",
+          "if (log) fs.appendFileSync(log, `${command}\\n`);",
+          "Atomics.wait(new Int32Array(new SharedArrayBuffer(4)), 0, 0, 80);",
+          "if (lock) fs.unlinkSync(lock);",
+          'if (command === "models") {',
+          '  process.stdout.write(`openai/gpt-test\\n{"id":"gpt-test","providerID":"openai","name":"GPT Test"}\\n`);',
+          '} else if (command === "agent") {',
+          '  process.stdout.write("[]\\n");',
+          "} else {",
+          '  process.stdout.write("[]\\n");',
+          "}",
+          "",
+        ].join("\n"),
+      );
+      yield* fs.writeFileString(
+        binaryPath,
+        [
+          ...(isWindows ? ["@echo off"] : ["#!/bin/sh"]),
+          isWindows
+            ? '"%T3_TEST_NODE_BINARY%" "%T3_TEST_OPENCODE_SCRIPT%" %*'
+            : 'exec "$T3_TEST_NODE_BINARY" "$T3_TEST_OPENCODE_SCRIPT" "$@"',
+          "",
+        ].join("\n"),
+      );
+      if (!isWindows) {
+        yield* fs.chmod(binaryPath, 0o755);
+      }
+
+      const runtime = yield* OpenCodeRuntime;
+      const inventory = yield* runtime.loadInventoryFromCli({
+        binaryPath,
+        cwd: tempDir,
+        environment: {
+          ...hostEnvironment,
+          T3_TEST_NODE_BINARY: executablePath,
+          T3_TEST_OPENCODE_SCRIPT: scriptPath,
+          T3_TEST_OPENCODE_LOCK: lockPath,
+          T3_TEST_OPENCODE_OVERLAP: overlapPath,
+          T3_TEST_OPENCODE_LOG: logPath,
+        },
+      });
+
+      NodeAssert.deepEqual(inventory.providerList.connected, ["openai"]);
+      const overlapExists = yield* fs.exists(overlapPath);
+      NodeAssert.equal(overlapExists, false);
+      const log = yield* fs.readFileString(logPath);
+      NodeAssert.equal(log.trim(), ["models", "agent", "debug"].join("\n"));
+    }),
+  );
+
+  it.effect("kills a hanging command process group when the command is interrupted", () =>
+    Effect.gen(function* () {
+      const fs = yield* FileSystem.FileSystem;
+      const path = yield* Path.Path;
+      const hostEnvironment = yield* HostProcessEnvironment;
+      const executablePath = yield* HostProcessExecutablePath;
+      const hostPlatform = yield* HostProcessPlatform;
+      if (hostPlatform === "win32") {
+        return;
+      }
+
+      const tempDir = yield* fs.makeTempDirectoryScoped({ prefix: "t3-opencode-hang-" });
+      const binaryPath = path.join(tempDir, "opencode");
+      const scriptPath = path.join(tempDir, "opencode.mjs");
+      const pidPath = path.join(tempDir, "pid");
+
+      yield* fs.writeFileString(
+        scriptPath,
+        [
+          'import * as fs from "node:fs";',
+          "fs.writeFileSync(process.env.T3_TEST_OPENCODE_PID, String(process.pid));",
+          "setInterval(() => {}, 1000);",
+          "",
+        ].join("\n"),
+      );
+      yield* fs.writeFileString(
+        binaryPath,
+        ["#!/bin/sh", 'exec "$T3_TEST_NODE_BINARY" "$T3_TEST_OPENCODE_SCRIPT" "$@"', ""].join("\n"),
+      );
+      yield* fs.chmod(binaryPath, 0o755);
+
+      const runtime = yield* OpenCodeRuntime;
+      const commandFiber = yield* runtime
+        .runOpenCodeCommand({
+          binaryPath,
+          args: ["--version"],
+          environment: {
+            ...hostEnvironment,
+            T3_TEST_NODE_BINARY: executablePath,
+            T3_TEST_OPENCODE_SCRIPT: scriptPath,
+            T3_TEST_OPENCODE_PID: pidPath,
+          },
+        })
+        .pipe(Effect.forkChild);
+
+      const pidText = yield* fs
+        .readFileString(pidPath)
+        .pipe(Effect.retry(Schedule.spaced("25 millis")), Effect.timeoutOption("2 seconds"));
+      if (Option.isNone(pidText)) {
+        yield* Fiber.interrupt(commandFiber);
+        NodeAssert.fail("Hanging OpenCode command never wrote its pid.");
+      }
+      const pid = Number(pidText.value.trim());
+      NodeAssert.ok(Number.isInteger(pid) && pid > 0);
+
+      yield* Fiber.interrupt(commandFiber);
+
+      const stillAlive = yield* Effect.sync(() => {
+        try {
+          process.kill(pid, 0);
+          return true;
+        } catch {
+          return false;
+        }
+      }).pipe(
+        Effect.filterOrFail(
+          (alive) => !alive,
+          () => new OpenCodeCommandStillAliveError(),
+        ),
+        Effect.retry(Schedule.spaced("25 millis")),
+        Effect.timeoutOption("2 seconds"),
+      );
+      NodeAssert.equal(Option.isSome(stillAlive), true);
+    }).pipe(TestClock.withLive),
   );
 });

--- a/apps/server/src/provider/opencodeRuntime.ts
+++ b/apps/server/src/provider/opencodeRuntime.ts
@@ -448,11 +448,23 @@ const makeOpenCodeRuntime = Effect.gen(function* () {
       const spawnCommand = yield* resolveCommand(input.binaryPath, input.args, input.environment);
       const child = yield* spawner.spawn(
         ChildProcess.make(spawnCommand.command, spawnCommand.args, {
+          detached: hostPlatform !== "win32",
           shell: spawnCommand.shell,
           ...(input.cwd ? { cwd: input.cwd } : {}),
           ...(input.environment ? { env: input.environment } : { extendEnv: true }),
         }),
       );
+      const terminateCommandGroup =
+        hostPlatform === "win32"
+          ? child.kill({ killSignal: "SIGKILL" }).pipe(Effect.asVoid)
+          : Effect.sync(() => {
+              try {
+                process.kill(-Number(child.pid), "SIGKILL");
+              } catch {
+                // The command and its process group may already have exited.
+              }
+            });
+      yield* Effect.addFinalizer(() => terminateCommandGroup.pipe(Effect.ignore));
       const collectOptions =
         input.maxOutputBytes === undefined ? undefined : { maxBytes: input.maxOutputBytes };
       const [stdout, stderr, code] = yield* Effect.all(
@@ -754,10 +766,11 @@ const makeOpenCodeRuntime = Effect.gen(function* () {
           ...commandContext,
         }).pipe(Effect.exit);
 
-      // First attempt — run all inventory commands in parallel.
+      // Every OpenCode CLI command opens the same shared SQLite database. Running them
+      // concurrently causes "database is locked" failures, so run them one at a time.
       const [initialModelsResult, initialAgentsResult, initialSkillsResult] = yield* Effect.all(
         [runModelsCli(), runAgentsCli(), runSkillsCli()],
-        { concurrency: "unbounded" },
+        { concurrency: 1 },
       );
       let modelsResult = initialModelsResult;
       let agentsResult = initialAgentsResult;
@@ -775,7 +788,7 @@ const makeOpenCodeRuntime = Effect.gen(function* () {
             needsAgentsRetry ? runAgentsCli() : Effect.succeed(agentsResult),
             needsSkillsRetry ? runSkillsCli() : Effect.succeed(skillsResult),
           ],
-          { concurrency: "unbounded" },
+          { concurrency: 1 },
         );
         modelsResult = m2;
         agentsResult = a2;

--- a/apps/server/src/provider/opencodeRuntime.ts
+++ b/apps/server/src/provider/opencodeRuntime.ts
@@ -437,13 +437,15 @@ function ensureRuntimeError(
     : new OpenCodeRuntimeError({ operation, detail, cause });
 }
 
+// OpenCode CLI commands share one SQLite database per machine. The lock is
+// process-wide so concurrent provider checks, snapshots, and separately
+// constructed OpenCodeRuntime instances cannot overlap inventory sequences.
+const openCodeInventoryCliLock = Semaphore.makeUnsafe(1);
+
 const makeOpenCodeRuntime = Effect.gen(function* () {
   const spawner = yield* ChildProcessSpawner.ChildProcessSpawner;
   const netService = yield* NetService.NetService;
   const hostPlatform = yield* HostProcessPlatform;
-  // Every OpenCode CLI command opens the same shared SQLite database. Inventory
-  // refreshes from provider checks, snapshots, and retries must not overlap.
-  const inventoryCliLock = yield* Semaphore.make(1);
   const resolveCommand = (command: string, args: ReadonlyArray<string>, env?: NodeJS.ProcessEnv) =>
     resolveSpawnCommand(command, args, env ? { env } : {});
 
@@ -843,7 +845,7 @@ const makeOpenCodeRuntime = Effect.gen(function* () {
         agents,
         skills,
       };
-    }).pipe(inventoryCliLock.withPermits(1));
+    }).pipe(openCodeInventoryCliLock.withPermits(1));
 
   return {
     startOpenCodeServerProcess,

--- a/apps/server/src/provider/opencodeRuntime.ts
+++ b/apps/server/src/provider/opencodeRuntime.ts
@@ -24,6 +24,7 @@ import * as Option from "effect/Option";
 import * as P from "effect/Predicate";
 import * as Ref from "effect/Ref";
 import * as Result from "effect/Result";
+import * as Semaphore from "effect/Semaphore";
 import * as Scope from "effect/Scope";
 import * as Schema from "effect/Schema";
 import * as Stream from "effect/Stream";
@@ -440,6 +441,9 @@ const makeOpenCodeRuntime = Effect.gen(function* () {
   const spawner = yield* ChildProcessSpawner.ChildProcessSpawner;
   const netService = yield* NetService.NetService;
   const hostPlatform = yield* HostProcessPlatform;
+  // Every OpenCode CLI command opens the same shared SQLite database. Inventory
+  // refreshes from provider checks, snapshots, and retries must not overlap.
+  const inventoryCliLock = yield* Semaphore.make(1);
   const resolveCommand = (command: string, args: ReadonlyArray<string>, env?: NodeJS.ProcessEnv) =>
     resolveSpawnCommand(command, args, env ? { env } : {});
 
@@ -839,7 +843,7 @@ const makeOpenCodeRuntime = Effect.gen(function* () {
         agents,
         skills,
       };
-    });
+    }).pipe(inventoryCliLock.withPermits(1));
 
   return {
     startOpenCodeServerProcess,

--- a/docs/internals/providers.md
+++ b/docs/internals/providers.md
@@ -62,10 +62,10 @@ a Mastra session is absent.
 
 Standard OpenCode discovery probes `opencode --version` for at most four seconds. The probe command
 runs in its own process group so a hanging wrapper cannot keep provider status running after the
-timeout. Inventory CLI commands (`models --verbose`, `agent list`, `debug skill`) run one at a time,
-and the whole inventory sequence including its retry is serialized across concurrent refreshes,
-because they share OpenCode's SQLite database. OpenCode Go stays on the Mastra controller and does
-not use this CLI probe path.
+timeout. Inventory CLI commands (`models --verbose`, `agent list`, `debug skill`) run one at a time.
+A process-wide permit serializes the full inventory sequence, including retries, across concurrent
+provider checks and separately constructed OpenCode runtimes, because they share one SQLite database.
+OpenCode Go stays on the Mastra controller and does not use this CLI probe path.
 
 ## Raw protocol observation
 

--- a/docs/internals/providers.md
+++ b/docs/internals/providers.md
@@ -60,6 +60,12 @@ the active runtime and starts the selected provider without reusing an incompati
 bridge is not the Codex turn path, and AgentController never falls back to the legacy Codex loop when
 a Mastra session is absent.
 
+Standard OpenCode discovery probes `opencode --version` for at most four seconds. The probe command
+runs in its own process group so a hanging wrapper cannot keep provider status running after the
+timeout. Inventory CLI commands (`models --verbose`, `agent list`, `debug skill`) run one at a time
+because they share OpenCode's SQLite database. OpenCode Go stays on the Mastra controller and does
+not use this CLI probe path.
+
 ## Raw protocol observation
 
 The [ACP protocol](../../packages/effect-acp/src/protocol.ts) and

--- a/docs/internals/providers.md
+++ b/docs/internals/providers.md
@@ -62,7 +62,8 @@ a Mastra session is absent.
 
 Standard OpenCode discovery probes `opencode --version` for at most four seconds. The probe command
 runs in its own process group so a hanging wrapper cannot keep provider status running after the
-timeout. Inventory CLI commands (`models --verbose`, `agent list`, `debug skill`) run one at a time
+timeout. Inventory CLI commands (`models --verbose`, `agent list`, `debug skill`) run one at a time,
+and the whole inventory sequence including its retry is serialized across concurrent refreshes,
 because they share OpenCode's SQLite database. OpenCode Go stays on the Mastra controller and does
 not use this CLI probe path.
 


### PR DESCRIPTION
## Problem

A hanging OpenCode wrapper can keep provider discovery running indefinitely and retain CPU-heavy descendants. OpenCode also opens the same shared SQLite database for every CLI command, so running `models --verbose`, `agent list`, and `debug skill` at the same time fails with "database is locked" and can take the provider offline until restart.

## Adaptation

This ports the remaining CLI probe reliability from upstream T3 Code without changing the legacy OpenCode adapter session path or OpenCode Go's Mastra controller.

- Local `opencode --version` probes stop after four seconds.
- Probe commands spawn in a process group on POSIX and are killed when the command scope closes, including after timeout.
- Inventory CLI commands run one at a time on both the first pass and the retry pass.

Akeru subscription env, MCP headers, lazy attachments, and raw retention are unchanged. This PR does not add OpenCode ServerOwner or SDK skill loading.

## Upstream

Adapted from [pingdotgg/t3code#8750](https://github.com/pingdotgg/t3code/pull/8750) and [pingdotgg/t3code#10427](https://github.com/pingdotgg/t3code/pull/10427).

## Scope

- `apps/server/src/provider/opencodeRuntime.ts`
- `apps/server/src/provider/Layers/OpenCodeProvider.ts`
- focused tests
- `docs/internals/providers.md`

Not in this PR: child-session ownership/approvals (#8480, #9005), approval retry/revert (#9282, #9653, #9924), part-index memory (#9684, #9689, #9738, #10116), or SDK skill loading (#9585).

## Verification

- `vp test run apps/server/src/provider/Layers/OpenCodeProvider.test.ts apps/server/src/provider/opencodeRuntime.inventory.test.ts apps/server/src/provider/opencodeRuntime.cliParsers.test.ts apps/server/src/provider/opencodeRuntime.environment.test.ts` — 33 tests passed, including hanging version probe timeout, sequential inventory commands, and process-group kill on interrupt.
- Targeted lint on the changed files passed.
- Server typecheck reports no new errors in the changed files.

No browser or native client verification: this is server discovery/CLI process behavior. No live OpenCode CLI was required for these tests.

## Limitations

Windows process-group kill uses the child kill path rather than POSIX negative-PID groups. The hanging-command process-group test skips on Windows.

Made with Grok 4.6 High in Grok Build via Orca.