### PR TITLE
fix(server): stop Windows terminal processes when closing

### DIFF
--- a/apps/server/src/terminal/NodePtyAdapter.test.ts
+++ b/apps/server/src/terminal/NodePtyAdapter.test.ts
@@ -21,15 +21,51 @@ const spawn = vi.fn(() => ({
 
 vi.mock("node-pty", () => ({ spawn }));
 
-const testLayer = NodePtyAdapter.layer.pipe(
-  Layer.provide(
-    Layer.mergeAll(
-      NodeServices.layer,
-      Layer.succeed(HostProcessPlatform, "win32"),
-      Layer.succeed(HostProcessArchitecture, "x64"),
+const makeTestLayer = (platform: NodeJS.Platform = "win32") =>
+  NodePtyAdapter.layer.pipe(
+    Layer.provide(
+      Layer.mergeAll(
+        NodeServices.layer,
+        Layer.succeed(HostProcessPlatform, platform),
+        Layer.succeed(HostProcessArchitecture, "x64"),
+      ),
     ),
-  ),
-);
+  );
+
+const testLayer = makeTestLayer();
+
+for (const platform of ["win32", "linux", "darwin"] as const) {
+  it.effect(`terminates through node-pty using ${platform} semantics`, () =>
+    Effect.gen(function* () {
+      spawn.mockClear();
+      const adapter = yield* PtyAdapter.PtyAdapter;
+      const process = yield* adapter.spawn({
+        shell: "test-shell",
+        cwd: ".",
+        cols: 80,
+        rows: 24,
+        env: {},
+      });
+      const nativeProcess = spawn.mock.results.at(-1)!.value;
+      nativeProcess.kill.mockImplementation((signal?: string) => {
+        if (platform === "win32" && signal) {
+          throw new Error("Signals not supported on windows.");
+        }
+      });
+
+      process.kill("SIGTERM");
+      process.kill("SIGKILL");
+      process.kill();
+
+      assert.deepEqual(
+        nativeProcess.kill.mock.calls,
+        platform === "win32"
+          ? [[undefined], [undefined], [undefined]]
+          : [["SIGTERM"], ["SIGKILL"], [undefined]],
+      );
+    }).pipe(Effect.provide(makeTestLayer(platform))),
+  );
+}
 
 it.effect("spawns through the public adapter with the provided host references", () =>
   Effect.gen(function* () {

--- a/apps/server/src/terminal/NodePtyAdapter.ts
+++ b/apps/server/src/terminal/NodePtyAdapter.ts
@@ -69,9 +69,11 @@ const ensureNodePtySpawnHelperExecutable = Effect.fn(function* () {
 
 class NodePtyProcess implements PtyAdapter.PtyProcess {
   private readonly process: import("node-pty").IPty;
+  private readonly platform: NodeJS.Platform;
 
-  constructor(process: import("node-pty").IPty) {
+  constructor(process: import("node-pty").IPty, platform: NodeJS.Platform) {
     this.process = process;
+    this.platform = platform;
   }
 
   get pid(): number {
@@ -87,7 +89,8 @@ class NodePtyProcess implements PtyAdapter.PtyProcess {
   }
 
   kill(signal?: string): void {
-    this.process.kill(signal);
+    // node-pty terminates the Windows process tree without a POSIX signal.
+    this.process.kill(this.platform === "win32" ? undefined : signal);
   }
 
   onData(callback: (data: string) => void): () => void {
@@ -164,7 +167,7 @@ export const make = Effect.fn("NodePtyAdapter.make")(function* (
             cause,
           }),
       });
-      return new NodePtyProcess(ptyProcess);
+      return new NodePtyProcess(ptyProcess, platform);
     }),
   });
 });


### PR DESCRIPTION
## Problem

Closing a Windows terminal can hide the session while child processes keep running, including HTTP servers that still hold their ports. The terminal manager sends SIGTERM/SIGKILL, but node-pty rejects POSIX signals on Windows.

## Changes

`NodePtyAdapter` omits the signal on Windows so node-pty runs its native process-tree termination. Linux and macOS keep their existing signal behavior. The change stays in the server adapter, so every client that closes a terminal gets it.

Adapted from pingdotgg/t3code#10771. Process ownership, history, and Akeru session fields are unchanged.

## Scope

This PR is Windows terminal close only.

Covered here:

- #10771 Windows process-tree close

Still assigned to this handoff, in later PRs:

- #9476 Windows terminal process polling
- client incremental rollover / hidden rendering (#9707 #9718 #9663 #9747)
- terminal input (#9199 #8541 #11018 #10060)
- desktop browser debugger / shortcuts / context menu (#9068 #9840 #10621 #10670)
- quit confirmation sequence (#9076 #9141 #9485 #9657)

Server history bounds already landed in a separate PR.

## Verification

- `vp test run apps/server/src/terminal/NodePtyAdapter.test.ts`: 6 passed, including Windows, Linux, and macOS kill semantics. The Windows case fails if a signal is passed through.
- `vp lint` on the two adapter files: clean.

No Windows host in this environment, so native process-tree termination was not exercised on a real Windows machine. Linux/macOS signal behavior is covered by the same adapter tests.

Implemented and verified by Grok 4.6 High in Grok Build via Orca.
