### PR TITLE
fix(web): stop highlighter freezes by using Oniguruma WASM

### DIFF
--- a/apps/web/src/components/DiffPanel.tsx
+++ b/apps/web/src/components/DiffPanel.tsx
@@ -37,6 +37,7 @@ import {
   resolveDiffThemeName,
   resolveFileDiffPath,
 } from "../lib/diffRendering";
+import { PREFERRED_HIGHLIGHTER } from "../lib/syntaxHighlighting";
 import { areAllDiffFilesCollapsed, toggleAllDiffFiles } from "../lib/diffCollapse";
 import { useTurnDiffSummaries } from "../hooks/useTurnDiffSummaries";
 import { useProject, useThread } from "../state/entities";
@@ -960,6 +961,7 @@ export default function DiffPanel({
                     lineDiffType: "none",
                     overflow: wordWrap ? "wrap" : "scroll",
                     theme: resolveDiffThemeName(resolvedTheme),
+                    preferredHighlighter: PREFERRED_HIGHLIGHTER,
                     themeType: resolvedTheme as DiffThemeType,
                     stickyHeaders: true,
                     ...(loadDiffFiles ? { loadDiffFiles } : {}),

--- a/apps/web/src/components/DiffWorkerPoolProvider.tsx
+++ b/apps/web/src/components/DiffWorkerPoolProvider.tsx
@@ -4,6 +4,7 @@ import * as Schema from "effect/Schema";
 import { useEffect, useMemo, type ReactNode } from "react";
 import { useTheme } from "../hooks/useTheme";
 import { resolveDiffThemeName, type DiffThemeName } from "../lib/diffRendering";
+import { PREFERRED_HIGHLIGHTER } from "../lib/syntaxHighlighting";
 
 export class DiffWorkerError extends Schema.TaggedErrorClass<DiffWorkerError>()("DiffWorkerError", {
   operation: Schema.Literals(["create-worker", "get-render-options", "set-render-options"]),
@@ -73,6 +74,7 @@ export function DiffWorkerPoolProvider({ children }: { children?: ReactNode }) {
       }}
       highlighterOptions={{
         theme: diffThemeName,
+        preferredHighlighter: PREFERRED_HIGHLIGHTER,
         tokenizeMaxLineLength: 1_000,
         useTokenTransformer: true,
       }}

--- a/apps/web/src/components/chat/MessagesTimeline.tsx
+++ b/apps/web/src/components/chat/MessagesTimeline.tsx
@@ -44,6 +44,7 @@ import {
   resolveDiffThemeName,
   resolveFileDiffPath,
 } from "../../lib/diffRendering";
+import { PREFERRED_HIGHLIGHTER } from "../../lib/syntaxHighlighting";
 import ChatMarkdown from "../ChatMarkdown";
 import {
   BotIcon,
@@ -2110,6 +2111,7 @@ function UserMessageReviewCommentCard({ comment }: { comment: ReviewCommentConte
               collapsed: false,
               diffStyle: "unified",
               theme: resolveDiffThemeName(ctx.resolvedTheme),
+              preferredHighlighter: PREFERRED_HIGHLIGHTER,
             }}
           />
         ))}

--- a/apps/web/src/components/files/FilePreviewPanel.tsx
+++ b/apps/web/src/components/files/FilePreviewPanel.tsx
@@ -25,6 +25,7 @@ import { useClientSettings } from "~/hooks/useSettings";
 import { useTheme } from "~/hooks/useTheme";
 import { getLocalStorageItem, setLocalStorageItem, useLocalStorage } from "~/hooks/useLocalStorage";
 import { DIFF_SURFACE_THEME_UNSAFE_CSS, resolveDiffThemeName } from "~/lib/diffRendering";
+import { PREFERRED_HIGHLIGHTER } from "~/lib/syntaxHighlighting";
 import { cn } from "~/lib/utils";
 import { isPreviewSupportedInRuntime } from "~/previewStateStore";
 import { resolvePathLinkTarget } from "~/terminal-links";
@@ -670,6 +671,7 @@ function EditableFileSurface({
               onLineSelectionEnd: handleLineSelectionEnd,
               overflow: wordWrap ? "wrap" : "scroll",
               theme: resolveDiffThemeName(resolvedTheme),
+              preferredHighlighter: PREFERRED_HIGHLIGHTER,
               themeType: resolvedTheme,
               unsafeCSS: FILE_LINK_REVEAL_UNSAFE_CSS,
               onPostRender: handlePostRender,
@@ -1039,6 +1041,7 @@ export default function FilePreviewPanel({
                     disableFileHeader: true,
                     overflow: wordWrap ? "wrap" : "scroll",
                     theme: resolveDiffThemeName(resolvedTheme),
+                    preferredHighlighter: PREFERRED_HIGHLIGHTER,
                     themeType: resolvedTheme,
                     unsafeCSS: FILE_LINK_REVEAL_UNSAFE_CSS,
                     onPostRender: onFilePostRender,

--- a/apps/web/src/components/settings/SettingsFontPreviews.tsx
+++ b/apps/web/src/components/settings/SettingsFontPreviews.tsx
@@ -5,6 +5,7 @@ import { terminalThemeFromApp } from "../ThreadTerminalDrawer";
 import { useTheme } from "../../hooks/useTheme";
 import { DISCONNECTED_COMPOSER_PLACEHOLDER } from "../../composerPlaceholder";
 import { resolveDiffThemeName, type DiffThemeName } from "../../lib/diffRendering";
+import { PREFERRED_HIGHLIGHTER } from "../../lib/syntaxHighlighting";
 import { GhosttyTerminalSurface } from "~/terminal/ghostty/surface";
 
 // The font previews are the real surfaces, not lookalikes: the composer's
@@ -79,7 +80,7 @@ function loadDiffPreviewHtml(theme: DiffThemeName): Promise<readonly string[]> {
   if (promise === undefined) {
     promise = preloadPatchFile({
       patch: DIFF_PREVIEW_PATCH,
-      options: { diffStyle: "unified", theme },
+      options: { diffStyle: "unified", theme, preferredHighlighter: PREFERRED_HIGHLIGHTER },
     }).then((results) => results.map((result) => result.prerenderedHTML));
     diffPreviewHtmlByTheme.set(theme, promise);
   }

--- a/apps/web/src/lib/syntaxHighlighting.test.ts
+++ b/apps/web/src/lib/syntaxHighlighting.test.ts
@@ -9,7 +9,11 @@ vi.mock("@pierre/diffs", () => ({
   getSharedHighlighter,
 }));
 
-import { getSyntaxHighlighterPromise } from "./syntaxHighlighting";
+import { getSyntaxHighlighterPromise, PREFERRED_HIGHLIGHTER } from "./syntaxHighlighting";
+
+it("prefers the Oniguruma WASM highlighter", () => {
+  expect(PREFERRED_HIGHLIGHTER).toBe("shiki-wasm");
+});
 
 it("caches the recovered text highlighter for unsupported languages", async () => {
   const textHighlighter = {} as DiffsHighlighter;
@@ -25,4 +29,7 @@ it("caches the recovered text highlighter for unsupported languages", async () =
 
   expect(second).toBe(first);
   expect(getSharedHighlighter).toHaveBeenCalledTimes(2);
+  expect(getSharedHighlighter).toHaveBeenCalledWith(
+    expect.objectContaining({ preferredHighlighter: "shiki-wasm" }),
+  );
 });

--- a/apps/web/src/lib/syntaxHighlighting.ts
+++ b/apps/web/src/lib/syntaxHighlighting.ts
@@ -1,10 +1,19 @@
 import {
   getSharedHighlighter,
   type DiffsHighlighter,
+  type HighlighterTypes,
   type SupportedLanguages,
 } from "@pierre/diffs";
 
 import { resolveDiffThemeName } from "./diffRendering";
+
+/**
+ * Always highlight with the Oniguruma WASM engine. The JS regex engine can
+ * backtrack catastrophically and hang the tokenizing thread. The shared
+ * highlighter is a first-caller-wins singleton, so every creation site must
+ * pass this value.
+ */
+export const PREFERRED_HIGHLIGHTER: HighlighterTypes = "shiki-wasm";
 
 const highlighterPromiseCache = new Map<string, Promise<DiffsHighlighter>>();
 
@@ -15,7 +24,7 @@ export function getSyntaxHighlighterPromise(language: string): Promise<DiffsHigh
   const promise = getSharedHighlighter({
     themes: [resolveDiffThemeName("dark"), resolveDiffThemeName("light")],
     langs: [language as SupportedLanguages],
-    preferredHighlighter: "shiki-js",
+    preferredHighlighter: PREFERRED_HIGHLIGHTER,
   }).catch((error) => {
     if (language === "text") {
       highlighterPromiseCache.delete(language);


### PR DESCRIPTION
## What Changed

Chat markdown, search, shell commands, Settings font previews, and remaining Pierre file/diff option sites now create the shared highlighter with `shiki-wasm` (Oniguruma) instead of `shiki-js`.

The shared highlighter is first-caller-wins, so every creation site has to agree. Akeru has no pull-request code tab, and `MessagesTimeline` / `DiffPanel` / `FilePreviewPanel` are retained but not on the live bot/group routes. Those retained option objects still receive the same engine so they cannot steal the singleton later.

## Why

Shiki's JavaScript regex engine can backtrack forever on ordinary source lines. One match pins the renderer until the tab is force-quit. WASM Oniguruma tokenizes the same input without hanging.

Adapted from [pingdotgg/t3code#8360](https://github.com/pingdotgg/t3code/pull/8360). Credit to that work and to #3885 for the worker-pool approach.

## UI Changes

No intended visual change. Same grammars and themes. Isolated browser check: Scout bot chat still renders at 1440 and 390, Settings Appearance font previews still highlight the code-font sample, and Providers still lists ChatGPT, Claude, Grok, Kimi For Coding, and OpenCode Go.

This fixture home had no group chat, so group-route markdown highlighting was not exercised here. The renderer is the same `ChatMarkdown` path.

## Checklist

- [x] This PR is small and focused
- [x] I explained what changed and why
- [x] I linked the accepted plugin or provider proposal in **Why**, or this PR does not add one
- [x] I included before/after screenshots for any UI changes
- [ ] I included a video for animation/interaction changes

## Scope

- Does not resurrect ChatView.
- Does not change provider adapters.
- Does not upgrade Pierre or Shiki.

## Verification

- `vp test run apps/web/src/lib/syntaxHighlighting.test.ts` passed
- `vp lint` and `vp fmt` on the touched files passed
- `vp run --filter @t3tools/web typecheck` passed
- Isolated `vp run dev --home-dir` fixture, paired browser: bot chat, Settings Appearance including the highlighted code-font preview, Providers list

## Limitations

The catastrophic Go-comment hang from upstream #8356 was not reproduced here. The tests prove the engine selection. Desktop Electron and native mobile were not run.

Implemented and verified by Grok 4.6 High in Grok Build via Orca.
