### PR TITLE
fix(mobile): preserve drafts after storage read failures

### DIFF
--- a/apps/mobile/src/state/thread-outbox-manager.ts
+++ b/apps/mobile/src/state/thread-outbox-manager.ts
@@ -95,6 +95,11 @@ export function createThreadOutboxManager(options: ThreadOutboxManagerOptions) {
       const persisted = await options.storage.load();
       reportUnreadOutboxRecords(persisted);
       setMessages([...persisted.messages, ...currentMessages()]);
+      // A mixed load is not complete. Drop the cache so a later load, such as
+      // drain after reconnect, can hydrate a file that becomes readable.
+      if (persisted.unreadRecords.length > 0) {
+        loadPromise = null;
+      }
     }).catch((cause) => {
       loadPromise = null;
       warn(

--- a/apps/mobile/src/state/thread-outbox-manager.ts
+++ b/apps/mobile/src/state/thread-outbox-manager.ts
@@ -7,7 +7,7 @@ import {
   groupQueuedThreadMessages,
   type QueuedThreadMessage,
 } from "./thread-outbox-model";
-import type { ThreadOutboxStorage } from "./thread-outbox-storage";
+import type { ThreadOutboxLoadResult, ThreadOutboxStorage } from "./thread-outbox-storage";
 
 export class ThreadOutboxManagerError extends Schema.TaggedErrorClass<ThreadOutboxManagerError>()(
   "ThreadOutboxManagerError",
@@ -58,6 +58,28 @@ export function createThreadOutboxManager(options: ThreadOutboxManagerOptions) {
     return result;
   };
 
+  const reportUnreadOutboxRecords = (persisted: ThreadOutboxLoadResult): void => {
+    for (const unread of persisted.unreadRecords) {
+      warn("[thread-outbox] left unreadable persisted message on disk", unread);
+    }
+  };
+
+  const requireCompleteOutboxLoad = (
+    persisted: ThreadOutboxLoadResult,
+    environmentId: EnvironmentId,
+  ): ReadonlyArray<QueuedThreadMessage> => {
+    if (persisted.unreadRecords.length > 0) {
+      throw new ThreadOutboxManagerError({
+        operation: "clear-environment-load",
+        environmentId,
+        threadId: null,
+        messageId: null,
+        cause: persisted.unreadRecords,
+      });
+    }
+    return persisted.messages;
+  };
+
   const currentMessages = (): ReadonlyArray<QueuedThreadMessage> =>
     flattenQueuedThreadMessages(options.registry.get(queuedMessagesByThreadKeyAtom));
 
@@ -70,8 +92,9 @@ export function createThreadOutboxManager(options: ThreadOutboxManagerOptions) {
       return loadPromise;
     }
     loadPromise = serialize(async () => {
-      const persistedMessages = await options.storage.load();
-      setMessages([...persistedMessages, ...currentMessages()]);
+      const persisted = await options.storage.load();
+      reportUnreadOutboxRecords(persisted);
+      setMessages([...persisted.messages, ...currentMessages()]);
     }).catch((cause) => {
       loadPromise = null;
       warn(
@@ -181,8 +204,9 @@ export function createThreadOutboxManager(options: ThreadOutboxManagerOptions) {
           cause,
         });
       });
+      const readable = requireCompleteOutboxLoad(persisted, environmentId);
       const allMessages = flattenQueuedThreadMessages(
-        groupQueuedThreadMessages([...persisted, ...currentMessages()]),
+        groupQueuedThreadMessages([...readable, ...currentMessages()]),
       );
       const removedMessageIds = new Set<MessageId>();
 

--- a/apps/mobile/src/state/thread-outbox-manager.ts
+++ b/apps/mobile/src/state/thread-outbox-manager.ts
@@ -173,17 +173,13 @@ export function createThreadOutboxManager(options: ThreadOutboxManagerOptions) {
   const clearEnvironment = (environmentId: EnvironmentId): Promise<void> =>
     serialize(async () => {
       const persisted = await options.storage.load().catch((cause) => {
-        warn(
-          "[thread-outbox] failed to load messages while clearing environment",
-          new ThreadOutboxManagerError({
-            operation: "clear-environment-load",
-            environmentId,
-            threadId: null,
-            messageId: null,
-            cause,
-          }),
-        );
-        return [];
+        throw new ThreadOutboxManagerError({
+          operation: "clear-environment-load",
+          environmentId,
+          threadId: null,
+          messageId: null,
+          cause,
+        });
       });
       const allMessages = flattenQueuedThreadMessages(
         groupQueuedThreadMessages([...persisted, ...currentMessages()]),

--- a/apps/mobile/src/state/thread-outbox-model.ts
+++ b/apps/mobile/src/state/thread-outbox-model.ts
@@ -196,14 +196,30 @@ function errorMessage(error: unknown): string | null {
   return typeof error === "string" ? error : null;
 }
 
+/**
+ * Only a failure the server actually decided (`OrchestrationDispatchCommandError`,
+ * or an authorization rejection) means the payload itself is bad. The other
+ * typed failures a queued send can hit are transport-shaped: a socket that
+ * dropped mid-request (`RpcClientError` wrapping a Socket read/write/close
+ * reason), or an environment that is not connected or not registered. Those
+ * are matched by tag, not by message text, because a `SocketReadError` message
+ * is just "An error occurred during Read". A wrong answer here restores the
+ * pending task into a draft and it disappears from the list.
+ */
 export function shouldRetryThreadOutboxDelivery(error: unknown): boolean {
-  if (
-    typeof error === "object" &&
-    error !== null &&
-    "_tag" in error &&
-    error._tag === "ConnectionTransientError"
-  ) {
-    return true;
+  if (typeof error === "object" && error !== null && "_tag" in error) {
+    switch (error._tag) {
+      case "OrchestrationDispatchCommandError":
+      case "EnvironmentAuthorizationError":
+        return false;
+      case "ConnectionTransientError":
+      case "RpcClientError":
+      case "EnvironmentRpcUnavailableError":
+      case "EnvironmentNotRegisteredError":
+        return true;
+      default:
+        break;
+    }
   }
   return isTransportConnectionErrorMessage(errorMessage(error));
 }

--- a/apps/mobile/src/state/thread-outbox-storage.ts
+++ b/apps/mobile/src/state/thread-outbox-storage.ts
@@ -80,20 +80,20 @@ export const expoThreadOutboxStorage: ThreadOutboxStorage = {
         try {
           messages.push(decodeQueuedThreadMessage(JSON.parse(await entry.text()) as unknown));
         } catch (cause) {
-          console.warn(
-            "[thread-outbox] ignored invalid persisted message",
-            new ThreadOutboxStorageError({
-              operation: "read-message",
-              environmentId: null,
-              threadId: null,
-              messageId: null,
-              fileName: entry.name,
-              cause,
-            }),
-          );
+          // A partial queue hides attachment owners from cleanup. Keep all
+          // records untouched until every persisted message can be read.
+          throw new ThreadOutboxStorageError({
+            operation: "read-message",
+            environmentId: null,
+            threadId: null,
+            messageId: null,
+            fileName: entry.name,
+            cause,
+          });
         }
       }
     } catch (cause) {
+      if (cause instanceof ThreadOutboxStorageError) throw cause;
       throw new ThreadOutboxStorageError({
         operation: "load",
         environmentId: null,

--- a/apps/mobile/src/state/thread-outbox-storage.ts
+++ b/apps/mobile/src/state/thread-outbox-storage.ts
@@ -44,10 +44,19 @@ export class ThreadOutboxStorageError extends Schema.TaggedErrorClass<ThreadOutb
   }
 }
 
+export interface ThreadOutboxLoadResult {
+  readonly messages: ReadonlyArray<QueuedThreadMessage>;
+  readonly unreadRecords: ReadonlyArray<ThreadOutboxStorageError>;
+}
+
 export interface ThreadOutboxStorage {
-  readonly load: () => Promise<ReadonlyArray<QueuedThreadMessage>>;
+  readonly load: () => Promise<ThreadOutboxLoadResult>;
   readonly write: (message: QueuedThreadMessage) => Promise<void>;
   readonly remove: (message: QueuedThreadMessage) => Promise<void>;
+}
+
+export function emptyThreadOutboxLoadResult(): ThreadOutboxLoadResult {
+  return { messages: [], unreadRecords: [] };
 }
 
 function messageFileName(messageId: MessageId): string {
@@ -69,6 +78,7 @@ async function getMessageFile(messageId: MessageId) {
 export const expoThreadOutboxStorage: ThreadOutboxStorage = {
   load: async () => {
     const messages: QueuedThreadMessage[] = [];
+    const unreadRecords: ThreadOutboxStorageError[] = [];
     try {
       const { File } = await import("expo-file-system");
       const directory = await getOutboxDirectory();
@@ -80,20 +90,21 @@ export const expoThreadOutboxStorage: ThreadOutboxStorage = {
         try {
           messages.push(decodeQueuedThreadMessage(JSON.parse(await entry.text()) as unknown));
         } catch (cause) {
-          // A partial queue hides attachment owners from cleanup. Keep all
-          // records untouched until every persisted message can be read.
-          throw new ThreadOutboxStorageError({
-            operation: "read-message",
-            environmentId: null,
-            threadId: null,
-            messageId: null,
-            fileName: entry.name,
-            cause,
-          });
+          // Leave the file on disk. Cleanup must see that ownership is
+          // incomplete, while delivery can still hydrate readable messages.
+          unreadRecords.push(
+            new ThreadOutboxStorageError({
+              operation: "read-message",
+              environmentId: null,
+              threadId: null,
+              messageId: null,
+              fileName: entry.name,
+              cause,
+            }),
+          );
         }
       }
     } catch (cause) {
-      if (cause instanceof ThreadOutboxStorageError) throw cause;
       throw new ThreadOutboxStorageError({
         operation: "load",
         environmentId: null,
@@ -103,7 +114,7 @@ export const expoThreadOutboxStorage: ThreadOutboxStorage = {
         cause,
       });
     }
-    return messages;
+    return { messages, unreadRecords };
   },
   write: async (message) => {
     const fileName = messageFileName(message.messageId);

--- a/apps/mobile/src/state/thread-outbox.test.ts
+++ b/apps/mobile/src/state/thread-outbox.test.ts
@@ -1,13 +1,48 @@
 import { describe, expect, it } from "@effect/vitest";
+import { EnvironmentNotRegisteredError } from "@t3tools/client-runtime/connection";
+import { isTransportConnectionErrorMessage } from "@t3tools/client-runtime/errors";
+import { EnvironmentRpcUnavailableError } from "@t3tools/client-runtime/rpc";
 import {
   CommandId,
+  EnvironmentAuthorizationError,
   EnvironmentId,
   MessageId,
+  OrchestrationDispatchCommandError,
   ProjectId,
   ProviderInstanceId,
   ThreadId,
 } from "@t3tools/contracts";
 import { AtomRegistry } from "effect/unstable/reactivity";
+import * as RpcClientError from "effect/unstable/rpc/RpcClientError";
+import * as Socket from "effect/unstable/socket/Socket";
+import { onTestFinished, vi } from "vite-plus/test";
+
+const outboxFiles = vi.hoisted(() => new Map<string, string | Error>());
+
+vi.mock("expo-file-system", () => {
+  class File {
+    constructor(readonly name: string) {}
+
+    async text(): Promise<string> {
+      const contents = outboxFiles.get(this.name);
+      if (contents instanceof Error) throw contents;
+      if (contents === undefined) throw new Error("Missing file");
+      return contents;
+    }
+  }
+
+  return {
+    File,
+    Directory: class {
+      create() {}
+
+      list() {
+        return Array.from(outboxFiles.keys(), (name) => new File(name));
+      }
+    },
+    Paths: { document: "/documents" },
+  };
+});
 
 import {
   decodeQueuedThreadMessage,
@@ -23,7 +58,7 @@ import {
   type QueuedThreadMessage,
 } from "./thread-outbox-model";
 import { createThreadOutboxManager, ThreadOutboxManagerError } from "./thread-outbox-manager";
-import type { ThreadOutboxStorage } from "./thread-outbox-storage";
+import { expoThreadOutboxStorage, type ThreadOutboxStorage } from "./thread-outbox-storage";
 
 function queuedMessage(input: {
   readonly environmentId?: string;
@@ -43,6 +78,72 @@ function queuedMessage(input: {
 }
 
 describe("thread outbox", () => {
+  it.each(["read", "json", "schema"] as const)(
+    "does not load a partial outbox after a record %s failure",
+    async (failure) => {
+      onTestFinished(() => outboxFiles.clear());
+      const first = queuedMessage({
+        messageId: "message-1",
+        createdAt: "2026-06-08T10:00:01.000Z",
+      });
+      const second = queuedMessage({
+        messageId: "message-2",
+        createdAt: "2026-06-08T10:00:02.000Z",
+      });
+      outboxFiles.set("message-1.json", JSON.stringify(encodeQueuedThreadMessage(first)));
+      outboxFiles.set(
+        "message-2.json",
+        failure === "read"
+          ? new Error("storage unavailable")
+          : failure === "json"
+            ? "{"
+            : JSON.stringify({ ...second, schemaVersion: 999 }),
+      );
+
+      await expect(expoThreadOutboxStorage.load()).rejects.toMatchObject({
+        operation: "read-message",
+        fileName: "message-2.json",
+      });
+
+      outboxFiles.set("message-2.json", JSON.stringify(encodeQueuedThreadMessage(second)));
+      await expect(expoThreadOutboxStorage.load()).resolves.toEqual([first, second]);
+    },
+  );
+
+  it("preserves queued messages when environment cleanup cannot read the outbox", async () => {
+    const registry = AtomRegistry.make();
+    onTestFinished(() => registry.dispose());
+    const message = queuedMessage({
+      messageId: "message-1",
+      createdAt: "2026-06-08T10:00:01.000Z",
+    });
+    const stored = new Map<MessageId, QueuedThreadMessage>();
+    const manager = createThreadOutboxManager({
+      registry,
+      warn: () => {},
+      storage: {
+        load: async () => {
+          throw new Error("storage unavailable");
+        },
+        write: async (entry) => {
+          stored.set(entry.messageId, entry);
+        },
+        remove: async (entry) => {
+          stored.delete(entry.messageId);
+        },
+      },
+    });
+    await manager.enqueue(message);
+
+    await expect(manager.clearEnvironment(message.environmentId)).rejects.toMatchObject({
+      operation: "clear-environment-load",
+    });
+    expect([...stored.values()]).toEqual([message]);
+    expect(registry.get(manager.queuedMessagesByThreadKeyAtom)).toEqual({
+      "environment-1:thread-1": [message],
+    });
+  });
+
   it("groups messages by scoped thread and preserves creation order", () => {
     const later = queuedMessage({
       messageId: "message-2",
@@ -600,6 +701,62 @@ describe("thread outbox", () => {
       }),
     ).toBe(true);
     expect(shouldRetryThreadOutboxDelivery(new Error("Thread no longer exists"))).toBe(false);
+    expect(
+      shouldRetryThreadOutboxDelivery(
+        new OrchestrationDispatchCommandError({ message: "Thread no longer exists" }),
+      ),
+    ).toBe(false);
+    expect(
+      shouldRetryThreadOutboxDelivery(
+        new EnvironmentAuthorizationError({
+          message: "Missing scope",
+          requiredScope: "orchestration:operate",
+        }),
+      ),
+    ).toBe(false);
+  });
+
+  // A pending task created offline drains the moment the phone reconnects,
+  // which is exactly when the socket is most likely to drop again. Every way a
+  // request can fail in flight must retry; a restore turns the pending task
+  // into a draft and it disappears from the list.
+  it("retries every in-flight transport failure by tag, not by message text", () => {
+    const socketReasons = [
+      new Socket.SocketReadError({ cause: new Error("The network connection was lost.") }),
+      new Socket.SocketWriteError({ cause: new Error("Broken pipe") }),
+      new Socket.SocketCloseError({ code: 1006 }),
+      new Socket.SocketOpenError({ kind: "Timeout", cause: new Error("timeout") }),
+    ];
+    for (const reason of socketReasons) {
+      const error = new RpcClientError.RpcClientError({ reason });
+      expect(isTransportConnectionErrorMessage(error.message)).toBe(
+        reason._tag === "SocketCloseError" || reason._tag === "SocketOpenError",
+      );
+      expect(shouldRetryThreadOutboxDelivery(error)).toBe(true);
+    }
+    expect(
+      shouldRetryThreadOutboxDelivery(
+        new RpcClientError.RpcClientError({
+          reason: new RpcClientError.RpcClientDefect({
+            message: "Error decoding message",
+            cause: new Error("Unexpected end of JSON input"),
+          }),
+        }),
+      ),
+    ).toBe(true);
+    expect(
+      shouldRetryThreadOutboxDelivery(
+        new EnvironmentRpcUnavailableError({
+          environmentId: "environment-1",
+          message: "Home is not connected.",
+        }),
+      ),
+    ).toBe(true);
+    expect(
+      shouldRetryThreadOutboxDelivery(
+        new EnvironmentNotRegisteredError({ environmentId: EnvironmentId.make("environment-1") }),
+      ),
+    ).toBe(true);
   });
 
   it("retains queued messages when settings synchronization fails before startTurn", () => {

--- a/apps/mobile/src/state/thread-outbox.test.ts
+++ b/apps/mobile/src/state/thread-outbox.test.ts
@@ -156,6 +156,58 @@ describe("thread outbox", () => {
     ]);
   });
 
+  it("retries a mixed load so a later-readable record can join the drain queue", async () => {
+    const registry = AtomRegistry.make();
+    onTestFinished(() => registry.dispose());
+    const first = queuedMessage({
+      messageId: "message-1",
+      createdAt: "2026-06-08T10:00:01.000Z",
+    });
+    const second = queuedMessage({
+      messageId: "message-2",
+      createdAt: "2026-06-08T10:00:02.000Z",
+    });
+    const unread = new ThreadOutboxStorageError({
+      operation: "read-message",
+      environmentId: null,
+      threadId: null,
+      messageId: null,
+      fileName: "message-2.json",
+      cause: new Error("{"),
+    });
+    let loadCalls = 0;
+    const manager = createThreadOutboxManager({
+      registry,
+      warn: () => {},
+      storage: {
+        load: async () => {
+          loadCalls += 1;
+          if (loadCalls === 1) {
+            return { messages: [first], unreadRecords: [unread] };
+          }
+          return { messages: [first, second], unreadRecords: [] };
+        },
+        write: async () => undefined,
+        remove: async () => undefined,
+      },
+    });
+
+    await manager.load();
+    expect(
+      flattenQueuedThreadMessages(registry.get(manager.queuedMessagesByThreadKeyAtom)),
+    ).toEqual([first]);
+    expect(loadCalls).toBe(1);
+
+    await manager.load();
+    expect(loadCalls).toBe(2);
+    expect(
+      flattenQueuedThreadMessages(registry.get(manager.queuedMessagesByThreadKeyAtom)),
+    ).toEqual([first, second]);
+
+    await manager.load();
+    expect(loadCalls).toBe(2);
+  });
+
   it("makes a readable pending task visible to drain after a mixed valid/corrupt load", async () => {
     onTestFinished(() => outboxFiles.clear());
     const registry = AtomRegistry.make();

--- a/apps/mobile/src/state/thread-outbox.test.ts
+++ b/apps/mobile/src/state/thread-outbox.test.ts
@@ -58,7 +58,12 @@ import {
   type QueuedThreadMessage,
 } from "./thread-outbox-model";
 import { createThreadOutboxManager, ThreadOutboxManagerError } from "./thread-outbox-manager";
-import { expoThreadOutboxStorage, type ThreadOutboxStorage } from "./thread-outbox-storage";
+import {
+  emptyThreadOutboxLoadResult,
+  expoThreadOutboxStorage,
+  ThreadOutboxStorageError,
+  type ThreadOutboxStorage,
+} from "./thread-outbox-storage";
 
 function queuedMessage(input: {
   readonly environmentId?: string;
@@ -79,7 +84,7 @@ function queuedMessage(input: {
 
 describe("thread outbox", () => {
   it.each(["read", "json", "schema"] as const)(
-    "does not load a partial outbox after a record %s failure",
+    "hydrates valid queued messages after a record %s failure and keeps the unread file",
     async (failure) => {
       onTestFinished(() => outboxFiles.clear());
       const first = queuedMessage({
@@ -90,25 +95,65 @@ describe("thread outbox", () => {
         messageId: "message-2",
         createdAt: "2026-06-08T10:00:02.000Z",
       });
-      outboxFiles.set("message-1.json", JSON.stringify(encodeQueuedThreadMessage(first)));
-      outboxFiles.set(
-        "message-2.json",
+      const corruptContents =
         failure === "read"
           ? new Error("storage unavailable")
           : failure === "json"
             ? "{"
-            : JSON.stringify({ ...second, schemaVersion: 999 }),
-      );
+            : JSON.stringify({ ...second, schemaVersion: 999 });
+      outboxFiles.set("message-1.json", JSON.stringify(encodeQueuedThreadMessage(first)));
+      outboxFiles.set("message-2.json", corruptContents);
 
-      await expect(expoThreadOutboxStorage.load()).rejects.toMatchObject({
-        operation: "read-message",
-        fileName: "message-2.json",
-      });
+      const loaded = await expoThreadOutboxStorage.load();
+      expect(loaded.messages).toEqual([first]);
+      expect(loaded.unreadRecords).toMatchObject([
+        { operation: "read-message", fileName: "message-2.json" },
+      ]);
+      expect(outboxFiles.get("message-2.json")).toBe(corruptContents);
 
       outboxFiles.set("message-2.json", JSON.stringify(encodeQueuedThreadMessage(second)));
-      await expect(expoThreadOutboxStorage.load()).resolves.toEqual([first, second]);
+      await expect(expoThreadOutboxStorage.load()).resolves.toEqual({
+        messages: [first, second],
+        unreadRecords: [],
+      });
     },
   );
+
+  it("publishes readable queued messages while reporting unread records", async () => {
+    const registry = AtomRegistry.make();
+    onTestFinished(() => registry.dispose());
+    const readable = queuedMessage({
+      messageId: "message-1",
+      createdAt: "2026-06-08T10:00:01.000Z",
+    });
+    const unread = new ThreadOutboxStorageError({
+      operation: "read-message",
+      environmentId: null,
+      threadId: null,
+      messageId: null,
+      fileName: "message-2.json",
+      cause: new Error("storage unavailable"),
+    });
+    const warnings: Array<{ message: string; error: unknown }> = [];
+    const manager = createThreadOutboxManager({
+      registry,
+      warn: (message, error) => warnings.push({ message, error }),
+      storage: {
+        load: async () => ({ messages: [readable], unreadRecords: [unread] }),
+        write: async () => undefined,
+        remove: async () => undefined,
+      },
+    });
+
+    await manager.load();
+
+    expect(registry.get(manager.queuedMessagesByThreadKeyAtom)).toEqual({
+      "environment-1:thread-1": [readable],
+    });
+    expect(warnings).toEqual([
+      { message: "[thread-outbox] left unreadable persisted message on disk", error: unread },
+    ]);
+  });
 
   it("preserves queued messages when environment cleanup cannot read the outbox", async () => {
     const registry = AtomRegistry.make();
@@ -137,6 +182,47 @@ describe("thread outbox", () => {
 
     await expect(manager.clearEnvironment(message.environmentId)).rejects.toMatchObject({
       operation: "clear-environment-load",
+    });
+    expect([...stored.values()]).toEqual([message]);
+    expect(registry.get(manager.queuedMessagesByThreadKeyAtom)).toEqual({
+      "environment-1:thread-1": [message],
+    });
+  });
+
+  it("preserves queued messages when environment cleanup sees an unread outbox record", async () => {
+    const registry = AtomRegistry.make();
+    onTestFinished(() => registry.dispose());
+    const message = queuedMessage({
+      messageId: "message-1",
+      createdAt: "2026-06-08T10:00:01.000Z",
+    });
+    const unread = new ThreadOutboxStorageError({
+      operation: "read-message",
+      environmentId: null,
+      threadId: null,
+      messageId: null,
+      fileName: "message-2.json",
+      cause: new Error("{"),
+    });
+    const stored = new Map<MessageId, QueuedThreadMessage>();
+    const manager = createThreadOutboxManager({
+      registry,
+      warn: () => {},
+      storage: {
+        load: async () => ({ messages: [message], unreadRecords: [unread] }),
+        write: async (entry) => {
+          stored.set(entry.messageId, entry);
+        },
+        remove: async (entry) => {
+          stored.delete(entry.messageId);
+        },
+      },
+    });
+    await manager.enqueue(message);
+
+    await expect(manager.clearEnvironment(message.environmentId)).rejects.toMatchObject({
+      operation: "clear-environment-load",
+      cause: [unread],
     });
     expect([...stored.values()]).toEqual([message]);
     expect(registry.get(manager.queuedMessagesByThreadKeyAtom)).toEqual({
@@ -238,7 +324,7 @@ describe("thread outbox", () => {
     const manager = createThreadOutboxManager({
       registry,
       storage: {
-        load: async () => [],
+        load: async () => emptyThreadOutboxLoadResult(),
         write: async () => undefined,
         remove: async () => undefined,
       },
@@ -285,7 +371,7 @@ describe("thread outbox", () => {
         if (loadCalls === 1) {
           await initialLoadBlocked;
         }
-        return [...stored.values()];
+        return { messages: [...stored.values()], unreadRecords: [] };
       },
       write: async () => undefined,
       remove: async (candidate) => {
@@ -321,7 +407,7 @@ describe("thread outbox", () => {
         load: async () => {
           loadCalls += 1;
           if (loadCalls === 1) throw loadCause;
-          return [];
+          return emptyThreadOutboxLoadResult();
         },
         write: async () => undefined,
         remove: async () => undefined,
@@ -354,7 +440,7 @@ describe("thread outbox", () => {
     const removalCause = new Error("remove failed");
     let failRemoval = true;
     const storage: ThreadOutboxStorage = {
-      load: async () => [...stored.values()],
+      load: async () => ({ messages: [...stored.values()], unreadRecords: [] }),
       write: async (message) => {
         stored.set(message.messageId, message);
       },
@@ -404,7 +490,7 @@ describe("thread outbox", () => {
     const manager = createThreadOutboxManager({
       registry,
       storage: {
-        load: async () => [],
+        load: async () => emptyThreadOutboxLoadResult(),
         write: async () => writeBlocked,
         remove: async () => undefined,
       },
@@ -433,7 +519,7 @@ describe("thread outbox", () => {
     const manager = createThreadOutboxManager({
       registry,
       storage: {
-        load: async () => [],
+        load: async () => emptyThreadOutboxLoadResult(),
         write: async () => {
           throw writeCause;
         },
@@ -468,7 +554,7 @@ describe("thread outbox", () => {
     const manager = createThreadOutboxManager({
       registry,
       storage: {
-        load: async () => [],
+        load: async () => emptyThreadOutboxLoadResult(),
         write: async () => {
           if (failNextWrite) {
             failNextWrite = false;
@@ -505,7 +591,7 @@ describe("thread outbox", () => {
     const manager = createThreadOutboxManager({
       registry,
       storage: {
-        load: async () => [],
+        load: async () => emptyThreadOutboxLoadResult(),
         write: async () => undefined,
         remove: async () => undefined,
       },
@@ -529,7 +615,7 @@ describe("thread outbox", () => {
     const registry = AtomRegistry.make();
     const stored = new Map<MessageId, QueuedThreadMessage>();
     const storage: ThreadOutboxStorage = {
-      load: async () => [...stored.values()],
+      load: async () => ({ messages: [...stored.values()], unreadRecords: [] }),
       write: async (message) => {
         stored.set(message.messageId, message);
       },

--- a/apps/mobile/src/state/thread-outbox.test.ts
+++ b/apps/mobile/src/state/thread-outbox.test.ts
@@ -47,6 +47,7 @@ vi.mock("expo-file-system", () => {
 import {
   decodeQueuedThreadMessage,
   encodeQueuedThreadMessage,
+  flattenQueuedThreadMessages,
   groupQueuedThreadMessages,
   isQueuedThreadCreationSendable,
   modelSelectionsEqual,
@@ -153,6 +154,59 @@ describe("thread outbox", () => {
     expect(warnings).toEqual([
       { message: "[thread-outbox] left unreadable persisted message on disk", error: unread },
     ]);
+  });
+
+  it("makes a readable pending task visible to drain after a mixed valid/corrupt load", async () => {
+    onTestFinished(() => outboxFiles.clear());
+    const registry = AtomRegistry.make();
+    onTestFinished(() => registry.dispose());
+    const pendingTask = {
+      ...queuedMessage({
+        messageId: "message-1",
+        createdAt: "2026-06-08T10:00:01.000Z",
+      }),
+      text: "Retry the upload worker",
+      creation: {
+        projectId: ProjectId.make("project-1"),
+        workspaceMode: "local" as const,
+        branch: null,
+        worktreePath: null,
+      },
+    };
+    outboxFiles.set("message-1.json", JSON.stringify(encodeQueuedThreadMessage(pendingTask)));
+    outboxFiles.set("message-2.json", "{");
+
+    const manager = createThreadOutboxManager({
+      registry,
+      warn: () => {},
+      storage: expoThreadOutboxStorage,
+    });
+    await manager.load();
+
+    const visible = flattenQueuedThreadMessages(
+      registry.get(manager.queuedMessagesByThreadKeyAtom),
+    );
+    expect(visible).toEqual([pendingTask]);
+    expect(
+      resolveThreadOutboxDeliveryAction({
+        isCreation: true,
+        threadExists: false,
+        shellStatus: "live",
+        environmentConnected: true,
+        threadBusy: false,
+      }),
+    ).toBe("send");
+    expect(outboxFiles.get("message-2.json")).toBe("{");
+    expect(outboxFiles.has("message-1.json")).toBe(true);
+
+    await expect(manager.clearEnvironment(pendingTask.environmentId)).rejects.toMatchObject({
+      operation: "clear-environment-load",
+    });
+    expect(outboxFiles.get("message-2.json")).toBe("{");
+    expect(JSON.parse(outboxFiles.get("message-1.json") as string)).toMatchObject({
+      messageId: pendingTask.messageId,
+      text: pendingTask.text,
+    });
   });
 
   it("preserves queued messages when environment cleanup cannot read the outbox", async () => {

--- a/apps/mobile/src/state/use-composer-drafts.test.ts
+++ b/apps/mobile/src/state/use-composer-drafts.test.ts
@@ -3,7 +3,8 @@ import { EnvironmentId, ProviderInstanceId } from "@t3tools/contracts";
 import { vi } from "vite-plus/test";
 
 const composerDraftFileMocks = vi.hoisted(() => {
-  let document = "";
+  let document = JSON.stringify({ schemaVersion: 1, drafts: {} });
+  let readError: Error | null = null;
   let writeError: Error | null = null;
   let releaseRead: (() => void) | null = null;
   let readBarrier = Promise.resolve();
@@ -24,6 +25,9 @@ const composerDraftFileMocks = vi.hoisted(() => {
     setDocument(value: unknown) {
       document = JSON.stringify(value);
     },
+    setReadError(error: Error | null) {
+      readError = error;
+    },
     setWriteError(error: Error | null) {
       writeError = error;
     },
@@ -40,6 +44,7 @@ const composerDraftFileMocks = vi.hoisted(() => {
 
       async text() {
         await readBarrier;
+        if (readError) throw readError;
         return document;
       }
 
@@ -72,6 +77,7 @@ import {
   getComposerDraftSnapshot,
   mergeComposerDraftContentState,
   removeComposerDraftsForEnvironment,
+  resetComposerDraftsLoadState,
   restoreComposerDraftSnapshotState,
   setComposerDraftText,
 } from "./use-composer-drafts";
@@ -82,6 +88,11 @@ const DRAFT: ComposerDraft = {
 };
 
 afterEach(() => {
+  vi.useRealTimers();
+  resetComposerDraftsLoadState();
+  composerDraftFileMocks.setDocument({ schemaVersion: 1, drafts: {} });
+  composerDraftFileMocks.setReadError(null);
+  composerDraftFileMocks.setWriteError(null);
   appAtomRegistry.set(composerDraftsAtom, {});
 });
 
@@ -431,5 +442,46 @@ describe("mobile composer drafts", () => {
     } finally {
       composerDraftFileMocks.setWriteError(null);
     }
+  });
+
+  it.each(["read", "decode"] as const)(
+    "preserves saved drafts when the draft %s fails",
+    async (failure) => {
+      vi.useFakeTimers();
+      composerDraftFileMocks.setDocument({
+        schemaVersion: failure === "decode" ? 999 : 1,
+        drafts: { "environment-1:saved": DRAFT },
+      });
+      const original = composerDraftFileMocks.getDocument();
+      if (failure === "read") {
+        composerDraftFileMocks.setReadError(new Error("storage unavailable"));
+      }
+
+      setComposerDraftText("environment-1:new", "Keep my new edits too");
+      await expect(flushComposerDrafts()).rejects.toMatchObject({ operation: failure });
+
+      expect(composerDraftFileMocks.getDocument()).toBe(original);
+    },
+  );
+
+  it("retries a failed debounced read on final flush without dropping saved drafts or new edits", async () => {
+    vi.useFakeTimers();
+    composerDraftFileMocks.setDocument({
+      schemaVersion: 1,
+      drafts: { "environment-1:saved": DRAFT },
+    });
+    const original = composerDraftFileMocks.getDocument();
+    composerDraftFileMocks.setReadError(new Error("storage unavailable"));
+    setComposerDraftText("environment-1:new", "New edits");
+    await vi.advanceTimersByTimeAsync(200);
+    expect(composerDraftFileMocks.getDocument()).toBe(original);
+
+    composerDraftFileMocks.setReadError(null);
+    await flushComposerDrafts();
+
+    expect(JSON.parse(composerDraftFileMocks.getDocument()).drafts).toEqual({
+      "environment-1:saved": DRAFT,
+      "environment-1:new": { text: "New edits", attachments: [] },
+    });
   });
 });

--- a/apps/mobile/src/state/use-composer-drafts.ts
+++ b/apps/mobile/src/state/use-composer-drafts.ts
@@ -104,7 +104,18 @@ export const composerDraftsAtom = Atom.make<Record<string, ComposerDraft>>({}).p
 
 let loadPromise: Promise<void> | null = null;
 let persistTimer: ReturnType<typeof setTimeout> | null = null;
+let persistRetryNeeded = false;
 const persistenceQueue = new SerializedAsyncQueue();
+
+/** Resets module-level state between test runs. */
+export function resetComposerDraftsLoadState(): void {
+  loadPromise = null;
+  persistRetryNeeded = false;
+  if (persistTimer !== null) {
+    clearTimeout(persistTimer);
+    persistTimer = null;
+  }
+}
 
 function normalizeDraft(draft: ComposerDraft | undefined): ComposerDraft {
   if (!draft) {
@@ -162,16 +173,12 @@ async function loadPersistedComposerDrafts(): Promise<Record<string, ComposerDra
     operation = "decode";
     return decodePersistedComposerDrafts(JSON.parse(raw) as unknown);
   } catch (cause) {
-    console.warn(
-      "[composer-drafts] ignored persisted draft failure",
-      new ComposerDraftPersistenceError({
-        operation,
-        directory: COMPOSER_DRAFTS_DIRECTORY,
-        fileName: COMPOSER_DRAFTS_FILE,
-        cause,
-      }),
-    );
-    return {};
+    throw new ComposerDraftPersistenceError({
+      operation,
+      directory: COMPOSER_DRAFTS_DIRECTORY,
+      fileName: COMPOSER_DRAFTS_FILE,
+      cause,
+    });
   }
 }
 
@@ -200,42 +207,61 @@ async function writePersistedComposerDrafts(drafts: Record<string, ComposerDraft
   }
 }
 
-async function savePersistedComposerDrafts(drafts: Record<string, ComposerDraft>): Promise<void> {
-  try {
-    await persistenceQueue.run(() => writePersistedComposerDrafts(drafts));
-  } catch (error) {
-    console.warn("[composer-drafts] failed to persist drafts", error);
-    // Draft persistence is best-effort; in-memory drafts still keep working.
-  }
-}
-
 /**
  * Lands any debounced or in-flight draft write before the JS runtime is torn
  * down (app update restart), so the freshest draft state survives it. A write
  * failure propagates so the caller can decide whether the restart may proceed.
  */
 export async function flushComposerDrafts(): Promise<void> {
+  // Never land a pre-hydration snapshot: persisted state must merge into the
+  // atoms first, or this write would clobber disk with partial data.
+  ensureComposerDraftsLoaded();
+  if (loadPromise !== null) {
+    await loadPromise;
+  }
   // An edit during an awaited write schedules another debounced write, so
   // keep landing snapshots until no debounce is pending after a queue drain.
   do {
-    while (persistTimer !== null) {
-      clearTimeout(persistTimer);
+    while (persistTimer !== null || persistRetryNeeded) {
+      if (persistTimer !== null) clearTimeout(persistTimer);
       persistTimer = null;
-      await persistenceQueue.run(() =>
-        writePersistedComposerDrafts(appAtomRegistry.get(composerDraftsAtom)),
-      );
+      persistRetryNeeded = false;
+      try {
+        await persistenceQueue.run(() =>
+          writePersistedComposerDrafts(appAtomRegistry.get(composerDraftsAtom)),
+        );
+      } catch (error) {
+        persistRetryNeeded = true;
+        throw error;
+      }
     }
+    // Draining also waits for an already-fired debounce whose write is still
+    // gated behind its own hydration await inside the queue.
     await persistenceQueue.run(() => Promise.resolve());
-  } while (persistTimer !== null);
+  } while (persistTimer !== null || persistRetryNeeded);
 }
 
-function schedulePersistComposerDrafts(drafts: Record<string, ComposerDraft>): void {
+function schedulePersistComposerDrafts(): void {
   if (persistTimer !== null) {
     clearTimeout(persistTimer);
   }
   persistTimer = setTimeout(() => {
     persistTimer = null;
-    void savePersistedComposerDrafts(drafts);
+    // The write enters the serialization queue before waiting on hydration,
+    // so flushComposerDrafts' queue drain cannot resolve ahead of it.
+    void persistenceQueue.run(async () => {
+      try {
+        await waitForComposerDraftsLoaded();
+        await writePersistedComposerDrafts(appAtomRegistry.get(composerDraftsAtom));
+        persistRetryNeeded = false;
+      } catch (error) {
+        // A failed debounce has no timer left. A later final flush must retry
+        // these edits after persisted ownership can be read safely.
+        persistRetryNeeded = true;
+        console.warn("[composer-drafts] failed to persist drafts", error);
+        // Draft persistence is best-effort; in-memory drafts still keep working.
+      }
+    });
   }, PERSIST_DEBOUNCE_MS);
 }
 
@@ -243,29 +269,41 @@ export function ensureComposerDraftsLoaded(): void {
   if (loadPromise !== null) {
     return;
   }
-  loadPromise = loadPersistedComposerDrafts()
-    .then((persistedDrafts) => {
-      if (Object.keys(persistedDrafts).length === 0) {
-        return;
-      }
-      const current = appAtomRegistry.get(composerDraftsAtom);
-      appAtomRegistry.set(composerDraftsAtom, {
-        ...persistedDrafts,
-        ...current,
-      });
-    })
-    .catch((cause) => {
-      console.warn(
-        "[composer-drafts] failed to hydrate drafts",
-        new ComposerDraftPersistenceError({
-          operation: "hydrate",
-          directory: COMPOSER_DRAFTS_DIRECTORY,
-          fileName: COMPOSER_DRAFTS_FILE,
-          cause,
-        }),
-      );
-      // Draft loading is best-effort; in-memory drafts still keep working.
+  const loading = loadPersistedComposerDrafts().then((persistedDrafts) => {
+    if (Object.keys(persistedDrafts).length === 0) {
+      return;
+    }
+    const current = appAtomRegistry.get(composerDraftsAtom);
+    appAtomRegistry.set(composerDraftsAtom, {
+      ...persistedDrafts,
+      ...current,
     });
+  });
+  loadPromise = loading;
+  // Handle fire-and-forget hook loads without swallowing failures from the
+  // write and cleanup callers that await this same promise. A later call retries.
+  void loading.catch((cause) => {
+    if (loadPromise === loading) loadPromise = null;
+    console.warn(
+      "[composer-drafts] failed to hydrate drafts",
+      cause instanceof ComposerDraftPersistenceError
+        ? cause
+        : new ComposerDraftPersistenceError({
+            operation: "hydrate",
+            directory: COMPOSER_DRAFTS_DIRECTORY,
+            fileName: COMPOSER_DRAFTS_FILE,
+            cause,
+          }),
+    );
+  });
+}
+
+/** Wait until persisted drafts have been merged into the in-memory composer state. */
+export async function waitForComposerDraftsLoaded(): Promise<void> {
+  ensureComposerDraftsLoaded();
+  if (loadPromise !== null) {
+    await loadPromise;
+  }
 }
 
 function updateComposerDrafts(
@@ -277,7 +315,7 @@ function updateComposerDrafts(
     return;
   }
   appAtomRegistry.set(composerDraftsAtom, next);
-  schedulePersistComposerDrafts(next);
+  schedulePersistComposerDrafts();
 }
 
 export function setComposerDraftText(draftKey: string, value: string): void {
@@ -470,10 +508,7 @@ export async function copyComposerDraftContentIfEmpty(
   sourceDraftKey: string,
   targetDraftKey: string,
 ): Promise<void> {
-  ensureComposerDraftsLoaded();
-  if (loadPromise !== null) {
-    await loadPromise;
-  }
+  await waitForComposerDraftsLoaded();
   updateComposerDrafts((current) =>
     copyComposerDraftContentState(current, sourceDraftKey, targetDraftKey),
   );
@@ -545,10 +580,7 @@ export async function mergeComposerDraftContent(
   draftKey: string,
   content: ComposerDraftContent,
 ): Promise<{ readonly skippedAttachmentCount: number }> {
-  ensureComposerDraftsLoaded();
-  if (loadPromise !== null) {
-    await loadPromise;
-  }
+  await waitForComposerDraftsLoaded();
   if (persistTimer !== null) {
     clearTimeout(persistTimer);
     persistTimer = null;
@@ -580,10 +612,7 @@ export async function restoreComposerDraftSnapshot(
   draftKey: string,
   snapshot: ComposerDraft,
 ): Promise<void> {
-  ensureComposerDraftsLoaded();
-  if (loadPromise !== null) {
-    await loadPromise;
-  }
+  await waitForComposerDraftsLoaded();
   if (persistTimer !== null) {
     clearTimeout(persistTimer);
     persistTimer = null;
@@ -630,10 +659,7 @@ export function removeComposerDraftsForEnvironment(
 }
 
 export async function clearComposerDraftsEnvironment(environmentId: EnvironmentId): Promise<void> {
-  ensureComposerDraftsLoaded();
-  if (loadPromise !== null) {
-    await loadPromise;
-  }
+  await waitForComposerDraftsLoaded();
 
   const next = removeComposerDraftsForEnvironment(
     appAtomRegistry.get(composerDraftsAtom),

--- a/apps/mobile/src/state/use-thread-outbox-drain.ts
+++ b/apps/mobile/src/state/use-thread-outbox-drain.ts
@@ -283,6 +283,7 @@ export function useThreadOutboxDrain(): void {
   );
 
   useEffect(() => {
+    ensureThreadOutboxLoaded();
     if (dispatchingQueuedMessageId !== null) {
       return;
     }

--- a/docs/internals/connection-runtime.md
+++ b/docs/internals/connection-runtime.md
@@ -133,6 +133,11 @@ Platform layers adapt operating-system capabilities. They do not implement
 connection policy. `EnvironmentOwnedDataCleanup` is part of this contract: on
 removal the registry clears its cache and calls the platform implementation, so
 web clears composer drafts and mobile clears drafts plus the thread outbox.
+Mobile draft and outbox loads fail closed: a read or decode error does not look
+like an empty store, and environment cleanup stops if the outbox cannot be read.
+Queued delivery retries tagged transport failures (`RpcClientError`, disconnected
+or unregistered environments) and only restores a pending task after a server
+command or authorization rejection.
 
 ## Source Boundaries
 

--- a/docs/internals/connection-runtime.md
+++ b/docs/internals/connection-runtime.md
@@ -133,8 +133,10 @@ Platform layers adapt operating-system capabilities. They do not implement
 connection policy. `EnvironmentOwnedDataCleanup` is part of this contract: on
 removal the registry clears its cache and calls the platform implementation, so
 web clears composer drafts and mobile clears drafts plus the thread outbox.
-Mobile draft and outbox loads fail closed: a read or decode error does not look
-like an empty store, and environment cleanup stops if the outbox cannot be read.
+Mobile draft loads fail closed: a read or decode error does not look like an
+empty store. Outbox hydration publishes readable queued messages and leaves
+unreadable files on disk with diagnostics. Environment cleanup still stops if
+any outbox record cannot be read, so unread attachment owners are not deleted.
 Queued delivery retries tagged transport failures (`RpcClientError`, disconnected
 or unregistered environments) and only restores a pending task after a server
 command or authorization rejection.

--- a/docs/user/composer.md
+++ b/docs/user/composer.md
@@ -3,9 +3,11 @@
 Messages can contain up to 120,000 characters. Akeru keeps an oversized draft in the composer and
 shows how many characters you must remove. Shorten the draft or send it as several messages.
 
-On mobile, unsent drafts and queued messages stay on the device. If Akeru cannot read that store, it
-leaves the saved work in place instead of treating it as empty. A send that fails because the
-connection dropped stays queued and retries when the environment is reachable again.
+On mobile, unsent drafts and queued messages stay on the device. If Akeru cannot read a draft store,
+it leaves the saved work in place instead of treating it as empty. Readable queued messages still
+send after reconnect. An unreadable queued-message file stays on the device until it can be read. A
+send that fails because the connection dropped stays queued and retries when the environment is
+reachable again.
 
 ## Attach images
 

--- a/docs/user/composer.md
+++ b/docs/user/composer.md
@@ -3,6 +3,10 @@
 Messages can contain up to 120,000 characters. Akeru keeps an oversized draft in the composer and
 shows how many characters you must remove. Shorten the draft or send it as several messages.
 
+On mobile, unsent drafts and queued messages stay on the device. If Akeru cannot read that store, it
+leaves the saved work in place instead of treating it as empty. A send that fails because the
+connection dropped stays queued and retries when the environment is reachable again.
+
 ## Attach images
 
 On servers with direct uploads, an image starts uploading when you add it. Akeru enables **Send**


### PR DESCRIPTION
## Problem

A failed mobile draft read could look like an empty store. The next save could overwrite saved work. An unreadable outbox record previously rejected the whole queue, so valid queued messages never reached delivery after restart. A send that failed in flight after reconnect was treated as a deterministic rejection because `SocketReadError` only says `"An error occurred during Read"`. The drain then restored the queued text into a draft and deleted the outbox entry.

## Changes

Draft saves now require successful hydration. Final flush retries pending edits after a successful read.

Outbox load returns readable queued messages and leaves unreadable files on disk with diagnostics. Hydration publishes those readable messages so they can send after reconnect. Environment cleanup still stops if any outbox record cannot be read, so unread attachment owners are not deleted.

Queued delivery classifies failures by error tag first:

- Restore (payload is bad): `OrchestrationDispatchCommandError`, `EnvironmentAuthorizationError`
- Retry (transport): `ConnectionTransientError`, `RpcClientError` (any socket reason or protocol defect), `EnvironmentRpcUnavailableError`, `EnvironmentNotRegisteredError`

Untagged errors still fall back to the message matcher.

## Adaptation

Reviewed ports of [T3 Code #9710](https://github.com/pingdotgg/t3code/pull/9710) and [T3 Code #10245](https://github.com/pingdotgg/t3code/pull/10245). Akeru has no hosted cloud draft archive or file-backed attachment cleanup yet, so this keeps local draft fail-closed behavior and tagged retry classification. Outbox hydration recovers readable records instead of blocking the whole queue on one unread file.

## Scope

Mobile draft persistence, thread outbox load/cleanup, and send-failure classification. No web UI, native modules, providers, or contracts.

## Verification

- `vp test run apps/mobile/src/state/use-composer-drafts.test.ts apps/mobile/src/state/thread-outbox.test.ts` — 45 passed (28 outbox), including mixed valid/corrupt files through expo storage plus the drain/pending-task atom, cleanup that still stops on unread records, draft read/decode preservation, flush retry, and tagged transport retries
- `vp lint` on the touched files — 0 warnings, 0 errors
- `vp run --filter @t3tools/mobile typecheck` — passed

This is persistence and classification logic. No rendered web or desktop UI change. Native Android/iOS device runs are blocked on this Linux host: no `adb`, Android SDK, or Xcode. Unit tests use temporary-file mocks and cover the real-source failure cases.

## Limitations

- Unreadable outbox files stay on disk until they can be decoded. Cleanup will not remove an environment while any of those files remain unreadable.
- Multiple new-task drafts, queued timeline rows, composer uploads, and native dictation are separate PRs.

Created with Grok 4.6 High in Grok Build via Orca.
