### PR TITLE
feat(web): add provider model bulk visibility toggle

### DIFF
--- a/apps/web/src/components/settings/ProviderModelsSection.test.ts
+++ b/apps/web/src/components/settings/ProviderModelsSection.test.ts
@@ -1,7 +1,24 @@
-import { describe, expect, it } from "vite-plus/test";
-import type { ServerProviderModel } from "@t3tools/contracts";
+import { createElement, type ReactNode } from "react";
+import { renderToStaticMarkup } from "react-dom/server";
+import { describe, expect, it, vi } from "vite-plus/test";
+import {
+  ProviderDriverKind,
+  ProviderInstanceId,
+  type ServerProviderModel,
+} from "@t3tools/contracts";
 
-import { nextHiddenModelsForBulkToggle } from "./ProviderModelsSection";
+const mocks = vi.hoisted(() => ({
+  buttons: new Map<string, { onClick?: () => void }>(),
+}));
+
+vi.mock("../ui/button", () => ({
+  Button: (props: { children: ReactNode; onClick?: () => void }) => {
+    if (typeof props.children === "string") mocks.buttons.set(props.children, props);
+    return null;
+  },
+}));
+
+import { nextHiddenModelsForBulkToggle, ProviderModelsSection } from "./ProviderModelsSection";
 
 function model(slug: string, isCustom = false): ServerProviderModel {
   return { slug, name: slug, isCustom, capabilities: null };
@@ -28,5 +45,60 @@ describe("nextHiddenModelsForBulkToggle", () => {
     const next = nextHiddenModelsForBulkToggle(models, []);
     expect(next).toEqual(["codex", "gpt-5"]);
     expect(next).not.toContain("custom");
+  });
+});
+
+describe("ProviderModelsSection bulk visibility control", () => {
+  function renderSection(input: {
+    models: ReadonlyArray<ServerProviderModel>;
+    hiddenModels?: ReadonlyArray<string>;
+  }) {
+    mocks.buttons.clear();
+    const onHiddenModelsChange = vi.fn();
+    renderToStaticMarkup(
+      createElement(ProviderModelsSection, {
+        instanceId: ProviderInstanceId.make("codex"),
+        driverKind: ProviderDriverKind.make("codex"),
+        models: input.models,
+        customModels: input.models.filter((entry) => entry.isCustom).map((entry) => entry.slug),
+        hiddenModels: input.hiddenModels ?? [],
+        favoriteModels: [],
+        modelOrder: [],
+        onChange: vi.fn(),
+        onHiddenModelsChange,
+        onFavoriteModelsChange: vi.fn(),
+        onModelOrderChange: vi.fn(),
+      }),
+    );
+    return { onHiddenModelsChange };
+  }
+
+  it("omits the bulk control when every model is custom", () => {
+    renderSection({ models: [model("custom", true)] });
+
+    expect(mocks.buttons.has("Disable all")).toBe(false);
+    expect(mocks.buttons.has("Enable all")).toBe(false);
+  });
+
+  it("disables every built-in model from the visible control", () => {
+    const { onHiddenModelsChange } = renderSection({
+      models: [model("a"), model("b"), model("custom", true)],
+      hiddenModels: ["a"],
+    });
+
+    expect(mocks.buttons.has("Enable all")).toBe(false);
+    mocks.buttons.get("Disable all")?.onClick?.();
+    expect(onHiddenModelsChange).toHaveBeenCalledWith(["a", "b"]);
+  });
+
+  it("enables built-in models without clearing leftover hidden entries", () => {
+    const { onHiddenModelsChange } = renderSection({
+      models: [model("a"), model("b"), model("custom", true)],
+      hiddenModels: ["a", "b", "legacy", "custom"],
+    });
+
+    expect(mocks.buttons.has("Disable all")).toBe(false);
+    mocks.buttons.get("Enable all")?.onClick?.();
+    expect(onHiddenModelsChange).toHaveBeenCalledWith(["legacy", "custom"]);
   });
 });

--- a/apps/web/src/components/settings/ProviderModelsSection.test.ts
+++ b/apps/web/src/components/settings/ProviderModelsSection.test.ts
@@ -1,0 +1,32 @@
+import { describe, expect, it } from "vite-plus/test";
+import type { ServerProviderModel } from "@t3tools/contracts";
+
+import { nextHiddenModelsForBulkToggle } from "./ProviderModelsSection";
+
+function model(slug: string, isCustom = false): ServerProviderModel {
+  return { slug, name: slug, isCustom, capabilities: null };
+}
+
+describe("nextHiddenModelsForBulkToggle", () => {
+  it("hides every built-in model without hiding custom models", () => {
+    const models = [model("a"), model("b"), model("custom", true)];
+
+    expect(nextHiddenModelsForBulkToggle(models, ["a"])).toEqual(["a", "b"]);
+  });
+
+  it("shows every built-in model while preserving unrelated hidden entries", () => {
+    const models = [model("a"), model("b"), model("custom", true)];
+
+    expect(nextHiddenModelsForBulkToggle(models, ["a", "b", "legacy", "custom"])).toEqual([
+      "legacy",
+      "custom",
+    ]);
+  });
+
+  it("leaves favorites untouched because they are a separate list", () => {
+    const models = [model("codex"), model("gpt-5"), model("custom", true)];
+    const next = nextHiddenModelsForBulkToggle(models, []);
+    expect(next).toEqual(["codex", "gpt-5"]);
+    expect(next).not.toContain("custom");
+  });
+});

--- a/apps/web/src/components/settings/ProviderModelsSection.tsx
+++ b/apps/web/src/components/settings/ProviderModelsSection.tsx
@@ -75,6 +75,21 @@ interface ProviderModelsSectionProps {
   readonly onModelOrderChange: (next: ReadonlyArray<string>) => void;
 }
 
+export function nextHiddenModelsForBulkToggle(
+  models: ReadonlyArray<Pick<ServerProviderModel, "slug" | "isCustom">>,
+  hiddenModels: ReadonlyArray<string>,
+): string[] {
+  const builtInSlugs = models.filter((model) => !model.isCustom).map((model) => model.slug);
+  const builtInSlugSet = new Set(builtInSlugs);
+  const allBuiltInModelsHidden = builtInSlugs.every((slug) => hiddenModels.includes(slug));
+
+  if (allBuiltInModelsHidden) {
+    return hiddenModels.filter((slug) => !builtInSlugSet.has(slug));
+  }
+
+  return [...new Set([...hiddenModels, ...builtInSlugs])];
+}
+
 /**
  * Shared "Models" section rendered on both the built-in default and custom
  * provider-instance cards. Owns its own input + error local state so two
@@ -111,6 +126,9 @@ export function ProviderModelsSection({
       modelOrder,
     });
   }, [favoriteModelSet, modelOrder, models]);
+  const builtInModels = useMemo(() => models.filter((model) => !model.isCustom), [models]);
+  const allBuiltInModelsHidden =
+    builtInModels.length > 0 && builtInModels.every((model) => hiddenModelSet.has(model.slug));
 
   const handleAdd = () => {
     const normalized = normalizeCustomModelSlug(input);
@@ -188,7 +206,21 @@ export function ProviderModelsSection({
 
   return (
     <div>
-      <div className="text-xs font-medium text-foreground">Models</div>
+      <div className="flex items-center justify-between gap-2">
+        <div className="text-xs font-medium text-foreground">Models</div>
+        {builtInModels.length > 0 ? (
+          <Button
+            type="button"
+            size="xs"
+            variant="ghost-muted"
+            onClick={() =>
+              onHiddenModelsChange(nextHiddenModelsForBulkToggle(models, hiddenModels))
+            }
+          >
+            {allBuiltInModelsHidden ? "Enable all" : "Disable all"}
+          </Button>
+        ) : null}
+      </div>
       <div className="mt-1 text-xs text-muted-foreground">
         {models.length} model{models.length === 1 ? "" : "s"} available.
       </div>


### PR DESCRIPTION
## Problem

A provider with many built-in models requires hiding or showing each model individually.

## Changes

The Models header on each provider instance card now offers **Disable all** or **Enable all** when built-in models are available. The action changes only built-in slugs in `hiddenModels`: custom models remain visible, favorites remain separate, and unrelated hidden entries are preserved when enabling.

Adapted from [pingdotgg/t3code#10947](https://github.com/pingdotgg/t3code/pull/10947).

## Verification

- `vp test run apps/web/src/components/settings/ProviderModelsSection.test.ts`: 6 passed, including rendered visibility, labels, and click behavior.
- Web typecheck passed.
- Scoped lint, formatting, and `git diff --check` passed.

The earlier failed repository check was a Vite+ package-cache timeout before code checks began. This push rebases the change on current `main` and triggers a fresh run.

Implemented and verified by GPT-5.6 Sol in T3 Code via the Codex harness.
