### PR TITLE
fix(server): preserve inline provider secrets on redacted saves

### DIFF
--- a/apps/server/src/serverSettings.test.ts
+++ b/apps/server/src/serverSettings.test.ts
@@ -1073,6 +1073,128 @@ it.layer(NodeServices.layer)("server settings", (it) => {
     }).pipe(Effect.provide(makeServerSettingsLayer())),
   );
 
+  it.effect("keeps the inline value on disk when secret migration fails", () => {
+    const cause = new ServerSecretStore.SecretStorePersistError({
+      resource: "provider environment secret",
+      cause: new Error("Secret storage unavailable"),
+    });
+    const secretLayer = Layer.effect(
+      ServerSecretStore.ServerSecretStore,
+      Effect.map(ServerSecretStore.ServerSecretStore, (store) => ({
+        ...store,
+        set: () => Effect.fail(cause),
+      })),
+    ).pipe(Layer.provide(ServerSecretStore.layer));
+    const settingsLayer = ServerSettingsModule.layer.pipe(
+      Layer.provide(secretLayer),
+      Layer.provideMerge(Layer.fresh(SqlitePersistenceMemory)),
+      Layer.provideMerge(
+        Layer.fresh(
+          ServerConfig.layerTest(process.cwd(), {
+            prefix: "t3code-inline-secret-failure-test-",
+          }),
+        ),
+      ),
+    );
+    return Effect.gen(function* () {
+      const instanceId = ProviderInstanceId.make("codex_personal");
+      const service = yield* ServerSettingsModule.ServerSettingsService;
+      const config = yield* ServerConfig.ServerConfig;
+      const fs = yield* FileSystem.FileSystem;
+      const original =
+        '{"providerInstances":{"codex_personal":{"driver":"codex","environment":[{"name":"API_TOKEN","value":"inline-test-token","sensitive":true}],"config":{}}}}';
+      yield* fs.writeFileString(config.settingsPath, original);
+      const error = yield* Effect.flip(
+        service.updateSettings({
+          providerInstances: {
+            [instanceId]: {
+              driver: ProviderDriverKind.make("codex"),
+              environment: [{ name: "API_TOKEN", value: "", sensitive: true, valueRedacted: true }],
+              config: {},
+            },
+          },
+        }),
+      );
+      assert.equal(error.operation, "write-secret");
+      assert.strictEqual(error.cause, cause);
+      assert.equal(yield* fs.readFileString(config.settingsPath), original);
+      const settings = yield* service.getSettings;
+      assert.equal(
+        settings.providerInstances[instanceId]?.environment?.[0]?.value,
+        "inline-test-token",
+      );
+    }).pipe(Effect.provide(settingsLayer));
+  });
+
+  for (const { label, variable, expected, duplicate } of [
+    {
+      label: "preserves an inline secret on a redacted settings save",
+      variable: { name: "API_TOKEN", value: "", sensitive: true, valueRedacted: true },
+      expected: "inline-test-token",
+    },
+    {
+      label: "preserves the effective last inline secret when names are duplicated",
+      variable: { name: "API_TOKEN", value: "", sensitive: true, valueRedacted: true },
+      expected: "last-inline-test-token",
+      duplicate: true,
+    },
+    {
+      label: "replaces an inline secret with an explicit value",
+      variable: { name: "API_TOKEN", value: "replacement-test-token", sensitive: true },
+      expected: "replacement-test-token",
+    },
+    {
+      label: "clears an inline secret with an explicit empty value",
+      variable: { name: "API_TOKEN", value: "", sensitive: true },
+      expected: "",
+    },
+  ]) {
+    it.effect(label, () =>
+      Effect.gen(function* () {
+        const instanceId = ProviderInstanceId.make("codex_personal");
+        const serverSettings = yield* ServerSettingsModule.ServerSettingsService;
+        const serverConfig = yield* ServerConfig.ServerConfig;
+        const fileSystem = yield* FileSystem.FileSystem;
+        yield* fileSystem.writeFileString(
+          serverConfig.settingsPath,
+          duplicate
+            ? '{"providerInstances":{"codex_personal":{"driver":"codex","environment":[{"name":"API_TOKEN","value":"inline-test-token","sensitive":true},{"name":"API_TOKEN","value":"last-inline-test-token","sensitive":true}],"config":{}}}}'
+            : '{"providerInstances":{"codex_personal":{"driver":"codex","environment":[{"name":"API_TOKEN","value":"inline-test-token","sensitive":true}],"config":{}}}}',
+        );
+        const initial = yield* serverSettings.getSettings;
+        assert.equal(
+          initial.providerInstances[instanceId]?.environment?.[0]?.value,
+          "inline-test-token",
+        );
+
+        const next = yield* serverSettings.updateSettings({
+          providerInstances: {
+            [instanceId]: {
+              driver: ProviderDriverKind.make("codex"),
+              displayName: "Renamed provider",
+              environment: duplicate ? [variable, variable] : [variable],
+              config: {},
+            },
+          },
+        });
+        assert.equal(next.providerInstances[instanceId]?.environment?.[0]?.value, expected);
+        const raw = yield* fileSystem.readFileString(serverConfig.settingsPath);
+        assert.notInclude(raw, "inline-test-token");
+        assert.notInclude(raw, "replacement-test-token");
+
+        const reloaded = yield* Effect.gen(function* () {
+          const fresh = yield* ServerSettingsModule.ServerSettingsService;
+          return yield* fresh.getSettings;
+        }).pipe(
+          Effect.provide(
+            Layer.fresh(ServerSettingsModule.layer).pipe(Layer.provide(ServerSecretStore.layer)),
+          ),
+        );
+        assert.equal(reloaded.providerInstances[instanceId]?.environment?.[0]?.value, expected);
+      }).pipe(Effect.provide(makeServerSettingsLayer())),
+    );
+  }
+
   it.effect("stores sensitive provider instance environment values outside settings.json", () =>
     Effect.gen(function* () {
       const serverSettings = yield* ServerSettingsModule.ServerSettingsService;

--- a/apps/server/src/serverSettings.ts
+++ b/apps/server/src/serverSettings.ts
@@ -846,9 +846,20 @@ const make = Effect.gen(function* () {
           }
 
           nextSecretKeys.add(secretName);
-          if (!variable.valueRedacted) {
-            if (variable.value.length > 0) {
-              yield* secretStore.set(secretName, textEncoder.encode(variable.value)).pipe(
+          // Match the provider environment's last-value-wins behavior for duplicate names.
+          const previous = variable.valueRedacted
+            ? current.providerInstances[ProviderInstanceId.make(instanceId)]?.environment?.findLast(
+                (entry) => entry.name === variable.name,
+              )
+            : undefined;
+          const inlineValue =
+            previous?.sensitive && !previous.valueRedacted && previous.value.length > 0
+              ? previous.value
+              : undefined;
+          const value = inlineValue ?? variable.value;
+          if (!variable.valueRedacted || inlineValue !== undefined) {
+            if (value.length > 0) {
+              yield* secretStore.set(secretName, textEncoder.encode(value)).pipe(
                 Effect.mapError(
                   (cause) =>
                     new ServerSettingsError({


### PR DESCRIPTION
## Problem

Saving an unchanged provider can erase a sensitive environment value stored inline in settings.json. Clients return a redacted placeholder, but there may not yet be a corresponding secret-store entry.

## Fix

Before persisting that placeholder, migrate the current inline value for the same provider instance and variable into the secret store. Explicit replacements and clears keep their existing behavior. If the secret-store write fails, the original file and cached value stay in place.

This is an Akeru adaptation of upstream T3 Code work.

## Upstream

- https://github.com/pingdotgg/t3code/pull/10054

## Verification

- `vp test run apps/server/src/serverSettings.test.ts` — 45 passed
- Targeted lint — clean

## Model

Grok 4.6 High in Grok Build via Orca.