### PR TITLE
fix(server): skip disabled provider instances for text generation fallback

### DIFF
--- a/apps/server/src/serverSettings.test.ts
+++ b/apps/server/src/serverSettings.test.ts
@@ -655,6 +655,24 @@ it.layer(NodeServices.layer)("server settings", (it) => {
     }).pipe(Effect.provide(makeServerSettingsLayer())),
   );
 
+  it.effect("skips a disabled provider instance when picking the text generation fallback", () =>
+    Effect.gen(function* () {
+      const serverConfig = yield* ServerConfig.ServerConfig;
+      const fileSystem = yield* FileSystem.FileSystem;
+      const serverSettings = yield* ServerSettingsModule.ServerSettingsService;
+      // The Providers UI writes providerInstances only, so the legacy providers
+      // map decodes to defaults where codex is enabled and listed first.
+      yield* fileSystem.writeFileString(
+        serverConfig.settingsPath,
+        '{"providerInstances":{"codex":{"driver":"codex","enabled":false,"config":{}}}}',
+      );
+
+      const settings = yield* serverSettings.getSettings;
+
+      assert.equal(settings.textGenerationModelSelection.instanceId, "claudeAgent");
+    }).pipe(Effect.provide(makeServerSettingsLayer())),
+  );
+
   it.effect("keeps unused providers disabled in existing sparse settings files", () =>
     Effect.gen(function* () {
       const serverConfig = yield* ServerConfig.ServerConfig;

--- a/apps/server/src/serverSettings.ts
+++ b/apps/server/src/serverSettings.ts
@@ -22,6 +22,7 @@ import {
   type ProviderInstanceEnvironmentVariable,
   ProviderDriverKind,
   ProviderInstanceId,
+  resolveProviderInstanceEnabled,
   type SandboxProviderConnection,
   SANDBOX_PROVIDER_CREDENTIALS,
   ServerSettings,
@@ -351,7 +352,13 @@ function resolveTextGenerationProvider(settings: ServerSettings): ServerSettings
 }
 
 function fallbackTextGenerationProvider(settings: ServerSettings): ServerSettings {
-  const fallbackEntry = Object.entries(settings.providers).find(([, provider]) => provider.enabled);
+  // Same precedence as isModelSelectionProviderEnabled: an explicit provider
+  // instance wins over the legacy providers map, which decodes to defaults
+  // (codex enabled) when the Providers UI has only written providerInstances.
+  const fallbackEntry = Object.entries(settings.providers).find(([driver, provider]) => {
+    const instance = settings.providerInstances[ProviderInstanceId.make(driver)];
+    return instance === undefined ? provider.enabled : resolveProviderInstanceEnabled(instance);
+  });
   const fallback = fallbackEntry ? ProviderDriverKind.make(fallbackEntry[0]) : undefined;
   if (!fallback) {
     return settings;


### PR DESCRIPTION
## Problem

fallbackTextGenerationProvider read only the legacy settings.providers map when the configured text generation selection was disabled. The Providers UI writes providerInstances only, so that map decodes to schema defaults where Codex is enabled and listed first. Disabling Codex in Settings still sent every title, branch name, commit message, and PR request to Codex.

## Fix

The fallback now checks the providerInstances entry for each driver first, with the same precedence isModelSelectionProviderEnabled already uses, and only reads the legacy providers map when there is no instance entry.

This is an Akeru adaptation of upstream T3 Code work. All five providers keep the same fallback order.

## Upstream

- https://github.com/pingdotgg/t3code/pull/10346

## Verification

- `vp test run apps/server/src/serverSettings.test.ts` — 41 passed
- Targeted lint — clean

## Model

Grok 4.6 High in Grok Build via Orca.