### PR TITLE
fix(web): keep settings inputs focused during IME composition

### DIFF
--- a/apps/web/src/hooks/useCommitOnBlur.test.ts
+++ b/apps/web/src/hooks/useCommitOnBlur.test.ts
@@ -1,0 +1,30 @@
+import { describe, expect, it } from "vite-plus/test";
+
+import { shouldBlurCommitOnKeyDown } from "./useCommitOnBlur";
+
+function keyEvent(overrides: {
+  key?: string;
+  keyCode?: number;
+  isComposing?: boolean;
+}): Parameters<typeof shouldBlurCommitOnKeyDown>[0] {
+  return {
+    key: overrides.key ?? "Enter",
+    keyCode: overrides.keyCode ?? 13,
+    nativeEvent: { isComposing: overrides.isComposing ?? false } as KeyboardEvent["nativeEvent"],
+  };
+}
+
+describe("shouldBlurCommitOnKeyDown", () => {
+  it("commits on Enter after composition has finished", () => {
+    expect(shouldBlurCommitOnKeyDown(keyEvent({ key: "Enter" }))).toBe(true);
+  });
+
+  it("keeps focus during IME composition", () => {
+    expect(shouldBlurCommitOnKeyDown(keyEvent({ key: "Enter", isComposing: true }))).toBe(false);
+    expect(shouldBlurCommitOnKeyDown(keyEvent({ key: "Enter", keyCode: 229 }))).toBe(false);
+  });
+
+  it("ignores other keys", () => {
+    expect(shouldBlurCommitOnKeyDown(keyEvent({ key: "Escape" }))).toBe(false);
+  });
+});

--- a/apps/web/src/hooks/useCommitOnBlur.test.ts
+++ b/apps/web/src/hooks/useCommitOnBlur.test.ts
@@ -10,7 +10,7 @@ function keyEvent(overrides: {
   return {
     key: overrides.key ?? "Enter",
     keyCode: overrides.keyCode ?? 13,
-    nativeEvent: { isComposing: overrides.isComposing ?? false } as KeyboardEvent["nativeEvent"],
+    nativeEvent: { isComposing: overrides.isComposing ?? false },
   };
 }
 

--- a/apps/web/src/hooks/useCommitOnBlur.ts
+++ b/apps/web/src/hooks/useCommitOnBlur.ts
@@ -15,6 +15,13 @@ import { type ChangeEvent, type KeyboardEvent, useState } from "react";
  *   const bag = useCommitOnBlur(instance.displayName ?? "", (next) => {...});
  *   <Input {...bag} placeholder="e.g. Work" />
  */
+export function shouldBlurCommitOnKeyDown(
+  event: Pick<KeyboardEvent<HTMLInputElement>, "key" | "keyCode" | "nativeEvent">,
+): boolean {
+  if (event.nativeEvent.isComposing || event.keyCode === 229) return false;
+  return event.key === "Enter";
+}
+
 export function useCommitOnBlur(value: string, onCommit: (next: string) => void) {
   const [draft, setDraft] = useState<string | null>(null);
 
@@ -34,10 +41,9 @@ export function useCommitOnBlur(value: string, onCommit: (next: string) => void)
       }
     },
     onKeyDown: (event: KeyboardEvent<HTMLInputElement>) => {
-      if (event.key === "Enter") {
-        event.preventDefault();
-        (event.target as HTMLInputElement).blur();
-      }
+      if (!shouldBlurCommitOnKeyDown(event)) return;
+      event.preventDefault();
+      (event.target as HTMLInputElement).blur();
     },
   };
 }

--- a/apps/web/src/hooks/useCommitOnBlur.ts
+++ b/apps/web/src/hooks/useCommitOnBlur.ts
@@ -15,9 +15,11 @@ import { type ChangeEvent, type KeyboardEvent, useState } from "react";
  *   const bag = useCommitOnBlur(instance.displayName ?? "", (next) => {...});
  *   <Input {...bag} placeholder="e.g. Work" />
  */
-export function shouldBlurCommitOnKeyDown(
-  event: Pick<KeyboardEvent<HTMLInputElement>, "key" | "keyCode" | "nativeEvent">,
-): boolean {
+export function shouldBlurCommitOnKeyDown(event: {
+  readonly key: string;
+  readonly keyCode: number;
+  readonly nativeEvent: { readonly isComposing?: boolean };
+}): boolean {
   if (event.nativeEvent.isComposing || event.keyCode === 229) return false;
   return event.key === "Enter";
 }


### PR DESCRIPTION
## What Changed

`useCommitOnBlur` no longer treats Enter as commit while an IME is composing (`isComposing` or keyCode 229). Settings `DraftInput` fields keep focus until composition finishes.

## Why

Confirming a CJK candidate with Enter was also submitting the half-composed value and stealing focus. BotPromptComposer already ignored composing Enter. Settings inputs did not.

Adapted from [pingdotgg/t3code#10262](https://github.com/pingdotgg/t3code/pull/10262).

## UI Changes

No layout change. Callers: Settings provider instance names, portability paths, and other `DraftInput` fields.

## Checklist

- [x] This PR is small and focused
- [x] I explained what changed and why
- [x] I linked the accepted plugin or provider proposal in **Why**, or this PR does not add one
- [ ] I included before/after screenshots for any UI changes
- [ ] I included a video for animation/interaction changes

## Verification

- `vp test run apps/web/src/hooks/useCommitOnBlur.test.ts`
- targeted lint/format
- Settings opened on the isolated fixture. A real IME session was not available in this headless browser.

Implemented and verified by Grok 4.6 High in Grok Build via Orca.
