### PR TITLE
fix(server): stop overpricing cached Claude tokens

### DIFF
--- a/apps/server/src/usage/usagePricing.test.ts
+++ b/apps/server/src/usage/usagePricing.test.ts
@@ -1,0 +1,55 @@
+import { describe, expect, it } from "@effect/vitest";
+
+import { lookupRate, normalizeModelName, parseRateTable } from "./usagePricing.ts";
+
+const rate = (input: number, cacheRead?: number) => ({
+  input_cost_per_token: input,
+  output_cost_per_token: input * 5,
+  ...(cacheRead === undefined ? {} : { cache_read_input_token_cost: cacheRead }),
+});
+
+describe("usage pricing", () => {
+  it("keeps the existing model-name normalization contract", () => {
+    expect(normalizeModelName(" Anthropic/Claude-Opus-5 ")).toBe("claude-opus-5");
+  });
+
+  it("keeps the canonical Fable rate separate from DeepInfra in either order", () => {
+    const canonical = ["claude-fable-5", rate(1e-5, 1e-6)] as const;
+    const deepInfra = ["deepinfra/anthropic/claude-fable-5", rate(1e-5)] as const;
+
+    for (const entries of [
+      [canonical, deepInfra],
+      [deepInfra, canonical],
+    ]) {
+      const table = parseRateTable(Object.fromEntries(entries));
+
+      expect(lookupRate(table, "claude-fable-5")?.cacheReadCostPerToken).toBe(1e-6);
+      expect(lookupRate(table, "deepinfra/anthropic/claude-fable-5")?.cacheReadCostPerToken).toBe(
+        1e-5,
+      );
+      expect(lookupRate(table, "other/claude-fable-5")).toBeNull();
+    }
+  });
+
+  it("adds a bare alias when every qualified entry has the same rate", () => {
+    const table = parseRateTable({
+      "provider-a/example-model": rate(1),
+      "provider-b/example-model": rate(1),
+    });
+
+    expect(lookupRate(table, "example-model")).toEqual(
+      lookupRate(table, "provider-a/example-model"),
+    );
+  });
+
+  it("leaves an ambiguous bare name unpriced", () => {
+    const table = parseRateTable({
+      "provider-a/example-model": rate(1),
+      "provider-b/example-model": rate(3),
+    });
+
+    expect(lookupRate(table, "provider-a/example-model")?.inputCostPerToken).toBe(1);
+    expect(lookupRate(table, "provider-b/example-model")?.inputCostPerToken).toBe(3);
+    expect(lookupRate(table, "example-model")).toBeNull();
+  });
+});

--- a/apps/server/src/usage/usagePricing.test.ts
+++ b/apps/server/src/usage/usagePricing.test.ts
@@ -27,7 +27,7 @@ describe("usage pricing", () => {
       expect(lookupRate(table, "deepinfra/anthropic/claude-fable-5")?.cacheReadCostPerToken).toBe(
         1e-5,
       );
-      expect(lookupRate(table, "other/claude-fable-5")).toBeNull();
+      expect(lookupRate(table, "other/claude-fable-5")?.cacheReadCostPerToken).toBe(1e-6);
     }
   });
 
@@ -51,5 +51,14 @@ describe("usage pricing", () => {
     expect(lookupRate(table, "provider-a/example-model")?.inputCostPerToken).toBe(1);
     expect(lookupRate(table, "provider-b/example-model")?.inputCostPerToken).toBe(3);
     expect(lookupRate(table, "example-model")).toBeNull();
+    expect(lookupRate(table, "other/example-model")).toBeNull();
+  });
+
+  it("falls back to a canonical bare rate when the transcript is provider-qualified", () => {
+    const table = parseRateTable({
+      "claude-fable-5": rate(1e-5, 1e-6),
+    });
+
+    expect(lookupRate(table, "anthropic/claude-fable-5")?.cacheReadCostPerToken).toBe(1e-6);
   });
 });

--- a/apps/server/src/usage/usagePricing.ts
+++ b/apps/server/src/usage/usagePricing.ts
@@ -44,6 +44,9 @@ function finiteNumber(value: unknown): number | null {
  * Entries without both an input and an output rate are dropped: a half-priced
  * model would silently under-report cost, which is worse than reporting the
  * model as unpriced.
+ *
+ * Entries keep their full normalized key; a bare name is aliased only when no
+ * canonical entry exists and every qualified entry has the same rate.
  */
 export function parseRateTable(document: unknown): RateTable {
   const table = new Map<string, ModelRate>();
@@ -56,7 +59,9 @@ export function parseRateTable(document: unknown): RateTable {
     const output = finiteNumber(entry.output_cost_per_token);
     if (input === null || output === null) continue;
 
-    table.set(normalizeModelName(name), {
+    const key = normalizeRateKey(name);
+    if (key.length === 0) continue;
+    table.set(key, {
       inputCostPerToken: input,
       outputCostPerToken: output,
       // Anthropic bills cache reads at a discount and cache writes at a
@@ -66,20 +71,52 @@ export function parseRateTable(document: unknown): RateTable {
       cacheCreationCostPerToken: finiteNumber(entry.cache_creation_input_token_cost) ?? input,
     });
   }
+
+  // `null` marks a bare name claimed at conflicting rates: no alias for it.
+  const aliasCandidates = new Map<string, ModelRate | null>();
+  for (const [key, rate] of table) {
+    const alias = bareModelName(key);
+    if (alias.length === 0 || alias === key || table.has(alias)) continue;
+    const held = aliasCandidates.get(alias);
+    if (held === undefined) {
+      aliasCandidates.set(alias, rate);
+    } else if (held !== null && !sameRate(held, rate)) {
+      aliasCandidates.set(alias, null);
+    }
+  }
+  for (const [alias, rate] of aliasCandidates) {
+    if (rate !== null) table.set(alias, rate);
+  }
+
   return table;
+}
+
+function sameRate(a: ModelRate, b: ModelRate): boolean {
+  return (
+    a.inputCostPerToken === b.inputCostPerToken &&
+    a.outputCostPerToken === b.outputCostPerToken &&
+    a.cacheReadCostPerToken === b.cacheReadCostPerToken &&
+    a.cacheCreationCostPerToken === b.cacheCreationCostPerToken
+  );
+}
+
+function normalizeRateKey(model: string): string {
+  return model.trim().toLowerCase();
 }
 
 /**
  * Canonicalises a model name for lookup.
  *
- * Strips a `provider/` prefix (LiteLLM publishes both `claude-opus-5` and
- * `anthropic/claude-opus-5`) and lowercases, since transcripts are inconsistent
- * about casing.
+ * Strips a `provider/` prefix and lowercases, since transcripts are
+ * inconsistent about casing.
  */
 export function normalizeModelName(model: string): string {
-  const trimmed = model.trim().toLowerCase();
-  const slash = trimmed.lastIndexOf("/");
-  return slash === -1 ? trimmed : trimmed.slice(slash + 1);
+  return bareModelName(normalizeRateKey(model));
+}
+
+function bareModelName(key: string): string {
+  const slash = key.lastIndexOf("/");
+  return slash === -1 ? key : key.slice(slash + 1);
 }
 
 /**
@@ -99,9 +136,10 @@ const UNPRICEABLE_MODELS = new Set([
 ]);
 
 export function lookupRate(table: RateTable, model: string): ModelRate | null {
-  const normalized = normalizeModelName(model);
-  if (normalized.length === 0 || UNPRICEABLE_MODELS.has(normalized)) return null;
-  return table.get(normalized) ?? null;
+  const key = normalizeRateKey(model);
+  const bareName = bareModelName(key);
+  if (bareName.length === 0 || UNPRICEABLE_MODELS.has(bareName)) return null;
+  return table.get(key) ?? null;
 }
 
 export interface PricedUsage {

--- a/apps/server/src/usage/usagePricing.ts
+++ b/apps/server/src/usage/usagePricing.ts
@@ -139,7 +139,7 @@ export function lookupRate(table: RateTable, model: string): ModelRate | null {
   const key = normalizeRateKey(model);
   const bareName = bareModelName(key);
   if (bareName.length === 0 || UNPRICEABLE_MODELS.has(bareName)) return null;
-  return table.get(key) ?? null;
+  return table.get(key) ?? table.get(bareName) ?? null;
 }
 
 export interface PricedUsage {

--- a/apps/server/src/usage/usageScanCache.test.ts
+++ b/apps/server/src/usage/usageScanCache.test.ts
@@ -79,7 +79,7 @@ describe("scan cache round trip", () => {
 
   it("rejects the whole cache when an intern table holds a non-string", () => {
     // models: [1] would pass the undefined guard, put a number in a record's
-    // model, and crash normalizeModelName at aggregate time.
+    // model, and crash lookupRate at aggregate time.
     const encoded = encodeScanCache(cacheWith([["/a.jsonl", 100, [record()]]]));
     const poisoned = { ...encoded, models: [1] };
 

--- a/apps/server/src/usage/usageScanCache.ts
+++ b/apps/server/src/usage/usageScanCache.ts
@@ -124,7 +124,7 @@ export function decodeScanCache(document: unknown): ScanCache {
 
   // The intern tables must be all strings: a numeric entry would pass the
   // undefined guard below, land in a record's model, and crash the aggregate
-  // at normalizeModelName. A corrupt table rejects the whole cache.
+  // at lookupRate. A corrupt table rejects the whole cache.
   if (!root.models.every((value) => typeof value === "string")) return cache;
   if (!root.sessions.every((value) => typeof value === "string")) return cache;
   const models = root.models as readonly string[];


### PR DESCRIPTION
## Problem

The Usage page can overprice cached Claude tokens when LiteLLM publishes canonical and provider-qualified entries with the same bare model name. The parser stripped provider prefixes before inserting rates, so a later entry without the Anthropic cache discount could overwrite the canonical rate and price cache reads as ordinary input.

## Fix

Preserve each LiteLLM rate under its full normalized key. Keep canonical bare entries authoritative. Add a bare alias only when every qualified entry has the same effective rate. Leave genuinely conflicting bare names unpriced.

This is an Akeru adaptation of upstream T3 Code work.

## Upstream

- https://github.com/pingdotgg/t3code/pull/8806

## Verification

- `vp test run apps/server/src/usage/usagePricing.test.ts apps/server/src/usage/usageScanCache.test.ts apps/server/src/usage/usageAggregation.test.ts` — 30 passed
- Targeted lint on the four changed files — clean

No UI change. Usage page numbers follow the corrected table.

## Model

Grok 4.6 High in Grok Build via Orca.